### PR TITLE
Add pre-commit config to auto-lint files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+---
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace


### PR DESCRIPTION
Pre-commit (https://pre-commit.com/) is a tool for managing Git
hooks which can be useful to automatically run tasks before code
submission such as automatically removing trailing whitespace or
running flake8 / pylint against code.

This sets up some very basic linters to show what pre-commit
is capable of. If accepted, additional config can be added to
lint Python files as well such as with pylint and flake8.