### PR TITLE
Supply default SSH port for Ansible inventory when using sq-poller -a

### DIFF
--- a/suzieq/poller/genhosts.py
+++ b/suzieq/poller/genhosts.py
@@ -121,7 +121,7 @@ def convert_ansible_inventory(filename: str, namespace: str = 'default'):
             port = 443
         else:
             transport = 'ssh://'
-            port = entry["ansible_port"]
+            port = entry.get("ansible_port", 22)
 
         url = (f'{transport}{entry["ansible_host"]}'
                f':{port}')


### PR DESCRIPTION
When using `sq-poller -a` on an output of `ansible-inventory --list` that does not explicitly supply the SSH port it crashes as follows:
```
Traceback (most recent call last):
  File "/home/leo/suzieq/venv/lib/python3.8/site-packages/suzieq/poller/sq_poller.py", line 455, in poller_main
    asyncio.run(start_poller(userargs, cfg))
  File "/usr/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1494, in uvloop.loop.Loop.run_until_complete
  File "/home/leo/suzieq/venv/lib/python3.8/site-packages/suzieq/poller/sq_poller.py", line 239, in start_poller
    nodes, svcs = await asyncio.gather(*tasks)
  File "/home/leo/suzieq/venv/lib/python3.8/site-packages/suzieq/poller/nodes/node.py", line 108, in init_hosts
    convert_ansible_inventory(ans_inventory, namespace)))
  File "/home/leo/suzieq/venv/lib/python3.8/site-packages/suzieq/poller/genhosts.py", line 124, in convert_ansible_inventory
    port = entry["ansible_port"]
KeyError: 'ansible_port'
```

I think that supplying port 22 as the default shouldn't do any harm seeing as the alternative is an exception.