### PR TITLE
added docker-compose.yml for ease of deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.2'
+services:
+    sq-poller:
+        restart: unless-stopped
+        command: -D /suzieq/inventory
+        image:  ddutt/suzieq:prerc
+        volumes:
+            - "./parquet-output:/suzieq/parquet"
+            - "./sqpoller-output:/suzieq/sqpoller-output"
+            - "./suzieq-graphs:/tmp/suzieq-graphs"
+            - "./inventory.yml:/suzieq/inventory"
+        entrypoint:
+            - sq-poller
+    suzieq-cli:
+        restart: unless-stopped
+        image:  ddutt/suzieq:latest
+        stdin_open: true # docker run -i
+        tty: true        # docker run -t
+        volumes:
+            - "./parquet-out:/suzieq/parquet"
+        entrypoint:
+            - sh


### PR DESCRIPTION
create two containers, one to just run the poller and one to just run the UI (CLI for now, web UI later).
This way the user can easily provide a customer inventory file and all outputs can be retrieved directly outside of the container.

Signed of by Andrea Florio - <andrea@opensuse.org>