### PR TITLE
Fix var 'cfgfile' referenced before assignment

### DIFF
--- a/suzieq/utils.py
+++ b/suzieq/utils.py
@@ -155,6 +155,8 @@ def sq_get_config_file(config_file):
         cfgfile = "./suzieq-cfg.yml"
     elif os.path.exists(os.getenv("HOME") + "/.suzieq/suzieq-cfg.yml"):
         cfgfile = os.getenv("HOME") + "/.suzieq/suzieq-cfg.yml"
+    else:
+        cfgfile = None
     return cfgfile
 
 


### PR DESCRIPTION
The function sq_get_config_file() appears to intend to return cfgfile
regardless of if it is found or not as the load_sq_config() function
appears to have a condition to exit if a cfgfile is not present.

This resolves the "UnboundLocalError: local variable 'cfgfile'
referenced before assignment" thrown when trying to start the
suzieq-gui without a config file present to allow the sys.exit(1)
in load_sq_config() to exit.

Signed-off-by: Thanh Ha <zxiiro@gmail.com>