### PR TITLE
allow nx-os version agnostic polling

### DIFF
--- a/config/evpnVni.yml
+++ b/config/evpnVni.yml
@@ -60,7 +60,7 @@ apply:
         "rectype: _rectype?|VNI",
         ]'
 
-      - command: show nve interface nve regex * | json-pretty
+      - command: show nve interface nve 1 | json-pretty
         normalize: 'TABLE_nve_if/ROW_nve_if/*?/[
         "primary-ip: srcVtepIp",
         "encap-type: encapType",


### PR DESCRIPTION
show nve interface nve regex * | json-pretty   only works with NX-OS 9.3.3 and newer releases while show nve interface nve 1 | json-pretty  works with every NX-OS version.

furthermore, NX-OS allows only "nve1" to exist, and the outputs are identical therefore the proposed command would only improve compatibility