### PR TITLE
read the kickstart instead of last version before reload

### DIFF
--- a/config/device.yml
+++ b/config/device.yml
@@ -33,7 +33,7 @@ apply:
     version: all
     command: "show version | json"
     normalize: '[
-    "rr_sys_ver: version",
+    "kickstart_ver_str: version",
     "manufacturer: vendor?Cisco|Cisco",
     "chassis_id: model",
     "os: os?|nxos",


### PR DESCRIPTION
nx-os version before 9.3 didn't support "nx-os version" variable. reading kickstart_ver_str allows all nx-os version to be detected correctly