### PR TITLE
Fix address unique with columns=vrf

### DIFF
--- a/tests/integration/sqcmds/cumulus-samples/address.yml
+++ b/tests/integration/sqcmds/cumulus-samples/address.yml
@@ -1985,3 +1985,8 @@ tests:
     "172.16.1.1/24", "numRows": 2}, {"ipAddressList": "172.16.2.1/24", "numRows":
     2}, {"ipAddressList": "172.16.3.1/24", "numRows": 2}, {"ipAddressList": "172.16.4.1/24",
     "numRows": 2}, {"ipAddressList": "127.0.0.1/8", "numRows": 8}]'
+- command: address unique --columns="vrf" --count=True --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out
+  marks: address unique cumulus filter
+  output: '[{"vrf": "internet-vrf", "numRows": 4}, {"vrf": "mgmt", "numRows": 8},
+    {"vrf": "default", "numRows": 84}]'

--- a/tests/integration/sqcmds/eos-samples/address.yml
+++ b/tests/integration/sqcmds/eos-samples/address.yml
@@ -629,3 +629,8 @@ tests:
     18}, {"hostname": "leaf02", "numRows": 18}, {"hostname": "leaf03", "numRows":
     18}, {"hostname": "leaf04", "numRows": 18}, {"hostname": "dcedge01", "numRows":
     58}]'
+- command: address unique --columns=vrf --format=json --count=True
+  data-directory: tests/data/eos/parquet-out/
+  marks: address unique eos
+  output: '[{"vrf": "internet-vrf", "numRows": 4}, {"vrf": "evpn-vrf", "numRows":
+    16}, {"vrf": "default", "numRows": 75}]'

--- a/tests/integration/sqcmds/junos-samples/address.yml
+++ b/tests/integration/sqcmds/junos-samples/address.yml
@@ -1279,3 +1279,18 @@ tests:
     {"hostname": "firewall01"}, {"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname":
     "server101"}, {"hostname": "server102"}, {"hostname": "server201"}, {"hostname":
     "server202"}, {"hostname": "spine01"}, {"hostname": "spine02"}]'
+- command: address unique --columns=hostname --format=json --count=True
+  data-directory: tests/data/junos/parquet-out/
+  marks: address unique junos
+  output: '[{"hostname": "server101", "numRows": 3}, {"hostname": "server102", "numRows":
+    3}, {"hostname": "server201", "numRows": 3}, {"hostname": "server202", "numRows":
+    3}, {"hostname": "firewall01", "numRows": 10}, {"hostname": "dcedge01", "numRows":
+    58}, {"hostname": "spine01", "numRows": 60}, {"hostname": "spine02", "numRows":
+    60}, {"hostname": "leaf01", "numRows": 63}, {"hostname": "leaf02", "numRows":
+    63}, {"hostname": "exit01", "numRows": 66}, {"hostname": "exit02", "numRows":
+    66}]'
+- command: address unique --columns=vrf --format=json --count=True
+  data-directory: tests/data/junos/parquet-out/
+  marks: address unique junos
+  output: '[{"vrf": "internet-vrf", "numRows": 4}, {"vrf": "evpn-vrf", "numRows":
+    10}, {"vrf": "default", "numRows": 84}]'

