### PR TITLE
Enhance BGP fitering

### DIFF
--- a/suzieq/cli/sqcmds/BgpCmd.py
+++ b/suzieq/cli/sqcmds/BgpCmd.py
@@ -48,9 +48,11 @@ class BgpCmd(SqCommand):
         return df.dropna(how='any')
 
     @command("show")
+    @argument("vrf", description="vrf name to qualify")
+    @argument("peer", description="IP address, in quotes, to qualify output")    
     @argument("status", description="status of the session to match",
               choices=["all", "pass", "fail"])
-    def show(self, status: str = "all"):
+    def show(self, status: str = "all", vrf: str = '', peer: str = ''):
         """
         Show bgp info
         """
@@ -80,6 +82,7 @@ class BgpCmd(SqCommand):
         df = self.sqobj.get(
             hostname=self.hostname, columns=self.columns,
             namespace=self.namespace, state=state, addnl_fields=addnl_fields
+            vrf=vrf.split(), peer=peer.split()
         )
 
         if 'estdTime' in df.columns:


### PR DESCRIPTION
Allow to filter BGP by VRF or by Peer's IP.

root> bgp show vrf=default
root> bgp show peer="192.168.0.1"

Signed-off-by: Andrea Florio <andrea@opensuse.org>