### PR TITLE
Fix sample docker-compose setup

### DIFF
--- a/samples/Caddyfile
+++ b/samples/Caddyfile
@@ -1,3 +1,4 @@
+# Change suzieq.localhost to the fqdn you would like to use
 suzieq.localhost {
     
     reverse_proxy suzieq_gui:8501

--- a/samples/docker-compose.yml
+++ b/samples/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         stdin_open: true
         tty: true
         volumes:
-            - "parquet-output:/suzieq/parquet"
+            - "parquet-db:/suzieq/parquet"
             - "./inventory.yml:/suzieq/inventory.yml:ro"
             - "./suzieq-cfg.yml:/root/.suzieq/suzieq-cfg.yml:ro"
         entrypoint:
@@ -24,7 +24,7 @@ services:
         environment:
             - FORWARDED_ALLOW_IPS=*
         volumes:
-            - "parquet-output:/suzieq/parquet"
+            - "parquet-db:/suzieq/parquet"
             - "./suzieq-cfg.yml:/root/.suzieq/suzieq-cfg.yml:ro"
         expose:
             - 8000
@@ -38,7 +38,7 @@ services:
         stdin_open: true
         tty: true
         volumes:
-            - "parquet-output:/suzieq/parquet"
+            - "parquet-db:/suzieq/parquet"
             - "./suzieq-cfg.yml:/root/.suzieq/suzieq-cfg.yml:ro"
         expose:
             - 8501
@@ -61,5 +61,5 @@ services:
             - "443:443"
 
 volumes:
-    parquet-output:
+    parquet-db:
         driver: local

--- a/samples/docker-compose.yml
+++ b/samples/docker-compose.yml
@@ -1,21 +1,21 @@
 version: '3.2'
 services:
-    suzieq_poller: # Access the cli from this container
+    suzieq_poller:
         restart: unless-stopped
-        image:  ddutt/suzieq:0.13.0-rc #netenglabs/suzieq:latest
+        image: &suzieqImage netenglabs/suzieq:0.13.0
         container_name: suzieq_poller
-        command: -D /suzieq/inventory
+        command: -D /suzieq/inventory.yml -k
         stdin_open: true
         tty: true
         volumes:
             - "parquet-output:/suzieq/parquet"
-            - "./inventory.yml:/suzieq/inventory:ro"
+            - "./inventory.yml:/suzieq/inventory.yml:ro"
             - "./suzieq-cfg.yml:/root/.suzieq/suzieq-cfg.yml:ro"
         entrypoint:
             - sq-poller
     suzieq_restserver:
         restart: unless-stopped
-        image:  ddutt/suzieq:0.13.0-rc
+        image: *suzieqImage
         container_name: suzieq_restserver
         depends_on:
             - suzieq_poller
@@ -31,7 +31,7 @@ services:
         entrypoint: "sq-rest-server"
     suzieq_gui:
         restart: unless-stopped
-        image:  ddutt/suzieq:0.13.0-rc
+        image: *suzieqImage
         container_name: suzieq_gui
         depends_on:
             - suzieq_poller
@@ -44,7 +44,8 @@ services:
             - 8501
         entrypoint:
             - suzieq-gui
-    caddy: # HTTPS & Reverse Proxy to containers/services
+    caddy:
+        restart: unless-stopped
         image: "caddy:2-alpine"
         container_name: suzieq_caddy
         depends_on:
@@ -52,14 +53,13 @@ services:
             - suzieq_restserver
         volumes:
             - "./Caddyfile:/etc/caddy/Caddyfile:z,ro"
-            # Uncomment the below if you want to specify your own cert/key.  Be sure to update the Caddyfile also.
+            # Uncomment the below if you want to specify your own cert/key. Be sure to update the Caddyfile also.
             #- "./secrets/cert.crt:/root/certs/cert.crt:z,ro"
             #- "./secrets/cert.key:/root/certs/cert.key:z,ro"
         ports:
-            - 80:80 # allow Caddy to rederict to HTTPS
-            - 443:443
-        restart: unless-stopped
-​
+            - "80:80" # Allow Caddy to rederict to HTTPS
+            - "443:443"
+
 volumes:
     parquet-output:
         driver: local

--- a/samples/suzieq-cfg.yml
+++ b/samples/suzieq-cfg.yml
@@ -1,6 +1,6 @@
 data-directory: ./parquet
 temp-directory: /tmp/
-​
+
 rest:
 # Uncomment these lines if you're using your own files for the REST server
 # The certificates listed below are provided purely to get started, In any
@@ -18,12 +18,12 @@ rest:
 # This is only for the fastapi/restserver process.  Skip if using Caddy
   # rest-certfile: /secrets/cert.pem
   # rest-keyfile: /secrets/key.pem
-​
+
 poller:
   # logfile: /tmp/sq-poller.log
   logging-level: WARNING
   period: 60
-​
+
 coalescer:
   period: 1h
 # Comment the next line if you don't want the archive directory. This dir is
@@ -32,7 +32,7 @@ coalescer:
   archive-directory:
   # logfile: /tmp/sq-coalescer.log
   logging-level: WARNING
-​
+
 analyzer:
   # By default, the timezone is set to the local timezone. Uncomment
   # this line if you want the analyzer (CLI/GUI/REST) to display the time


### PR DESCRIPTION
Closes #382 
Corrects #383 

- Fixed gremlins in the `samples/suzieq-cfg.yml` config that broke suzieq startup
- Renamed docker parquet volume
- Moved to leverage the `netenglabs/suzieq` image instead of the ddutt build
- Added comment in the `Caddyfile` to change the setup from localhost to another fqdn