### PR TITLE
use the same image tag for sq-poller and suzieq-cli

### DIFF
--- a/samples/docker-compose.yml
+++ b/samples/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     sq-poller:
         restart: unless-stopped
         command: -D /suzieq/inventory
-        image:  ddutt/suzieq:prerc
+        image:  ddutt/suzieq:latest
         volumes:
             - "./parquet-output:/suzieq/parquet"
             - "./sqpoller-output:/suzieq/sqpoller-output"


### PR DESCRIPTION
use the same image tag for sq-poller and suzieq-cli

Signed-off-by: Andrea Florio <andrea@opensuse.org>