### PR TITLE
Let poetry automatically pull version from tags

### DIFF
--- a/docs/developer/devstart.md
+++ b/docs/developer/devstart.md
@@ -7,6 +7,8 @@ Setting up the development environment for Suzieq involves the following steps:
 * Make sure you have a python3 version that is > 3.7.1 and less than 3.9.0. If you don't have a system provided python version that matches this requirement, you can use [pyenv](https://realpython.com/intro-to-pyenv/) to install one.
 * If you've used pyenv to install a specific python version, ensure you activate it.
 * Install poetry--follow the instructions posted [here](https://python-poetry.org/docs/#installation).
+* Install *poetry-dynamic-versioning* -- follow the instructions posted
+  [here](https://pypi.org/project/poetry-dynamic-versioning/)
 * Ensure you have git installed (follow the instructions [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git))
 * Clone the github repository: ```git clone https://github.com/netenglabs/suzieq.git```. This creates a copy of the code repository in the subfolder suzieq in the current directory. 
 * Create the virtual environment and install the appropriate packages by typing: ```poetry install```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "suzieq"
-version = "0.16.0"
+version = "0.0.0"
 description = "A framework and application for network observability"
 readme = 'README.md'
 repository = 'https://github.com/netenglabs/suzieq'
@@ -13,7 +13,6 @@ homepage = 'https://www.stardustsystems.net/suzieq/'
 classifiers = [
    'Topic :: System :: Networking :: Monitoring'
 ]
-
 
 [tool.poetry.dependencies]
 python = ">3.7.1, < 3.9"
@@ -74,6 +73,12 @@ sq-anonymizer = 'suzieq.utilities.sq_anonymizer:anonymizer_main'
 suzieq-cli = 'suzieq.cli.sq_cli:cli_main'
 suzieq-gui = 'suzieq.gui.sq_gui:gui_main'
 
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"
+pattern = "^v(?P<base>\\d+\\.\\d+\\.\\d+)(-?((?P<stage>[a-zA-Z]+)\\.?(?P<revision>\\d+)?))?(\\+(?P<tagged_metadata>.+))?$"
+
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0.2", "poetry-dynamic-versioning"]
 build-backend = "poetry.masonry.api"

--- a/suzieq/version.py
+++ b/suzieq/version.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 
-SUZIEQ_VERSION = "0.16.0"
+__version__ = "0.0.0"
+SUZIEQ_VERSION = __version__
 
 if __name__ == '__main__':
     print(SUZIEQ_VERSION)


### PR DESCRIPTION
Rather than spending time updating the 2 files that have hardcoded
versions in them. Let poetry auto-generate the versions directly from
Git tags.

If a dev has a git tag checked out then `poetry build` will generate
a version directly from that tag, for example the tag "v0.15.1" will
produce a version "0.15.1".

Otherwise the version will be based on how many commits since the last
tag was available in Git history for example "0.15.1-post.13+d211ed4347"
where "post.13" represents 13 commits since v0.15.1 was tagged and
"d211ed4347" is the commit hash of the commit that generated this
version.

For this to work however devs are required to install
poetry-dynamic-versioning in addition to poetry at the global level.

Ref: https://pypi.org/project/poetry-dynamic-versioning/
Signed-off-by: Thanh Ha <zxiiro@gmail.com>