--- a/tests/integration/sqcmds/mixed-samples/address.yml
+++ b/tests/integration/sqcmds/mixed-samples/address.yml
@@ -1,0 +1,911 @@
+description: 'Testing verbs for address: show summarize unique'
+tests:
+- command: address show --format=json
+  data-directory: tests/data/mixed/parquet-out
+  marks: address show mixed
+  output: '[{"namespace": "mixed", "hostname": "leaf6-eos", "ifname": "Ethernet8",
+    "ipAddressList": [], "macaddr": "50:00:00:06:00:08", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1627395434695}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "ifname": "Ethernet4", "ipAddressList": [], "macaddr": "50:00:00:06:00:04",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1627395434695},
+    {"namespace": "mixed", "hostname": "leaf6-eos", "ifname": "Ethernet7", "ipAddressList":
+    [], "macaddr": "50:00:00:06:00:07", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1627395434695}, {"namespace": "mixed", "hostname": "leaf6-eos",
+    "ifname": "Ethernet6", "ipAddressList": [], "macaddr": "50:00:00:06:00:06", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1627395434695}, {"namespace":
+    "mixed", "hostname": "leaf6-eos", "ifname": "Ethernet1", "ipAddressList": ["10.1.6.2/30"],
+    "macaddr": "50:00:00:ca:39:cc", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395434695}, {"namespace": "mixed", "hostname": "leaf6-eos", "ifname":
+    "Ethernet3", "ipAddressList": [], "macaddr": "50:00:00:06:00:03", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1627395434695}, {"namespace":
+    "mixed", "hostname": "leaf6-eos", "ifname": "Ethernet2", "ipAddressList": ["10.2.6.2/30"],
+    "macaddr": "50:00:00:ca:39:cc", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395434695}, {"namespace": "mixed", "hostname": "leaf6-eos", "ifname":
+    "Loopback0", "ipAddressList": ["6.6.6.6/32"], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395434695},
+    {"namespace": "mixed", "hostname": "leaf6-eos", "ifname": "Management1", "ipAddressList":
+    ["172.29.151.8/24"], "macaddr": "50:00:00:06:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395434695}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "ifname": "Ethernet5", "ipAddressList": [], "macaddr": "50:00:00:06:00:05",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1627395434695},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "ifname": "Ethernet3", "ipAddressList":
+    [], "macaddr": "50:00:00:07:00:03", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1627395434802}, {"namespace": "mixed", "hostname": "leaf5-eos",
+    "ifname": "Ethernet4", "ipAddressList": [], "macaddr": "50:00:00:07:00:04", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1627395434802}, {"namespace":
+    "mixed", "hostname": "leaf5-eos", "ifname": "Management1", "ipAddressList": ["172.29.151.7/24"],
+    "macaddr": "50:00:00:07:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395434802}, {"namespace": "mixed", "hostname": "leaf5-eos", "ifname":
+    "Ethernet8", "ipAddressList": [], "macaddr": "50:00:00:07:00:08", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1627395434802}, {"namespace":
+    "mixed", "hostname": "leaf5-eos", "ifname": "Loopback0", "ipAddressList": ["5.5.5.5/32"],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395434802}, {"namespace": "mixed", "hostname": "leaf5-eos", "ifname":
+    "Ethernet2", "ipAddressList": ["10.2.5.2/30"], "macaddr": "50:00:00:e4:72:94",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395434802},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "ifname": "Ethernet7", "ipAddressList":
+    [], "macaddr": "50:00:00:07:00:07", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1627395434802}, {"namespace": "mixed", "hostname": "leaf5-eos",
+    "ifname": "Ethernet5", "ipAddressList": [], "macaddr": "50:00:00:07:00:05", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1627395434802}, {"namespace":
+    "mixed", "hostname": "leaf5-eos", "ifname": "Ethernet1", "ipAddressList": ["10.1.5.2/30"],
+    "macaddr": "50:00:00:e4:72:94", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395434802}, {"namespace": "mixed", "hostname": "leaf5-eos", "ifname":
+    "Ethernet6", "ipAddressList": [], "macaddr": "50:00:00:07:00:06", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1627395434802}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/49", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:31", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/30", "ipAddressList": [], "macaddr": "50:0b:00:00:01:1e",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/31", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:1f", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/32", "ipAddressList": [], "macaddr": "50:0b:00:00:01:20",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/33", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:21", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/34", "ipAddressList": [], "macaddr": "50:0b:00:00:01:22",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/35", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:23", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/36", "ipAddressList": [], "macaddr": "50:0b:00:00:01:24",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/37", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:25", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/38", "ipAddressList": [], "macaddr": "50:0b:00:00:01:26",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/39", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:27", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/40", "ipAddressList": [], "macaddr": "50:0b:00:00:01:28",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/41", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:29", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/29", "ipAddressList": [], "macaddr": "50:0b:00:00:01:1d",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/42", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:2a", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/44", "ipAddressList": [], "macaddr": "50:0b:00:00:01:2c",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/45", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:2d", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/46", "ipAddressList": [], "macaddr": "50:0b:00:00:01:2e",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/47", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:2f", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/48", "ipAddressList": [], "macaddr": "50:0b:00:00:01:30",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/50", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:32", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/51", "ipAddressList": [], "macaddr": "50:0b:00:00:01:33",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/52", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:34", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/53", "ipAddressList": [], "macaddr": "50:0b:00:00:01:35",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/54", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:36", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/55", "ipAddressList": [], "macaddr": "50:0b:00:00:01:37",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/56", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:38", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/43", "ipAddressList": [], "macaddr": "50:0b:00:00:01:2b",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/57", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:39", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/28", "ipAddressList": [], "macaddr": "50:0b:00:00:01:1c",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/26", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:1a", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "mgmt0", "ipAddressList": ["172.29.151.1/24"], "macaddr":
+    "50:00:00:0b:00:00", "ip6AddressList": [], "state": "up", "vrf": "management",
+    "timestamp": 1627395435116}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "ifname": "Ethernet1/1", "ipAddressList": ["10.1.1.1/30"], "macaddr": "50:0b:00:00:1b:08",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/2", "ipAddressList":
+    ["10.1.2.1/30"], "macaddr": "50:0b:00:00:1b:08", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/3", "ipAddressList": ["10.1.3.1/30"], "macaddr":
+    "50:0b:00:00:1b:08", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435116}, {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/4",
+    "ipAddressList": ["10.1.4.1/30"], "macaddr": "50:0b:00:00:1b:08", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435116}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/5", "ipAddressList":
+    ["10.1.5.1/30"], "macaddr": "50:0b:00:00:1b:08", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/6", "ipAddressList": ["10.1.6.1/30"], "macaddr":
+    "50:0b:00:00:1b:08", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435116}, {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/7",
+    "ipAddressList": [], "macaddr": "50:0b:00:00:1b:08", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/8", "ipAddressList": [], "macaddr": "50:0b:00:00:01:08",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/9", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:09", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/10", "ipAddressList": [], "macaddr": "50:0b:00:00:01:0a",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/11", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:0b", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/27", "ipAddressList": [], "macaddr": "50:0b:00:00:01:1b",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/12", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:0c", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/14", "ipAddressList": [], "macaddr": "50:0b:00:00:01:0e",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/15", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:0f", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/16", "ipAddressList": [], "macaddr": "50:0b:00:00:01:10",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/17", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:11", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/18", "ipAddressList": [], "macaddr": "50:0b:00:00:01:12",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/19", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:13", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/20", "ipAddressList": [], "macaddr": "50:0b:00:00:01:14",
+    "ip6AddressList": [], "state": "down", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/21", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:15", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/22", "ipAddressList": [], "macaddr": "50:0b:00:00:01:16",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/23", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:17", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/24", "ipAddressList": [], "macaddr": "50:0b:00:00:01:18",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/25", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:19", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/13", "ipAddressList": [], "macaddr": "50:0b:00:00:01:0d",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/58", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:3a", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/59", "ipAddressList": [], "macaddr": "50:0b:00:00:01:3b",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/60", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:3c", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/61", "ipAddressList": [], "macaddr": "50:0b:00:00:01:3d",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/62", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:3e", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Ethernet1/63", "ipAddressList": [], "macaddr": "50:0b:00:00:01:3f",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Ethernet1/64", "ipAddressList":
+    [], "macaddr": "50:0b:00:00:01:40", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "loopback0", "ipAddressList": ["11.11.11.11/32"], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435116}, {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "loopback100",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "ifname": "Vlan1", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1627395435116},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "ifname": "Vlan100", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395435116}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "ifname": "default", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435116}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "ifname": "management", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435116}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "ifname": "Ethernet1/42", "ipAddressList": [], "macaddr": "50:0c:00:00:01:2a",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/43", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:2b", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/45", "ipAddressList": [], "macaddr": "50:0c:00:00:01:2d",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/41", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:29", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/44", "ipAddressList": [], "macaddr": "50:0c:00:00:01:2c",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/40", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:28", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/34", "ipAddressList": [], "macaddr": "50:0c:00:00:01:22",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/38", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:26", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/37", "ipAddressList": [], "macaddr": "50:0c:00:00:01:25",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/36", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:24", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/35", "ipAddressList": [], "macaddr": "50:0c:00:00:01:23",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/49", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:31", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/33", "ipAddressList": [], "macaddr": "50:0c:00:00:01:21",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/39", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:27", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/50", "ipAddressList": [], "macaddr": "50:0c:00:00:01:32",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/55", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:37", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/52", "ipAddressList": [], "macaddr": "50:0c:00:00:01:34",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/53", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:35", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/54", "ipAddressList": [], "macaddr": "50:0c:00:00:01:36",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/32", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:20", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/56", "ipAddressList": [], "macaddr": "50:0c:00:00:01:38",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/57", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:39", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/58", "ipAddressList": [], "macaddr": "50:0c:00:00:01:3a",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/59", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:3b", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/60", "ipAddressList": [], "macaddr": "50:0c:00:00:01:3c",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/61", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:3d", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/62", "ipAddressList": [], "macaddr": "50:0c:00:00:01:3e",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/63", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:3f", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/64", "ipAddressList": [], "macaddr": "50:0c:00:00:01:40",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "loopback0", "ipAddressList":
+    ["22.22.22.22/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/51", "ipAddressList": [], "macaddr": "50:0c:00:00:01:33",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/31", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:1f", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/26", "ipAddressList": [], "macaddr": "50:0c:00:00:01:1a",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/29", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:1d", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/47", "ipAddressList": [], "macaddr": "50:0c:00:00:01:2f",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "mgmt0", "ipAddressList":
+    ["172.29.151.2/24"], "macaddr": "50:00:00:0c:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "management", "timestamp": 1627395435425}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "ifname": "Ethernet1/1", "ipAddressList": ["10.2.1.1/30"],
+    "macaddr": "50:0c:00:00:1b:08", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435425}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "ifname": "Ethernet1/2", "ipAddressList": ["10.2.2.1/30"], "macaddr": "50:0c:00:00:1b:08",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/3", "ipAddressList":
+    ["10.2.3.1/30"], "macaddr": "50:0c:00:00:1b:08", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/4", "ipAddressList": ["10.2.4.1/30"], "macaddr":
+    "50:0c:00:00:1b:08", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435425}, {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/5",
+    "ipAddressList": ["10.2.5.1/30"], "macaddr": "50:0c:00:00:1b:08", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435425}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/6", "ipAddressList":
+    ["10.2.6.1/30"], "macaddr": "50:0c:00:00:1b:08", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/7", "ipAddressList": [], "macaddr": "50:0c:00:00:1b:08",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/8", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:1b:08", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "default", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/9", "ipAddressList": [], "macaddr": "50:0c:00:00:1b:08",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "default", "timestamp":
+    1627395435425}, {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/10",
+    "ipAddressList": [], "macaddr": "50:0c:00:00:01:0a", "ip6AddressList": [], "state":
+    "notConnected", "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "ifname": "Ethernet1/11", "ipAddressList": [], "macaddr":
+    "50:0c:00:00:01:0b", "ip6AddressList": [], "state": "notConnected", "vrf": "bridge",
+    "timestamp": 1627395435425}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "ifname": "Ethernet1/12", "ipAddressList": [], "macaddr": "50:0c:00:00:01:0c",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/30", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:1e", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/13", "ipAddressList": [], "macaddr": "50:0c:00:00:01:0d",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/15", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:0f", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/16", "ipAddressList": [], "macaddr": "50:0c:00:00:01:10",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/17", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:11", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/18", "ipAddressList": [], "macaddr": "50:0c:00:00:01:12",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/19", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:13", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/20", "ipAddressList": [], "macaddr": "50:0c:00:00:01:14",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/21", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:15", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/22", "ipAddressList": [], "macaddr": "50:0c:00:00:01:16",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/23", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:17", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/24", "ipAddressList": [], "macaddr": "50:0c:00:00:01:18",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/25", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:19", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/48", "ipAddressList": [], "macaddr": "50:0c:00:00:01:30",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/27", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:1b", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/28", "ipAddressList": [], "macaddr": "50:0c:00:00:01:1c",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "Ethernet1/14", "ipAddressList":
+    [], "macaddr": "50:0c:00:00:01:0e", "ip6AddressList": [], "state": "notConnected",
+    "vrf": "bridge", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "ifname": "Ethernet1/46", "ipAddressList": [], "macaddr": "50:0c:00:00:01:2e",
+    "ip6AddressList": [], "state": "notConnected", "vrf": "bridge", "timestamp": 1627395435425},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "ifname": "management", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435425}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "ifname": "default", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435425}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "mtun", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em13",
+    "ipAddressList": [], "macaddr": "50:00:00:05:00:0d", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "em14", "ipAddressList": [], "macaddr": "50:00:00:05:00:0e",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "esi", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "gre", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "ipip", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "irb",
+    "ipAddressList": [], "macaddr": "02:05:86:71:13:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "jsrv", "ipAddressList": [], "macaddr": "02:05:86:71:13:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "lo0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "lsi", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "pimd", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "pime",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "em12", "ipAddressList": [], "macaddr": "50:00:00:05:00:0c",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "pip0", "ipAddressList":
+    [], "macaddr": "02:05:86:71:0e:df", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "vme", "ipAddressList": [], "macaddr": "02:05:86:71:13:01", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "vtep", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/0.0",
+    "ipAddressList": ["10.1.3.2/30"], "macaddr": "02:05:86:71:13:03", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/1.0", "ipAddressList": ["10.2.3.2/30"],
+    "macaddr": "02:05:86:71:13:07", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname":
+    "xe-0/0/2.0", "ipAddressList": [], "macaddr": "02:05:86:71:13:0b", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/3.0", "ipAddressList": [],
+    "macaddr": "02:05:86:71:13:0f", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname":
+    "bme0.0", "ipAddressList": ["128.0.0.1/2", "128.0.0.4/2", "128.0.0.16/2", "128.0.0.63/2"],
+    "macaddr": "02:00:00:00:00:0a", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname":
+    "em0.0", "ipAddressList": ["172.29.151.5/24"], "macaddr": "50:00:00:05:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em1.0", "ipAddressList":
+    ["169.254.0.2/24"], "macaddr": "50:00:00:05:00:01", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "em2.32768", "ipAddressList": ["192.168.1.2/24"], "macaddr":
+    "50:00:00:05:00:02", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em4.32768",
+    "ipAddressList": ["192.0.2.2/24"], "macaddr": "50:00:00:05:00:04", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "lo0.16385", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname":
+    "tap", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "em11", "ipAddressList": [], "macaddr":
+    "50:00:00:05:00:0b", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em10",
+    "ipAddressList": [], "macaddr": "50:00:00:05:00:0a", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "em9", "ipAddressList": [], "macaddr": "50:00:00:05:00:09",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "gr-0/0/0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "pfe-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "ENET2", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "pfh-0/0/0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "ENET2",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname":
+    "xe-0/0/0", "ipAddressList": [], "macaddr": "02:05:86:71:13:03", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/1", "ipAddressList": [], "macaddr":
+    "02:05:86:71:13:07", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/2",
+    "ipAddressList": [], "macaddr": "02:05:86:71:13:0b", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "xe-0/0/3", "ipAddressList": [], "macaddr": "02:05:86:71:13:0f",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/4", "ipAddressList":
+    [], "macaddr": "02:05:86:71:13:13", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "xe-0/0/5", "ipAddressList": [], "macaddr": "02:05:86:71:13:17", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/6", "ipAddressList": [], "macaddr":
+    "02:05:86:71:13:1b", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/7",
+    "ipAddressList": [], "macaddr": "02:05:86:71:13:1f", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "xe-0/0/8", "ipAddressList": [], "macaddr": "02:05:86:71:13:23",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/9", "ipAddressList":
+    [], "macaddr": "02:05:86:71:13:27", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "xe-0/0/10", "ipAddressList": [], "macaddr": "02:05:86:71:13:2b", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "xe-0/0/11", "ipAddressList": [],
+    "macaddr": "02:05:86:71:13:2f", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname":
+    "bme0", "ipAddressList": [], "macaddr": "02:00:00:00:00:0a", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "cbp0", "ipAddressList": [], "macaddr":
+    "02:05:86:71:13:14", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "dsc",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "em0", "ipAddressList": [], "macaddr": "50:00:00:05:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em1", "ipAddressList":
+    [], "macaddr": "50:00:00:05:00:01", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "em2", "ipAddressList": [], "macaddr": "50:00:00:05:00:02", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "em3", "ipAddressList": [], "macaddr":
+    "50:00:00:05:00:03", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em4",
+    "ipAddressList": [], "macaddr": "50:00:00:05:00:04", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "ifname": "em5", "ipAddressList": [], "macaddr": "50:00:00:05:00:05",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395435943},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "em6", "ipAddressList":
+    [], "macaddr": "50:00:00:05:00:06", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "ifname": "em7", "ipAddressList": [], "macaddr": "50:00:00:05:00:07", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "em8", "ipAddressList": [], "macaddr":
+    "50:00:00:05:00:08", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395435943}, {"namespace": "mixed", "hostname": "leaf3-qfx", "ifname": "lo0.0",
+    "ipAddressList": ["3.3.3.3/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395435943}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "ifname": "jsrv.1", "ipAddressList": ["128.0.0.127/2"],
+    "macaddr": "02:05:86:71:13:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395435943}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname":
+    "lo0.16385", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "pfe-0/0/0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "ENET2",
+    "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname":
+    "em13", "ipAddressList": [], "macaddr": "50:00:00:03:00:0d", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "em14", "ipAddressList": [], "macaddr":
+    "50:00:00:03:00:0e", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "esi",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "gre", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "ipip", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "irb", "ipAddressList": [], "macaddr": "02:05:86:71:87:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "jsrv", "ipAddressList": [], "macaddr":
+    "02:05:86:71:87:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "lo0",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "lsi", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "mtun", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "pimd", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "pime", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "pip0",
+    "ipAddressList": [], "macaddr": "02:05:86:71:82:df", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "tap", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "gr-0/0/0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "vtep", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/0.0", "ipAddressList": ["10.1.4.2/30"],
+    "macaddr": "02:05:86:71:87:03", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname":
+    "xe-0/0/1.0", "ipAddressList": ["10.2.4.2/30"], "macaddr": "02:05:86:71:87:07",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "bme0.0", "ipAddressList":
+    ["128.0.0.1/2", "128.0.0.4/2", "128.0.0.16/2", "128.0.0.63/2"], "macaddr": "02:00:00:00:00:0a",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em0.0", "ipAddressList":
+    ["172.29.151.6/24"], "macaddr": "50:00:00:03:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "em1.0", "ipAddressList": ["169.254.0.2/24"], "macaddr":
+    "50:00:00:03:00:01", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em2.32768",
+    "ipAddressList": ["192.168.1.2/24"], "macaddr": "50:00:00:03:00:02", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "em4.32768", "ipAddressList": ["192.0.2.2/24"],
+    "macaddr": "50:00:00:03:00:04", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname":
+    "jsrv.1", "ipAddressList": ["128.0.0.127/2"], "macaddr": "02:05:86:71:87:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "lo0.0", "ipAddressList":
+    ["4.4.4.4/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "em12", "ipAddressList": [], "macaddr": "50:00:00:03:00:0c",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em11", "ipAddressList":
+    [], "macaddr": "50:00:00:03:00:0b", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "vme", "ipAddressList": [], "macaddr": "02:05:86:71:87:01", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "em9", "ipAddressList": [], "macaddr":
+    "50:00:00:03:00:09", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em10",
+    "ipAddressList": [], "macaddr": "50:00:00:03:00:0a", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "pfh-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "ENET2", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/0", "ipAddressList":
+    [], "macaddr": "02:05:86:71:87:03", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "xe-0/0/1", "ipAddressList": [], "macaddr": "02:05:86:71:87:07", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/2", "ipAddressList": [], "macaddr":
+    "02:05:86:71:87:0b", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/4",
+    "ipAddressList": [], "macaddr": "02:05:86:71:87:13", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "xe-0/0/5", "ipAddressList": [], "macaddr": "02:05:86:71:87:17",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/6", "ipAddressList":
+    [], "macaddr": "02:05:86:71:87:1b", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "xe-0/0/7", "ipAddressList": [], "macaddr": "02:05:86:71:87:1f", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/8", "ipAddressList": [], "macaddr":
+    "02:05:86:71:87:23", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/9",
+    "ipAddressList": [], "macaddr": "02:05:86:71:87:27", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "xe-0/0/10", "ipAddressList": [], "macaddr": "02:05:86:71:87:2b",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/3", "ipAddressList":
+    [], "macaddr": "02:05:86:71:87:0f", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "bme0", "ipAddressList": [], "macaddr": "02:00:00:00:00:0a", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "em8", "ipAddressList": [], "macaddr":
+    "50:00:00:03:00:08", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "xe-0/0/11",
+    "ipAddressList": [], "macaddr": "02:05:86:71:87:2f", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "em7", "ipAddressList": [], "macaddr": "50:00:00:03:00:07",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em6", "ipAddressList":
+    [], "macaddr": "50:00:00:03:00:06", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "em4", "ipAddressList": [], "macaddr": "50:00:00:03:00:04", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "em5", "ipAddressList": [], "macaddr":
+    "50:00:00:03:00:05", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em2",
+    "ipAddressList": [], "macaddr": "50:00:00:03:00:02", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "ifname": "em1", "ipAddressList": [], "macaddr": "50:00:00:03:00:01",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395436097},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em0", "ipAddressList":
+    [], "macaddr": "50:00:00:03:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "ifname": "dsc", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "ifname": "cbp0", "ipAddressList": [], "macaddr":
+    "02:05:86:71:87:14", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395436097}, {"namespace": "mixed", "hostname": "leaf4-qfx", "ifname": "em3",
+    "ipAddressList": [], "macaddr": "50:00:00:03:00:03", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395436097}, {"namespace": "mixed", "hostname":
+    "leaf1-ios", "ifname": "GigabitEthernet0/14", "ipAddressList": [], "macaddr":
+    "50:00:00:09:00:0e", "ip6AddressList": [], "state": "down", "vrf": "default",
+    "timestamp": 1627395437160}, {"namespace": "mixed", "hostname": "leaf1-ios", "ifname":
+    "GigabitEthernet0/9", "ipAddressList": [], "macaddr": "50:00:00:09:00:09", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1627395437160}, {"namespace":
+    "mixed", "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/13", "ipAddressList":
+    [], "macaddr": "50:00:00:09:00:0d", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437160}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "ifname": "GigabitEthernet0/12", "ipAddressList": [], "macaddr": "50:00:00:09:00:0c",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1627395437160},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/11",
+    "ipAddressList": [], "macaddr": "50:00:00:09:00:0b", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437160}, {"namespace": "mixed",
+    "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/10", "ipAddressList": [],
+    "macaddr": "50:00:00:09:00:0a", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437160}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "ifname": "GigabitEthernet0/8", "ipAddressList": [], "macaddr": "50:00:00:09:00:08",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1627395437160},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/3",
+    "ipAddressList": [], "macaddr": "50:00:00:09:00:03", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437160}, {"namespace": "mixed",
+    "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/6", "ipAddressList": [],
+    "macaddr": "50:00:00:09:00:06", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437160}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "ifname": "GigabitEthernet0/5", "ipAddressList": [], "macaddr": "50:00:00:09:00:05",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1627395437160},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/4",
+    "ipAddressList": [], "macaddr": "50:00:00:09:00:04", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437160}, {"namespace": "mixed",
+    "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/2", "ipAddressList": [],
+    "macaddr": "50:00:00:09:00:02", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437160}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "ifname": "GigabitEthernet0/1", "ipAddressList": ["10.2.1.2/30"], "macaddr": "50:00:00:09:00:01",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395437160},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/15",
+    "ipAddressList": [], "macaddr": "50:00:00:09:00:0f", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437160}, {"namespace": "mixed",
+    "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/7", "ipAddressList": ["172.29.151.3/24"],
+    "macaddr": "50:00:00:09:00:07", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395437160}, {"namespace": "mixed", "hostname": "leaf1-ios", "ifname":
+    "Loopback0", "ipAddressList": ["1.1.1.1/32"], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395437160},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "ifname": "GigabitEthernet0/0",
+    "ipAddressList": ["10.1.1.2/30"], "macaddr": "50:00:00:09:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1627395437160}, {"namespace":
+    "mixed", "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/1", "ipAddressList":
+    ["10.2.2.2/30"], "macaddr": "50:00:00:0a:00:01", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1627395437566}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "ifname": "Loopback0", "ipAddressList": ["2.2.2.2/32"], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1627395437566}, {"namespace": "mixed", "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/15",
+    "ipAddressList": [], "macaddr": "50:00:00:0a:00:0f", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437566}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/14", "ipAddressList": [],
+    "macaddr": "50:00:00:0a:00:0e", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437566}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "ifname": "GigabitEthernet0/13", "ipAddressList": [], "macaddr": "50:00:00:0a:00:0d",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1627395437566},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/11",
+    "ipAddressList": [], "macaddr": "50:00:00:0a:00:0b", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437566}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/10", "ipAddressList": [],
+    "macaddr": "50:00:00:0a:00:0a", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437566}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "ifname": "GigabitEthernet0/0", "ipAddressList": ["10.1.2.2/30"], "macaddr": "50:00:00:0a:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1627395437566},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/9",
+    "ipAddressList": [], "macaddr": "50:00:00:0a:00:09", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437566}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/7", "ipAddressList": ["172.29.151.4/24"],
+    "macaddr": "50:00:00:0a:00:07", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1627395437566}, {"namespace": "mixed", "hostname": "leaf2-ios", "ifname":
+    "GigabitEthernet0/6", "ipAddressList": [], "macaddr": "50:00:00:0a:00:06", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1627395437566}, {"namespace":
+    "mixed", "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/5", "ipAddressList":
+    ["10.1.2.21/30"], "macaddr": "50:00:00:0a:00:05", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437566}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/4", "ipAddressList": ["10.1.2.17/30"],
+    "macaddr": "50:00:00:0a:00:04", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437566}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "ifname": "GigabitEthernet0/3", "ipAddressList": ["10.1.2.13/30"], "macaddr":
+    "50:00:00:0a:00:03", "ip6AddressList": [], "state": "down", "vrf": "default",
+    "timestamp": 1627395437566}, {"namespace": "mixed", "hostname": "leaf2-ios", "ifname":
+    "GigabitEthernet0/2", "ipAddressList": ["10.1.2.9/30"], "macaddr": "50:00:00:0a:00:02",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1627395437566},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/8",
+    "ipAddressList": [], "macaddr": "50:00:00:0a:00:08", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1627395437566}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "ifname": "GigabitEthernet0/12", "ipAddressList": [],
+    "macaddr": "50:00:00:0a:00:0c", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1627395437566}]'
+- command: address show --columns=hostname --format=json
+  data-directory: tests/data/mixed/parquet-out
+  marks: address show mixed
+  output: '[{"hostname": "leaf6-eos"}, {"hostname": "leaf6-eos"}, {"hostname": "leaf6-eos"},
+    {"hostname": "leaf6-eos"}, {"hostname": "leaf6-eos"}, {"hostname": "leaf6-eos"},
+    {"hostname": "leaf6-eos"}, {"hostname": "leaf6-eos"}, {"hostname": "leaf6-eos"},
+    {"hostname": "leaf6-eos"}, {"hostname": "leaf5-eos"}, {"hostname": "leaf5-eos"},
+    {"hostname": "leaf5-eos"}, {"hostname": "leaf5-eos"}, {"hostname": "leaf5-eos"},
+    {"hostname": "leaf5-eos"}, {"hostname": "leaf5-eos"}, {"hostname": "leaf5-eos"},
+    {"hostname": "leaf5-eos"}, {"hostname": "leaf5-eos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"}, {"hostname": "spine1-nxos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"}, {"hostname": "spine2-nxos"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf3-qfx"}, {"hostname": "leaf3-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf4-qfx"}, {"hostname": "leaf1-ios"},
+    {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"},
+    {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"},
+    {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"},
+    {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"},
+    {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"}, {"hostname": "leaf1-ios"},
+    {"hostname": "leaf1-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"},
+    {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"},
+    {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"},
+    {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"},
+    {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"},
+    {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf2-ios"}]'
+- command: address summarize --format=json
+  data-directory: tests/data/mixed/parquet-out
+  marks: address summarize mixed
+  output: '{"mixed": {"deviceCnt": 8, "addressCnt": 309, "uniqueV4AddressCnt": 52,
+    "uniqueV6AddressCnt": 0, "uniqueIfMacCnt": 228, "deviceWithv4AddressCnt": 8, "deviceWithv6AddressCnt":
+    0, "subnetsUsed": ["30", "24", "2", "32"], "subnetTopCounts": [{"30": 28}, {"24":
+    14}, {"2": 10}]}}'
+- command: address unique --columns=hostname --format=json
+  data-directory: tests/data/mixed/parquet-out
+  marks: address unique mixed
+  output: '[{"hostname": "leaf1-ios"}, {"hostname": "leaf2-ios"}, {"hostname": "leaf3-qfx"},
+    {"hostname": "leaf4-qfx"}, {"hostname": "leaf5-eos"}, {"hostname": "leaf6-eos"},
+    {"hostname": "spine1-nxos"}, {"hostname": "spine2-nxos"}]'
+- command: address unique --columns=hostname --format=json --count=True
+  data-directory: tests/data/mixed/parquet-out
+  marks: address unique mixed
+  output: '[{"hostname": "leaf5-eos", "numRows": 10}, {"hostname": "leaf6-eos", "numRows":
+    10}, {"hostname": "leaf1-ios", "numRows": 17}, {"hostname": "leaf2-ios", "numRows":
+    17}, {"hostname": "leaf4-qfx", "numRows": 57}, {"hostname": "leaf3-qfx", "numRows":
+    59}, {"hostname": "spine2-nxos", "numRows": 68}, {"hostname": "spine1-nxos", "numRows":
+    71}]'
+- command: address unique --columns=vrf --format=json
+  data-directory: tests/data/mixed/parquet-out
+  marks: address unique mixed
+  output: '[{"vrf": "default"}, {"vrf": "management"}]'

--- a/tests/integration/sqcmds/nxos-samples/address.yml
+++ b/tests/integration/sqcmds/nxos-samples/address.yml
@@ -1961,6 +1961,22 @@ tests:
     "leaf03"}, {"hostname": "leaf04"}, {"hostname": "server101"}, {"hostname": "server102"},
     {"hostname": "server301"}, {"hostname": "server302"}, {"hostname": "spine01"},
     {"hostname": "spine02"}]'
+- command: address unique --columns=hostname --format=json --count=True
+  data-directory: tests/data/nxos/parquet-out/
+  marks: address unique nxos
+  output: '[{"hostname": "server101", "numRows": 5}, {"hostname": "server102", "numRows":
+    5}, {"hostname": "server301", "numRows": 5}, {"hostname": "server302", "numRows":
+    5}, {"hostname": "firewall01", "numRows": 10}, {"hostname": "dcedge01", "numRows":
+    58}, {"hostname": "spine01", "numRows": 70}, {"hostname": "spine02", "numRows":
+    70}, {"hostname": "exit01", "numRows": 77}, {"hostname": "exit02", "numRows":
+    77}, {"hostname": "leaf01", "numRows": 78}, {"hostname": "leaf02", "numRows":
+    78}, {"hostname": "leaf03", "numRows": 78}, {"hostname": "leaf04", "numRows":
+    78}]'
+- command: address unique --columns=vrf --format=json --count=True
+  data-directory: tests/data/nxos/parquet-out/
+  marks: address unique nxos
+  output: '[{"vrf": "internet-vrf", "numRows": 4}, {"vrf": "management", "numRows":
+    8}, {"vrf": "evpn-vrf", "numRows": 10}, {"vrf": "default", "numRows": 65}]'
 - command: address show --address=10.0.0.11 --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: address show filter nxos

