### PR TITLE
interfaces: Check if vlan_df is not empty before accessing vlanList

### DIFF
--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -266,7 +266,8 @@ class InterfacesObj(SqPandasEngine):
 
         combined_df['assertReason'] += combined_df.apply(
             lambda x: []
-            if set(x['vlanList']) == set(x['vlanListPeer'])
+            if (not vlan_df.empty and
+              set(x['vlanList']) == set(x['vlanListPeer']))
             else ['VLAN set mismatch'], axis=1)
 
         combined_df['assert'] = combined_df.apply(


### PR DESCRIPTION
Fix assert failed for not existing vlanList

```
donatas> interface assert namespace=srv
               error
0  ERROR: 'vlanList'
Assert failed
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>