### PR TITLE
fix issue #431 - Missing BGP ASN number and AFI prefixes assignmentment to AFI type

### DIFF
--- a/suzieq/poller/services/bgp.py
+++ b/suzieq/poller/services/bgp.py
@@ -488,23 +488,21 @@ class BgpService(Service):
                 drop_indices.append(i)
                 # Find the matching entry in the already processed data
                 if check_peer_key in vrf_peer_dict:
-                    for afi_type in vrf_peer_dict[check_peer_key].keys():
-                        # Add routerID and ASN in all AFI types
-                        old_entry = vrf_peer_dict[check_peer_key][afi_type]
-                        old_entry['routerId'] = entry['routerId']
-                        old_entry['asn'] = entry['asn']
-                        # Add prefixes only in corresponding AFI type
-                        if afi_type == entry['afi']:
-                            if entry['statePfx'].isdecimal():
-                                old_entry['pfxRx'] = int(entry['statePfx'])
-                    else:
-                        pass
+                    # loop to add Router ID and ASN in all the registries
+                    for index, item in enumerate(vrf_peer_dict[check_peer_key]):
+                        old_entry = vrf_peer_dict[check_peer_key]
+                        old_entry[index]['routerId'] = entry['routerId']
+                        old_entry[index]['asn'] = entry['asn']
+                        # add the prefix only in matching AFI-SAFI
+                        if entry['afi'].lower() == old_entry[index]['afi'] and \
+                                entry['safi'].lower() == old_entry[index]['safi']:
+                            old_entry[index]['pfxRx'] = entry['statePfx']
                 continue
             else:
                 if check_peer_key not in vrf_peer_dict:
-                    vrf_peer_dict[check_peer_key] = {}
-                # Add AFI type sub-key
-                vrf_peer_dict[check_peer_key][entry['afi']] = entry
+                    vrf_peer_dict[check_peer_key] = [entry]
+                else:
+                    vrf_peer_dict[check_peer_key].append(entry)
 
             bfd_status = entry.get('bfdStatus', 'disabled').lower()
             if not bfd_status or (bfd_status == "unknown"):


### PR DESCRIPTION
Small update in the loop for processing gathered data (**show ip bgp all neigh**) at `suzieq/poller/services/bgp.py`

Previously the loop updates the last entry of (**show ip bgp all neigh**) to add ASN and prefixes from (**show ip bgp all summ**), without considering adding to the correct AFY type.

By adding an extra KEY per AFI type, we can filter and add the prefixes to the correct AFI type. And also add the ASN to all the AFI types.

Now **suzieq-cli** displays the correct information.

![fixed_wrong_asn_and_prefixes_to_afi_type](https://user-images.githubusercontent.com/16782779/136381111-0d73cd36-5a2b-4e0a-8394-de00de829175.jpg)

Pytest (as expected) returns the same output after this change.

Closes #431

Signed-off-by: adrian <aegiacometti@hotmail.com>