--- a/tests/integration/sqcmds/vmx-samples/address.yml
+++ b/tests/integration/sqcmds/vmx-samples/address.yml
@@ -1,0 +1,752 @@
+description: 'Testing verbs for address: show summarize unique'
+tests:
+- command: address show --format=json
+  data-directory: tests/data/vmx/parquet-out
+  marks: address show vmx
+  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lo0.16385",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "ifname": "fti3", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti2", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "fti1", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "esi", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "em1", "ipAddressList": [], "macaddr":
+    "50:06:00:0f:00:01", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "dsc", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "demux0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "cbp0", "ipAddressList": [], "macaddr": "2c:6b:f5:7d:ef:11", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:7d:f6:c1", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "ae0", "ipAddressList": [], "macaddr": "2c:6b:f5:7d:f6:c0", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti4", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/9", "ipAddressList": [], "macaddr": "50:06:00:10:00:0b", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/7", "ipAddressList":
+    [], "macaddr": "50:06:00:10:00:09", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/6", "ipAddressList": [], "macaddr": "50:06:00:10:00:08", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/5", "ipAddressList":
+    [], "macaddr": "50:06:00:10:00:07", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/4", "ipAddressList": [], "macaddr": "50:06:00:10:00:06", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/3", "ipAddressList":
+    [], "macaddr": "2c:6b:f5:7d:f6:c0", "ip6AddressList": [], "state": "up", "vrf":
+    "ae0", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/2", "ipAddressList": [], "macaddr": "2c:6b:f5:7d:f6:c0", "ip6AddressList":
+    [], "state": "up", "vrf": "ae0", "timestamp": 1631009088901}, {"namespace": "vmx",
+    "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/0", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:7d:f6:c1", "ip6AddressList": [], "state": "up", "vrf": "ae1", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "ge-0/0/1", "ipAddressList": [], "macaddr": "2c:6b:f5:7d:f6:c1", "ip6AddressList":
+    [], "state": "up", "vrf": "ae1", "timestamp": 1631009088901}, {"namespace": "vmx",
+    "hostname": "TOR4CRP-DGW-RT01", "ifname": "pfh-0/0/0", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "ENET2", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "pfe-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "ENET2", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lc-0/0/0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/8", "ipAddressList": [], "macaddr": "50:06:00:10:00:0a", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti5", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "lo0.16384", "ipAddressList": ["127.0.0.1/32"], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti7", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "fti6", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fxp0.0", "ipAddressList": ["172.26.145.154/22"],
+    "macaddr": "50:06:00:0f:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "em1.0", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"],
+    "macaddr": "50:06:00:0f:00:01", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "irb.201", "ipAddressList": ["172.16.21.254/24"], "macaddr": "2c:6b:f5:7d:f6:f0",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "jsrv.1", "ipAddressList":
+    ["128.0.0.127/2"], "macaddr": "2c:6b:f5:7d:f6:c0", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "ipAddressList": ["10.0.20.3/29"], "macaddr":
+    "2c:6b:f5:7d:f6:c1", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "ae1.10", "ipAddressList": ["10.0.10.3/29"], "macaddr": "2c:6b:f5:7d:f6:c1", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "VRF-B", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "VRF-A", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "vtep", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "tap", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "rbeb", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "irb.101", "ipAddressList": ["172.16.11.254/24"], "macaddr": "2c:6b:f5:7d:f6:f0",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "pip0", "ipAddressList":
+    [], "macaddr": "2c:6b:f5:7d:f6:b0", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "pp0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fxp0", "ipAddressList": [],
+    "macaddr": "50:06:00:0f:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ipip", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "irb", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:7d:f6:f0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "jsrv", "ipAddressList": [], "macaddr": "2c:6b:f5:7d:f6:c0", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "gre", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "lsi", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "mtun", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "pimd", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "pime", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "lo0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "gre", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ipip",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "irb", "ipAddressList": [], "macaddr": "2c:6b:f5:2e:e8:f0",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "jsrv", "ipAddressList":
+    [], "macaddr": "2c:6b:f5:2e:e8:c0", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "lo0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lsi", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "mtun",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "pimd", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "pime", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "vtep", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "pp0", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "rbeb",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "tap", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "em1.0", "ipAddressList":
+    ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"], "macaddr": "50:06:00:03:00:01",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fxp0.0", "ipAddressList":
+    ["172.26.145.152/22"], "macaddr": "50:06:00:03:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "jsrv.1", "ipAddressList": ["128.0.0.127/2"], "macaddr":
+    "2c:6b:f5:2e:e8:c0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lo0.16384",
+    "ipAddressList": ["127.0.0.1/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lo0.16385", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fxp0", "ipAddressList": [], "macaddr": "50:06:00:03:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "pip0", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:2e:e8:b0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti7",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "demux0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti5", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/0", "ipAddressList": [], "macaddr": "50:06:00:04:00:02", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lc-0/0/0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "pfh-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "ENET2", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/1", "ipAddressList": [],
+    "macaddr": "50:06:00:04:00:03", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/2", "ipAddressList": [], "macaddr": "2c:6b:f5:2e:e8:c1", "ip6AddressList":
+    [], "state": "up", "vrf": "ae1", "timestamp": 1631009089182}, {"namespace": "vmx",
+    "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/3", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:2e:e8:c1", "ip6AddressList": [], "state": "up", "vrf": "ae1", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/4",
+    "ipAddressList": [], "macaddr": "2c:6b:f5:2e:e8:c2", "ip6AddressList": [], "state":
+    "up", "vrf": "ae2", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "ge-0/0/5", "ipAddressList": [], "macaddr": "2c:6b:f5:2e:e8:c2",
+    "ip6AddressList": [], "state": "up", "vrf": "ae2", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/6", "ipAddressList":
+    [], "macaddr": "50:06:00:04:00:08", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/7", "ipAddressList": [], "macaddr": "50:06:00:04:00:09", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/8", "ipAddressList": [],
+    "macaddr": "50:06:00:04:00:0a", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/9", "ipAddressList": [], "macaddr": "50:06:00:04:00:0b", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae1", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:2e:e8:c1", "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2",
+    "ipAddressList": [], "macaddr": "2c:6b:f5:2e:e8:c2", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "cbp0", "ipAddressList": [], "macaddr": "2c:6b:f5:2e:e1:11",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "dsc", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "em1", "ipAddressList": [], "macaddr": "50:06:00:03:00:01", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "esi", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti0",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "fti1", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti2", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti3", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti4", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti6",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "pfe-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "ENET2", "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/0", "ipAddressList":
+    [], "macaddr": "2c:6b:f5:82:1c:c0", "ip6AddressList": [], "state": "up", "vrf":
+    "ae0", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti6", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti7", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fxp0",
+    "ipAddressList": [], "macaddr": "50:06:00:0b:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "gre", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ipip", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "irb", "ipAddressList": [], "macaddr": "2c:6b:f5:82:1c:f0", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "jsrv", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "lo0",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "lsi", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "mtun", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti5", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "pimd", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "pip0",
+    "ipAddressList": [], "macaddr": "2c:6b:f5:82:1c:b0", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "pp0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "rbeb", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "tap", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "vtep", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "em1.0",
+    "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"], "macaddr": "50:06:00:0b:00:01",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fxp0.0", "ipAddressList":
+    ["172.26.145.151/22"], "macaddr": "50:06:00:0b:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "jsrv.1", "ipAddressList": ["128.0.0.127/2"], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "lo0.16384",
+    "ipAddressList": ["127.0.0.1/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "pime", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "lo0.16385",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "fti4", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti2", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "lc-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "pfe-0/0/0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "ENET2",
+    "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "pfh-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "ENET2", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/1", "ipAddressList": [],
+    "macaddr": "2c:6b:f5:82:1c:c0", "ip6AddressList": [], "state": "up", "vrf": "ae0",
+    "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/2", "ipAddressList": [], "macaddr": "2c:6b:f5:82:1c:c1", "ip6AddressList":
+    [], "state": "up", "vrf": "ae1", "timestamp": 1631009089423}, {"namespace": "vmx",
+    "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/3", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:82:1c:c1", "ip6AddressList": [], "state": "up", "vrf": "ae1", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/4",
+    "ipAddressList": [], "macaddr": "50:06:00:0a:00:06", "ip6AddressList": [], "state":
+    "down", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "ge-0/0/5", "ipAddressList": [], "macaddr": "50:06:00:0a:00:07",
+    "ip6AddressList": [], "state": "down", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/6", "ipAddressList":
+    [], "macaddr": "50:06:00:0a:00:08", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/7", "ipAddressList": [], "macaddr": "50:06:00:0a:00:09", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti3", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/8",
+    "ipAddressList": [], "macaddr": "50:06:00:0a:00:0a", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "ae0", "ipAddressList": [], "macaddr": "2c:6b:f5:82:1c:c0",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ae1", "ipAddressList":
+    [], "macaddr": "2c:6b:f5:82:1c:c1", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "cbp0", "ipAddressList": [], "macaddr": "2c:6b:f5:82:15:11", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "demux0", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "dsc",
+    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "em1", "ipAddressList": [], "macaddr": "50:06:00:0b:00:01",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "esi", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti1", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/9",
+    "ipAddressList": [], "macaddr": "50:06:00:0a:00:0b", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "pfh-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "ENET2", "timestamp": 1631009089434},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "pfe-0/0/0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "ENET2", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/4", "ipAddressList": [], "macaddr": "50:06:00:0c:00:06", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "ge-0/0/0", "ipAddressList": [],
+    "macaddr": "50:06:00:0c:00:02", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/1", "ipAddressList": [], "macaddr": "50:06:00:0c:00:03", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "lc-0/0/0", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/3", "ipAddressList": [], "macaddr": "50:06:00:0c:00:05", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "irb", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:9b:2c:f0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ge-0/0/2", "ipAddressList": [], "macaddr": "50:06:00:0c:00:04", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "jsrv", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:9b:2c:c0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "lo0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "lsi", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "mtun", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "pimd", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "pime", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "pip0", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:9b:2c:b0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "pp0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "rbeb", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "tap", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "vtep", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ge-0/0/2.0", "ipAddressList": ["10.0.100.0/31"], "macaddr": "50:06:00:0c:00:04",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089434},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "ge-0/0/3.0", "ipAddressList":
+    [], "macaddr": "50:06:00:0c:00:05", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "em1.0", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"],
+    "macaddr": "50:06:00:01:00:01", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "fxp0.0", "ipAddressList": ["172.26.145.155/22"], "macaddr": "50:06:00:01:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089434},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "jsrv.1", "ipAddressList":
+    ["128.0.0.127/2"], "macaddr": "2c:6b:f5:9b:2c:c0", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "lo0.16384", "ipAddressList": ["127.0.0.1/32"], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ipip", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "lo0.16385", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "gre", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti7", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ge-0/0/5", "ipAddressList": [], "macaddr": "50:06:00:0c:00:07", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "ge-0/0/6", "ipAddressList": [],
+    "macaddr": "50:06:00:0c:00:08", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/7", "ipAddressList": [], "macaddr": "50:06:00:0c:00:09", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "ge-0/0/8", "ipAddressList": [],
+    "macaddr": "50:06:00:0c:00:0a", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/9", "ipAddressList": [], "macaddr": "50:06:00:0c:00:0b", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "cbp0", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:9b:25:11", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "demux0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "dsc", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fxp0", "ipAddressList": [], "macaddr": "50:06:00:01:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "em1", "ipAddressList": [], "macaddr":
+    "50:06:00:01:00:01", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti1", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti2", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti3", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti4", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti5", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti6", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "esi", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "pfe-0/0/0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "ENET2", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "lc-0/0/0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae1", "ipAddressList": [], "macaddr": "2c:6b:f5:b6:ce:c1", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "pfh-0/0/0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "ENET2", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/0", "ipAddressList": [], "macaddr": "2c:6b:f5:b6:ce:c1", "ip6AddressList":
+    [], "state": "up", "vrf": "ae1", "timestamp": 1631009089864}, {"namespace": "vmx",
+    "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/1", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:b6:ce:c1", "ip6AddressList": [], "state": "up", "vrf": "ae1", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ge-0/0/2", "ipAddressList": [], "macaddr": "2c:6b:f5:b6:ce:c0", "ip6AddressList":
+    [], "state": "up", "vrf": "ae0", "timestamp": 1631009089864}, {"namespace": "vmx",
+    "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/3", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:b6:ce:c0", "ip6AddressList": [], "state": "up", "vrf": "ae0", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "lsi", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/9", "ipAddressList":
+    [], "macaddr": "50:06:00:0e:00:0b", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "jsrv", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "irb", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:b6:ce:f0", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ipip", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "gre", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "fxp0", "ipAddressList": [], "macaddr": "50:06:00:0d:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "fti7", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti6", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "mtun", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti5", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "fti3", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti2", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "fti1", "ipAddressList": [],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "esi", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "em1", "ipAddressList": [], "macaddr": "50:06:00:0d:00:01", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "dsc", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "demux0", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "cbp0", "ipAddressList": [],
+    "macaddr": "2c:6b:f5:b6:c7:11", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti4", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ae0", "ipAddressList": [], "macaddr":
+    "2c:6b:f5:b6:ce:c0", "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "pimd", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "pip0", "ipAddressList": [],
+    "macaddr": "2c:6b:f5:b6:ce:b0", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/4", "ipAddressList": [], "macaddr": "50:06:00:0e:00:06", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/5", "ipAddressList":
+    [], "macaddr": "50:06:00:0e:00:07", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/6", "ipAddressList": [], "macaddr": "50:06:00:0e:00:08", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/7", "ipAddressList":
+    [], "macaddr": "50:06:00:0e:00:09", "ip6AddressList": [], "state": "down", "vrf":
+    "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/8", "ipAddressList": [], "macaddr": "50:06:00:0e:00:0a", "ip6AddressList":
+    [], "state": "down", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "lo0.16385", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "lo0.16384", "ipAddressList": ["127.0.0.1/32"], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "jsrv.1", "ipAddressList":
+    ["128.0.0.127/2"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "irb.200", "ipAddressList": ["172.16.20.254/24"],
+    "macaddr": "2c:6b:f5:b6:ce:f0", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "pime", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "irb.100", "ipAddressList": ["172.16.10.254/24"],
+    "macaddr": "2c:6b:f5:b6:ce:f0", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "em1.0", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"],
+    "macaddr": "50:06:00:0d:00:01", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae1.20", "ipAddressList": ["10.0.20.2/29"], "macaddr": "2c:6b:f5:b6:ce:c1",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ae1.10", "ipAddressList":
+    ["10.0.10.2/29"], "macaddr": "2c:6b:f5:b6:ce:c1", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "VRF-B", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "VRF-A", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "vtep", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "tap", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "rbeb", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "pp0", "ipAddressList": [], "macaddr":
+    "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "fxp0.0", "ipAddressList": ["172.26.145.153/22"], "macaddr": "50:06:00:0d:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "lo0", "ipAddressList":
+    [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1631009089864}]'
+- command: address show --columns=hostname --format=json
+  data-directory: tests/data/vmx/parquet-out
+  marks: address show vmx
+  output: '[{"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"},
+    {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname":
+    "TOR4CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"},
+    {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"},
+    {"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-ACC-SW01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"},
+    {"hostname": "TOR1BBN-PE-RT01"}, {"hostname": "TOR1BBN-PE-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname":
+    "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"},
+    {"hostname": "TOR1CRP-DGW-RT01"}]'
+- command: address summarize --format=json
+  data-directory: tests/data/vmx/parquet-out
+  marks: address summarize vmx
+  output: '{"vmx": {"deviceCnt": 5, "addressCnt": 252, "uniqueV4AddressCnt": 19, "uniqueV6AddressCnt":
+    0, "uniqueIfMacCnt": 70, "deviceWithv4AddressCnt": 5, "deviceWithv6AddressCnt":
+    0, "subnetsUsed": ["2", "22", "32", "8", "24", "29", "31"], "subnetTopCounts":
+    [{"2": 15}, {"22": 5}, {"32": 5}]}}'
+- command: address unique --columns=hostname --format=json
+  data-directory: tests/data/vmx/parquet-out
+  marks: address unique vmx
+  output: '[{"hostname": "CRP-ACC-SW01"}, {"hostname": "CRP-DIS-SW01"}, {"hostname":
+    "TOR1BBN-PE-RT01"}, {"hostname": "TOR1CRP-DGW-RT01"}, {"hostname": "TOR4CRP-DGW-RT01"}]'
+- command: address unique --columns=hostname --format=json --count=True
+  data-directory: tests/data/vmx/parquet-out
+  marks: address unique vmx
+  output: '[{"hostname": "CRP-ACC-SW01", "numRows": 48}, {"hostname": "CRP-DIS-SW01",
+    "numRows": 48}, {"hostname": "TOR1BBN-PE-RT01", "numRows": 48}, {"hostname": "TOR1CRP-DGW-RT01",
+    "numRows": 54}, {"hostname": "TOR4CRP-DGW-RT01", "numRows": 54}]'
+- command: address unique --columns=vrf --format=json
+  data-directory: tests/data/vmx/parquet-out
+  marks: address unique vmx
+  output: '[{"vrf": "default"}]'


### PR DESCRIPTION
This PR fixes #463 to use address unique with columns=vrf.

It does so by adding a dedicated query, still allowing for users' query to be specified and run.