### PR TITLE
Add prefixlen validation in routes table

### DIFF
--- a/tests/integration/sqcmds/cumulus-samples/route.yml
+++ b/tests/integration/sqcmds/cumulus-samples/route.yml
@@ -4574,7 +4574,7 @@ tests:
     6, "action": "forward", "timestamp": 1616638470426}]'
 - command: route show --prefixlen=64 --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
-  marks: route show
+  marks: route show filter prefixlen cumulus
   output: '[{"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix":
     "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"],
     "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
@@ -4645,6 +4645,30 @@ tests:
     "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480",
     "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
     "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426}]'
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen=">128" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen="<0" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus
+- command: route show --prefixlen=">24 and !32" --format=json
+  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  marks: route show filter prefixlen cumulus  
 - command: route summarize --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route summarize

--- a/tests/integration/sqcmds/cumulus-samples/route.yml
+++ b/tests/integration/sqcmds/cumulus-samples/route.yml
@@ -4648,27 +4648,2860 @@ tests:
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route show filter prefixlen cumulus
+  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
+    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
+    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:1::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d", "fe80::5054:ff:fe8c:5b4d",
+    "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2", "swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"], "oifs":
+    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs":
+    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"],
+    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
+    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.22/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
+    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.127.1",
+    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.102/32", "nexthopIps": ["169.254.127.3"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs":
+    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
+    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
+    ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
+    "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs":
+    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
+    ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e", "fe80::5054:ff:fe7e:5a82"],
+    "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
+    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
+    "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps":
+    [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp5.2"], "protocol":
+    "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
+    "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
+    "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fedc:803b"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "169.254.1.0/30", "nexthopIps": [""], "oifs": ["peerlink.4094"],
+    "protocol": "kernel", "source": "169.254.1.2", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
+    "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe8d:ffce",
+    "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
+    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
+    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
+    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe6c:9df3"],
+    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
+    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
+    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
+    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
 - command: route show --prefixlen="<=24" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route show filter prefixlen cumulus
+  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol": "",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
+    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "192.168.121.254", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server102", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": [""],
+    "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.102", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.2.1"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
+    "10.0.0.0/8", "nexthopIps": ["172.16.2.1"], "oifs": ["bond0"], "protocol": "",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs":
+    ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.103", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "server104", "vrf": "default", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.180",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433},
+    {"namespace": "dual-bgp", "hostname": "server104", "vrf": "default", "prefix":
+    "172.16.4.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel",
+    "source": "172.16.4.104", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname": "server104",
+    "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.4.1"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.4.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.3.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.222", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433}, {"namespace":
+    "dual-bgp", "hostname": "server103", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.103",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433},
+    {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default", "prefix":
+    "172.16.0.0/16", "nexthopIps": ["172.16.3.1"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469433}, {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469433}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp4", "swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp4", "swp3"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.186",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517}, {"namespace":
+    "dual-bgp", "hostname": "server101", "vrf": "default", "prefix": "10.0.0.0/8",
+    "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517},
+    {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default", "prefix":
+    "172.16.0.0/16", "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469517}, {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469517}, {"namespace": "dual-bgp", "hostname": "server101",
+    "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "192.168.121.233", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469517}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.141", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.4.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp3", "swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "mgmt",
+    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "192.168.121.51", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp3", "swp4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "172.16.2.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.181",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.4.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "mgmt",
+    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "192.168.121.164", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "leaf04", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
+    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["vlan13"], "protocol":
+    "kernel", "source": "172.16.3.1", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "172.16.4.0/24", "nexthopIps": [""], "oifs": ["vlan24"],
+    "protocol": "kernel", "source": "172.16.4.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
+    "leaf04", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs":
+    ["eth0"], "protocol": "kernel", "source": "192.168.121.132", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
+    "dual-bgp", "hostname": "leaf01", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.119",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps":
+    [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.2.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002}, {"namespace":
+    "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.1.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.2.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.1.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "mgmt",
+    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "192.168.121.94", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname":
+    "leaf03", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps": [""], "oifs":
+    ["vlan24"], "protocol": "kernel", "source": "172.16.4.1", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.3.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}, {"namespace":
+    "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}, {"namespace":
+    "dual-bgp", "hostname": "leaf03", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.33",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route show filter prefixlen cumulus
+  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
+    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
+    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:1::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d", "fe80::5054:ff:fe8c:5b4d",
+    "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2", "swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"], "oifs":
+    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs":
+    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"],
+    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
+    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.22/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
+    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.127.1",
+    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.102/32", "nexthopIps": ["169.254.127.3"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs":
+    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
+    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
+    ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
+    "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs":
+    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
+    ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e", "fe80::5054:ff:fe7e:5a82"],
+    "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
+    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
+    "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps":
+    [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp5.2"], "protocol":
+    "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
+    "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
+    "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fedc:803b"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "169.254.1.0/30", "nexthopIps": [""], "oifs": ["peerlink.4094"],
+    "protocol": "kernel", "source": "169.254.1.2", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
+    "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe8d:ffce",
+    "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
+    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
+    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
+    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe6c:9df3"],
+    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
+    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
+    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
+    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
 - command: route show --prefixlen=">=24" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route show filter prefixlen cumulus
+  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
+    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
+    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "192.168.121.254", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server102", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": [""],
+    "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.102", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.253.1/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": [""],
+    "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
+    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.103",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
+    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.180", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433}, {"namespace":
+    "dual-bgp", "hostname": "server104", "vrf": "default", "prefix": "172.16.4.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.4.104",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433},
+    {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default", "prefix":
+    "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
+    "source": "192.168.121.222", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname": "server103",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"],
+    "protocol": "kernel", "source": "172.16.3.103", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:1::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d", "fe80::5054:ff:fe8c:5b4d",
+    "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2", "swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"], "oifs":
+    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp4", "swp3"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp4", "swp3"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "mgmt",
+    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "192.168.121.186", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fec6:7cc6"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64",
+    "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs": ["swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469517}, {"namespace": "dual-bgp", "hostname": "server101",
+    "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "192.168.121.233", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469517}, {"namespace": "dual-bgp",
+    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
+    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.22/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
+    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.127.1",
+    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.102/32", "nexthopIps": ["169.254.127.3"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs":
+    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.141", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
+    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs":
+    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe79:485e"],
+    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
+    ["fe80::5054:ff:fe40:386"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64",
+    "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e",
+    "fe80::5054:ff:fe7e:5a82"], "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp3", "swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.51", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp3", "swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.253/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol":
+    "kernel", "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "172.16.4.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["swp5.4"],
+    "protocol": "kernel", "source": "169.254.254.9", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.2"], "oifs": ["swp5.2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps":
+    [""], "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.254.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.181", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.12/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps":
+    [""], "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.4.0/24",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "172.16.3.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30", "nexthopIps": [""],
+    "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel", "source": "169.254.127.3",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"], "oifs": ["swp6"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.164", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["vlan13"], "protocol":
+    "kernel", "source": "172.16.3.1", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "172.16.4.0/24", "nexthopIps": [""], "oifs": ["vlan24"],
+    "protocol": "kernel", "source": "172.16.4.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
+    "leaf04", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
+    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::22/128", "nexthopIps":
+    ["fe80::5054:ff:fedc:803b"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
+    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe8d:ffce"],
+    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.132",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
+    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
+    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
+    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.119",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
+    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
+    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.2.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.1.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
+    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe6c:9df3"],
+    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["vlan24"], "protocol":
+    "kernel", "source": "172.16.2.1", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
+    "default", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["vlan13"],
+    "protocol": "kernel", "source": "172.16.1.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname":
+    "leaf02", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps": [""], "oifs":
+    ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
+    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.94",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
+    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
+    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.4.0/24",
+    "nexthopIps": [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.4.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.3.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
+    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "mgmt", "prefix": "192.168.121.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.33",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:2::/64",
+    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
 - command: route show --prefixlen="!24" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route show filter prefixlen cumulus
+  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol": "",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
+    "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname": "server102",
+    "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.2.1"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server102", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.2.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
+    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
+    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
+    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.4.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.4.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.3.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
+    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs":
+    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d",
+    "fe80::5054:ff:fe8c:5b4d", "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2",
+    "swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"],
+    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs":
+    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"],
+    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
+    "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517}, {"namespace":
+    "dual-bgp", "hostname": "server101", "vrf": "default", "prefix": "10.0.0.0/8",
+    "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517},
+    {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default", "prefix":
+    "172.16.0.0/16", "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469517}, {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default",
+    "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:1::1"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469517}, {"namespace": "dual-bgp", "hostname": "internet",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp1"],
+    "protocol": "kernel", "source": "169.254.127.0", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.127.1",
+    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "internet",
+    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
+    ["fe80::5054:ff:fea1:d20b"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp2"], "protocol": "kernel",
+    "source": "169.254.127.2", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs":
+    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
+    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
+    ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
+    "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs":
+    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
+    ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e", "fe80::5054:ff:fe7e:5a82"],
+    "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
+    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
+    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
+    "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps":
+    [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.102/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp5.2"], "protocol":
+    "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.12/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
+    "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
+    "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
+    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::22/128", "nexthopIps":
+    ["fe80::5054:ff:fedc:803b"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
+    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64",
+    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
+    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
+    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe8d:ffce"],
+    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
+    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
+    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
+    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
+    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
+    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2",
+    "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
+    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64",
+    "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fe6c:9df3"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.2", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
+    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
+    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
+    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
+    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
+    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
+    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
+    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
+    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
+    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
+    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
+    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30",
+    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
+    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
+    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2",
+    "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname":
+    "leaf03", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480",
+    "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32",
+    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1616638470426}]'
 - command: route show --prefixlen=">128" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen cumulus
 - command: route show --prefixlen="<0" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen cumulus
 - command: route show --prefixlen=">24 and !32" --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
-  marks: route show filter prefixlen cumulus  
+  error:
+    error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
+      length'' (i.e. ''>= 24'')"}]'
+  marks: route show filter prefixlen cumulus
 - command: route summarize --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   marks: route summarize

--- a/tests/integration/sqcmds/eos-samples/route.yml
+++ b/tests/integration/sqcmds/eos-samples/route.yml
@@ -1244,6 +1244,33 @@ tests:
     "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs":
     ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200,
     "ipvers": 4, "action": "forward", "timestamp": 1623025174546}]'
+- command: route show --prefixlen=64 --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen=">128" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen="<0" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos
+- command: route show --prefixlen=">24 and !32" --format=json
+  data-directory: tests/data/eos/parquet-out/
+  marks: route show filter prefixlen eos  
 - command: route unique --columns=prefixlen --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route unique eos

--- a/tests/integration/sqcmds/eos-samples/route.yml
+++ b/tests/integration/sqcmds/eos-samples/route.yml
@@ -1247,30 +1247,2961 @@ tests:
 - command: route show --prefixlen=64 --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route show filter prefixlen eos
+  output: '[]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route show filter prefixlen eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/31",
+    "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps":
+    ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "169.254.127.0/31", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["Ethernet4"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [], "oifs":
+    ["Ethernet3.3"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540}, {"namespace":
+    "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs": ["Loopback1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/31", "nexthopIps":
+    [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "192.168.0.179/32",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": [], "oifs": ["Loopback1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["0.0.0.0"], "oifs": ["Ethernet3.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01",
+    "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps":
+    [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "169.254.127.2/31", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["Ethernet4"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    [], "oifs": ["Ethernet3"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Ethernet5"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Ethernet4"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1", "Ethernet2",
+    "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174547},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Ethernet5"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs":
+    ["Management1"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": [], "oifs": ["Ethernet3"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Ethernet4"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.151", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.137", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.57", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.230", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.189",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.4/30", "nexthopIps": [""], "oifs": ["eth2.3"],
+    "protocol": "kernel", "source": "169.254.253.6", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": [""],
+    "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.127.3"], "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.255.2.250/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:f000/128", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025176627}]'
 - command: route show --prefixlen="<=24" --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route show filter prefixlen eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix":
+    "172.16.2.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.134", "10.0.0.134"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [], "oifs": ["Vlan10"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    [], "oifs": ["Vlan30"], "protocol": "connected", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "172.16.3.0/24", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "169.254.0.0/24", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.253.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs": ["Vlan30"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs": ["Vlan20"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs": ["Vlan30"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs": ["Vlan10"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.134",
+    "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs": ["Vlan30"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs": ["Vlan20"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.112",
+    "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.2"], "oifs":
+    ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "169.254.0.0/24", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.254.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs":
+    [], "protocol": "bgpaggregate", "source": "", "preference": 200, "ipvers": 4,
+    "action": "drop", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs":
+    [], "protocol": "bgpaggregate", "source": "", "preference": 200, "ipvers": 4,
+    "action": "drop", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs":
+    [], "protocol": "bgpaggregate", "source": "", "preference": 200, "ipvers": 4,
+    "action": "drop", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.254.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "server301",
+    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["bond0"],
+    "protocol": "kernel", "source": "172.16.2.201", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174767}, {"namespace": "eos", "hostname":
+    "server301", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174767}, {"namespace": "eos", "hostname":
+    "server301", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.151", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server301", "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps":
+    ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server301", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.137", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
+    [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.1.101", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.1.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.57", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps":
+    ["172.16.1.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.102", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.230", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "10.255.2.189", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "bgp", "source": "10.0.0.200", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace": "eos",
+    "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["169.254.253.5", "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"], "protocol":
+    "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01", "vrf":
+    "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.127.3"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.3"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["em0.0"], "protocol": "access-internal", "source": "", "preference":
+    12, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route show filter prefixlen eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/31",
+    "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps":
+    ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "169.254.127.0/31", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["Ethernet4"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [], "oifs":
+    ["Ethernet3.3"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540}, {"namespace":
+    "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs": ["Loopback1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/31", "nexthopIps":
+    [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "192.168.0.179/32",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": [], "oifs": ["Loopback1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["0.0.0.0"], "oifs": ["Ethernet3.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01",
+    "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps":
+    [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "169.254.127.2/31", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["Ethernet4"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    [], "oifs": ["Ethernet3"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Ethernet5"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Ethernet4"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1", "Ethernet2",
+    "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174547},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Ethernet5"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs":
+    ["Management1"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": [], "oifs": ["Ethernet3"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Ethernet4"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.151", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.137", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.57", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.230", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.189",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.4/30", "nexthopIps": [""], "oifs": ["eth2.3"],
+    "protocol": "kernel", "source": "169.254.253.6", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": [""],
+    "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.127.3"], "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.255.2.250/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:f000/128", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025176627}]'
 - command: route show --prefixlen=">=24" --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route show filter prefixlen eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix":
+    "172.16.2.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.134", "10.0.0.134"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs": ["Vlan10"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/31",
+    "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [], "oifs": ["Vlan30"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.0.0.12/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "172.16.2.0/24", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "172.16.3.0/24", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "169.254.127.2/31", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs":
+    ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps":
+    ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps":
+    ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["Ethernet4"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["Ethernet3.4"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet3.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps":
+    ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [], "oifs":
+    ["Ethernet3.3"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs": ["Vlan30"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.31",
+    "10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs":
+    ["Vlan20"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540}, {"namespace":
+    "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs": ["Loopback1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/31", "nexthopIps":
+    [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "192.168.0.179/32",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [], "oifs": ["Vlan30"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [], "oifs": ["Vlan10"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.31", "10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134",
+    "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": [], "oifs": ["Loopback1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs":
+    ["Vlan30"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": [], "oifs": ["Vlan20"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.31", "10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112",
+    "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default",
+    "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32",
+    "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.254.4/30", "nexthopIps": ["0.0.0.0"], "oifs": ["Ethernet3.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01",
+    "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps":
+    [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "172.16.3.0/24", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.200/32", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs": [], "protocol":
+    "bgpaggregate", "source": "", "preference": 200, "ipvers": 4, "action": "drop",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs": [], "protocol":
+    "bgpaggregate", "source": "", "preference": 200, "ipvers": 4, "action": "drop",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs":
+    [], "protocol": "bgpaggregate", "source": "", "preference": 200, "ipvers": 4,
+    "action": "drop", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["Ethernet3.4"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": [],
+    "oifs": ["Ethernet4"], "protocol": "connected", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.254.10"], "oifs":
+    ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": [], "oifs":
+    ["Ethernet3"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174547},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "192.168.0.179/32",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025174547},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": [], "oifs": ["Ethernet5"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps":
+    [], "oifs": ["Management1"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    [], "oifs": ["Ethernet4"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    [], "oifs": ["Ethernet6"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    [], "oifs": ["Ethernet6"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["Ethernet5"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": [], "oifs": ["Ethernet3"], "protocol":
+    "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1", "Ethernet2", "Ethernet3",
+    "Ethernet4", "Ethernet5", "Ethernet6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    [], "oifs": ["Ethernet4"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "server301", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.2.201", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174767}, {"namespace": "eos", "hostname": "server301", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.151", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174767}, {"namespace": "eos", "hostname": "server301", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.151", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174767}, {"namespace": "eos", "hostname": "server301", "vrf":
+    "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174767}, {"namespace": "eos", "hostname": "server302", "vrf":
+    "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server302", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.137", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server302", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.137", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server101", "vrf":
+    "default", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server101", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.57", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server101", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.57", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server302", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.3.202", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server101", "vrf":
+    "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.230", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174998}, {"namespace": "eos", "hostname": "server102", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.3.102", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174998}, {"namespace": "eos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174998}, {"namespace": "eos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.230", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174998}, {"namespace": "eos", "hostname": "firewall01", "vrf":
+    "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.189",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.189",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.127.3"], "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps":
+    [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "10.255.2.250/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.127.3"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.127.2/31", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.127.2/32", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.3"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:f000/128", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025176627}]'
 - command: route show --prefixlen="!24" --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route show filter prefixlen eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": [], "oifs":
+    ["Loopback1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174530},
+    {"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps":
+    ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174530}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174530}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "169.254.127.2/31", "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs":
+    ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.6"],
+    "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps":
+    ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["Ethernet4"], "protocol": "connected", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["Ethernet3.4"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174538}, {"namespace":
+    "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174538},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174538}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [], "oifs":
+    ["Ethernet3.3"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174538}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174540}, {"namespace":
+    "eos", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/31", "nexthopIps":
+    [], "oifs": ["Vlan4094"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174540}, {"namespace":
+    "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174540}, {"namespace": "eos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": [], "oifs": ["Loopback1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.13/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174540}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174540},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174540}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    [], "oifs": ["Loopback1"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix":
+    "169.254.1.0/31", "nexthopIps": [], "oifs": ["Vlan4094"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix":
+    "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs":
+    ["Management1"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31",
+    "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol":
+    "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174542}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174542}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps":
+    ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix":
+    "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "169.254.1.0/31", "nexthopIps": [], "oifs":
+    ["Vlan4094"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix": "192.168.0.179/32",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": [], "oifs": ["Loopback1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174543}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.32", "10.0.0.31"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.32", "10.0.0.31"], "oifs":
+    ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174543}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.32", "10.0.0.31"],
+    "oifs": ["_nexthopVrf:default", "_nexthopVrf:default"], "protocol": "ibgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174543},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30",
+    "nexthopIps": ["0.0.0.0"], "oifs": ["Ethernet3.3"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "192.168.0.179/32",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.2"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.200/32", "nexthopIps": ["169.254.254.2"], "oifs": ["Ethernet3.2"], "protocol":
+    "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"], "oifs": ["Ethernet3.3"],
+    "protocol": "ebgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"], "oifs":
+    ["Ethernet3.3"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["Ethernet3.2"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["Ethernet3.3"], "protocol": "ebgp", "source": "",
+    "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": [], "oifs": ["Ethernet3.4"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025174546},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "ibgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["Ethernet4"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174546}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["Ethernet4"], "protocol": "ebgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["Ethernet3.4"], "protocol": "ebgp", "source": "", "preference": 200,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.127.0"], "oifs": ["Ethernet4"], "protocol": "ebgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1623025174546}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    [], "oifs": ["Ethernet3"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174547}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs": ["Management1"],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Ethernet5"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Ethernet4"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1", "Ethernet2",
+    "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174547},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1", "Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174547}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["Loopback0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["Ethernet5"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"], "oifs":
+    ["Management1"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["Ethernet3", "Ethernet4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": [], "oifs": ["Ethernet3"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": [], "oifs": ["Ethernet4"],
+    "protocol": "ospf", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025174549}, {"namespace": "eos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"],
+    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace":
+    "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025174549}, {"namespace": "eos",
+    "hostname": "server301", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.151", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server301", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174767}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.137", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.1.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.57", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174997}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.230", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "server102", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025174998}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.189",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs":
+    ["eth0"], "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1623025175208}, {"namespace": "eos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.253.4/30", "nexthopIps": [""],
+    "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208}, {"namespace":
+    "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025175208},
+    {"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.127.3"], "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.255.2.250/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025176627}, {"namespace":
+    "eos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:f000/128", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["em0.0"],
+    "protocol": "access-internal", "source": "", "preference": 12, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025176627}]'
 - command: route show --prefixlen=">128" --format=json
   data-directory: tests/data/eos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen eos
 - command: route show --prefixlen="<0" --format=json
   data-directory: tests/data/eos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen eos
 - command: route show --prefixlen=">24 and !32" --format=json
   data-directory: tests/data/eos/parquet-out/
-  marks: route show filter prefixlen eos  
+  error:
+    error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
+      length'' (i.e. ''>= 24'')"}]'
+  marks: route show filter prefixlen eos
 - command: route unique --columns=prefixlen --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: route unique eos

--- a/tests/integration/sqcmds/junos-samples/route.yml
+++ b/tests/integration/sqcmds/junos-samples/route.yml
@@ -803,6 +803,33 @@ tests:
     {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname":
     "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"},
     {"hostname": "exit01"}]'
+- command: route show --prefixlen=64 --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen=">128" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen="<0" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos
+- command: route show --prefixlen=">24 and !32" --format=json
+  data-directory: tests/data/junos/parquet-out/
+  marks: route show filter prefixlen junos  
 - command: route summarize --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route summarize junos

--- a/tests/integration/sqcmds/junos-samples/route.yml
+++ b/tests/integration/sqcmds/junos-samples/route.yml
@@ -806,30 +806,2465 @@ tests:
 - command: route show --prefixlen=64 --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route show filter prefixlen junos
+  output: '[]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route show filter prefixlen junos
+  output: '[{"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source":
+    "10.255.5.72", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server201", "vrf": "default",
+    "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.5.49", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025796137}, {"namespace": "junos", "hostname": "server102", "vrf": "default",
+    "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.5.169", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server202", "vrf":
+    "default", "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.5.71", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1623025796549}, {"namespace": "junos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549}, {"namespace":
+    "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.5.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.5.40",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.254/32", "nexthopIps": [], "oifs": ["irb.10"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.122/32", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": [], "oifs": ["irb.10"], "protocol": "evpn", "source": "", "preference":
+    7, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "fe80::205:860f:fc71:ad00/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": [], "oifs": ["irb.30"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": [], "oifs":
+    ["irb.30"], "protocol": "evpn", "source": "", "preference": 7, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.255.5.184/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.255.5.184/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": [], "oifs": ["irb.20"], "protocol":
+    "evpn", "source": "", "preference": 7, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.254/32", "nexthopIps": [], "oifs": ["irb.20"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": [], "oifs": ["irb.30"],
+    "protocol": "evpn", "source": "", "preference": 7, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": [], "oifs": ["irb.30"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "fe80::205:860f:fc71:5500/128", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.121/32", "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps": [], "oifs": ["lo0.999"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": ":vxlan", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "fe80::205:860f:fc71:2700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.255.5.252/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.5.250/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:c200/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.9/32", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.3/32", "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"], "oifs": ["xe-0/0/3.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    ":vxlan", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "10.255.5.252/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.1/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps":
+    [], "oifs": [], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "multirecv", "timestamp": 1623025802688}, {"namespace": "junos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0",
+    "xe-0/0/2.0", "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["xe-0/0/2.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.255.5.118/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:c600/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:2e00/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["xe-0/0/3.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["xe-0/0/2.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0", "xe-0/0/2.0",
+    "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.255.5.117/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "internet-vrf", "prefix": "169.254.127.1/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/3.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/3.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.9/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "fe80::205:860f:fc71:7400/128", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs": ["xe-0/0/3.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.255.5.251/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs":
+    [], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action":
+    "multirecv", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "default", "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.255.5.251/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}]'
 - command: route show --prefixlen="<=24" --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route show filter prefixlen junos
+  output: '[{"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol": "", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025795928},
+    {"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.5.72",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025795928},
+    {"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.1.254"], "oifs": ["eth1"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025795928},
+    {"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["eth1"], "protocol": "kernel", "source": "172.16.1.101",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025795928},
+    {"namespace": "junos", "hostname": "server201", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth1"], "protocol": "kernel", "source": "172.16.2.201",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796137},
+    {"namespace": "junos", "hostname": "server201", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["eth1"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796137},
+    {"namespace": "junos", "hostname": "server201", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.5.49",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796137},
+    {"namespace": "junos", "hostname": "server201", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796137},
+    {"namespace": "junos", "hostname": "server102", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796138},
+    {"namespace": "junos", "hostname": "server102", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.5.169",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796138},
+    {"namespace": "junos", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["eth1"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796138},
+    {"namespace": "junos", "hostname": "server102", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["eth1"], "protocol": "kernel", "source": "172.16.3.102",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796138},
+    {"namespace": "junos", "hostname": "server202", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796342},
+    {"namespace": "junos", "hostname": "server202", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.5.71",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796342},
+    {"namespace": "junos", "hostname": "server202", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["eth1"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796342},
+    {"namespace": "junos", "hostname": "server202", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["eth1"], "protocol": "kernel", "source": "172.16.3.202",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796342},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.5.40",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [], "oifs": ["irb.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "169.254.0.0/24",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.5.1"], "oifs": ["em0.0"], "protocol": "access-internal", "source": "",
+    "preference": 12, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": ":vxlan", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": [], "oifs": ["irb.20"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.5.1"], "oifs": ["em0.0"], "protocol": "access-internal", "source": "",
+    "preference": 12, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": ":vxlan", "prefix": "10.255.5.0/24", "nexthopIps":
+    [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": ":vxlan", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs":
+    ["em0.0"], "protocol": "access-internal", "source": "", "preference": 12, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["em0.0"],
+    "protocol": "access-internal", "source": "", "preference": 12, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.127.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.1"], "oifs":
+    ["xe-0/0/0.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.127.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["xe-0/0/2.4"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["xe-0/0/2.4"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["xe-0/0/2.4"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.255.5.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": ":vxlan", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": ":vxlan", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs":
+    ["em0.0"], "protocol": "access-internal", "source": "", "preference": 12, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["em0.0"],
+    "protocol": "access-internal", "source": "", "preference": 12, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.255.5.0/24", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": ":vxlan", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": ":vxlan", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["em0.0"], "protocol":
+    "access-internal", "source": "", "preference": 12, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "evpn", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "evpn", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route show filter prefixlen junos
+  output: '[{"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source":
+    "10.255.5.72", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server201", "vrf": "default",
+    "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.5.49", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025796137}, {"namespace": "junos", "hostname": "server102", "vrf": "default",
+    "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.5.169", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server202", "vrf":
+    "default", "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.5.71", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1623025796549}, {"namespace": "junos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549}, {"namespace":
+    "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.5.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.5.40",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.254/32", "nexthopIps": [], "oifs": ["irb.10"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.122/32", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": [], "oifs": ["irb.10"], "protocol": "evpn", "source": "", "preference":
+    7, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "fe80::205:860f:fc71:ad00/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": [], "oifs": ["irb.30"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": [], "oifs":
+    ["irb.30"], "protocol": "evpn", "source": "", "preference": 7, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.255.5.184/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.255.5.184/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": [], "oifs": ["irb.20"], "protocol":
+    "evpn", "source": "", "preference": 7, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.254/32", "nexthopIps": [], "oifs": ["irb.20"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": [], "oifs": ["irb.30"],
+    "protocol": "evpn", "source": "", "preference": 7, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": [], "oifs": ["irb.30"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "fe80::205:860f:fc71:5500/128", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.121/32", "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps": [], "oifs": ["lo0.999"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": ":vxlan", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "fe80::205:860f:fc71:2700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.255.5.252/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.5.250/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:c200/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.9/32", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.3/32", "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"], "oifs": ["xe-0/0/3.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    ":vxlan", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "10.255.5.252/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.1/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps":
+    [], "oifs": [], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "multirecv", "timestamp": 1623025802688}, {"namespace": "junos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0",
+    "xe-0/0/2.0", "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["xe-0/0/2.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.255.5.118/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:c600/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:2e00/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["xe-0/0/3.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["xe-0/0/2.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0", "xe-0/0/2.0",
+    "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.255.5.117/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "internet-vrf", "prefix": "169.254.127.1/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/3.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/3.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.9/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "fe80::205:860f:fc71:7400/128", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs": ["xe-0/0/3.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.255.5.251/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs":
+    [], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action":
+    "multirecv", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "default", "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.255.5.251/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}]'
 - command: route show --prefixlen=">=24" --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route show filter prefixlen junos
+  output: '[{"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source":
+    "10.255.5.72", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server101", "vrf": "default",
+    "prefix": "10.255.5.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
+    "source": "10.255.5.72", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server101", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["eth1"], "protocol": "kernel",
+    "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025795928}, {"namespace": "junos", "hostname": "server201", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["eth1"], "protocol":
+    "kernel", "source": "172.16.2.201", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796137}, {"namespace": "junos", "hostname": "server201", "vrf":
+    "default", "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.5.49", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796137}, {"namespace": "junos", "hostname": "server201", "vrf":
+    "default", "prefix": "10.255.5.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.5.49", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796137}, {"namespace": "junos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.5.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.5.169", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.5.169", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server102", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["eth1"], "protocol":
+    "kernel", "source": "172.16.3.102", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server202", "vrf":
+    "default", "prefix": "10.255.5.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.5.71", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "server202", "vrf":
+    "default", "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.5.71", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "server202", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["eth1"], "protocol":
+    "kernel", "source": "172.16.3.202", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1623025796549}, {"namespace": "junos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549}, {"namespace":
+    "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.5.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.5.40",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.5.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.5.40",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.254/32", "nexthopIps": [], "oifs": ["irb.10"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.122/32", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [], "oifs": ["irb.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": [], "oifs": ["irb.10"], "protocol": "evpn", "source": "", "preference":
+    7, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "fe80::205:860f:fc71:ad00/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": [], "oifs": ["irb.30"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "169.254.0.0/24", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": [], "oifs": ["irb.30"],
+    "protocol": "evpn", "source": "", "preference": 7, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.255.5.184/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.0.0.11/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.255.5.0/24",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": ":vxlan", "prefix": "10.255.5.184/32", "nexthopIps":
+    [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    [], "oifs": ["irb.20"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": [], "oifs":
+    ["irb.20"], "protocol": "evpn", "source": "", "preference": 7, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.254/32", "nexthopIps": [], "oifs": ["irb.20"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps":
+    [], "oifs": ["irb.30"], "protocol": "evpn", "source": "", "preference": 7, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": [], "oifs":
+    ["irb.30"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:5500/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.122/32", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.121/32", "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps": [], "oifs": ["lo0.999"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan",
+    "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan",
+    "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "default", "prefix": "fe80::205:860f:fc71:2700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.255.5.252/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.5.250/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["xe-0/0/0.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["xe-0/0/0.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["xe-0/0/0.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:c200/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["xe-0/0/2.4"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
+    ["xe-0/0/2.4"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["xe-0/0/2.4"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.9/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.3/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/3.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/3.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.255.5.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    ":vxlan", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "10.255.5.252/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.1/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.255.5.0/24", "nexthopIps":
+    [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802688}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0", "xe-0/0/2.0",
+    "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs":
+    ["xe-0/0/2.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.255.5.118/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802688}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:c600/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1623025802890},
+    {"namespace": "junos", "hostname": "spine01", "vrf": "default", "prefix": "fe80::205:860f:fc71:2e00/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802890}, {"namespace":
+    "junos", "hostname": "spine01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1623025802890}, {"namespace": "junos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802890}, {"namespace":
+    "junos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["xe-0/0/2.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802890}, {"namespace":
+    "junos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0",
+    "xe-0/0/2.0", "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.255.5.117/32", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.127.1/32", "nexthopIps": [], "oifs": ["xe-0/0/3.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["xe-0/0/3.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.255.5.0/24", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.9/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/2.4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "fe80::205:860f:fc71:7400/128", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs": ["xe-0/0/3.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "169.254.0.0/24",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.255.5.251/32", "nexthopIps":
+    [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": ":vxlan", "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": ":vxlan", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.255.5.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "evpn", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "evpn", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.12"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.255.5.251/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.122/32", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}]'
 - command: route show --prefixlen="!24" --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route show filter prefixlen junos
+  output: '[{"namespace": "junos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source":
+    "10.255.5.72", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server101", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server101", "vrf": "default",
+    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.1.254"], "oifs": ["eth1"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025795928}, {"namespace": "junos", "hostname": "server201", "vrf": "default",
+    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.2.254"], "oifs": ["eth1"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025796137}, {"namespace": "junos", "hostname": "server201", "vrf": "default",
+    "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.5.49", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025796137}, {"namespace": "junos", "hostname": "server201", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025796137}, {"namespace": "junos", "hostname": "server102", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1623025796138}, {"namespace": "junos", "hostname": "server102", "vrf": "default",
+    "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.5.169", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server102", "vrf":
+    "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["eth1"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025796138}, {"namespace": "junos", "hostname": "server202",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs":
+    ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "server202",
+    "vrf": "default", "prefix": "10.255.5.1/32", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "dhcp", "source": "10.255.5.71", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "server202",
+    "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["eth1"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025796342}, {"namespace": "junos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1623025796549}, {"namespace": "junos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549}, {"namespace":
+    "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.5.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.5.40",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.5.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1623025796549},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.254/32", "nexthopIps": [], "oifs": ["irb.10"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.122/32", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": [], "oifs": ["irb.10"], "protocol": "evpn", "source": "", "preference":
+    7, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "fe80::205:860f:fc71:ad00/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": [], "oifs": ["irb.30"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.102/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.5.1"], "oifs": ["em0.0"], "protocol": "access-internal", "source": "",
+    "preference": 12, "ipvers": 4, "action": "forward", "timestamp": 1623025801173},
+    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": [], "oifs": ["irb.30"], "protocol": "evpn", "source": "", "preference":
+    7, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025801173}, {"namespace":
+    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.255.5.184/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": ":vxlan",
+    "prefix": "10.0.0.11/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": ":vxlan",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": ":vxlan", "prefix": "10.255.5.184/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01",
+    "vrf": ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["10.0.0.31"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": [], "oifs": ["irb.20"], "protocol": "evpn", "source": "", "preference":
+    7, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32",
+    "nexthopIps": [], "oifs": ["irb.20"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": [], "oifs": ["irb.30"], "protocol":
+    "evpn", "source": "", "preference": 7, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.254/32", "nexthopIps": [], "oifs": ["irb.30"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:5500/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.121/32", "nexthopIps": ["10.0.0.31"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps": [], "oifs": ["lo0.999"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs":
+    ["em0.0"], "protocol": "access-internal", "source": "", "preference": 12, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs":
+    [], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action":
+    "multirecv", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": ":vxlan", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "leaf02", "vrf": ":vxlan", "prefix": "10.0.0.12/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "leaf02", "vrf": ":vxlan", "prefix": "10.255.5.185/32", "nexthopIps": [], "oifs":
+    ["em0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02",
+    "vrf": ":vxlan", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.5.1"], "oifs": ["em0.0"], "protocol": "access-internal",
+    "source": "", "preference": 12, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:2700/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.255.5.252/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["em0.0"], "protocol":
+    "access-internal", "source": "", "preference": 12, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.5.250/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "dcedge01", "vrf": "default", "prefix": "fe80::205:860f:fc71:c200/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps":
+    [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.9/32", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.3/32", "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"], "oifs": ["xe-0/0/3.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1623025802263}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf":
+    ":vxlan", "prefix": "10.0.0.32/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "10.255.5.252/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025802263}, {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.0/30",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "exit02", "vrf": ":vxlan", "prefix": "169.254.253.1/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/2.3"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.127.2"], "oifs": ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025802263}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps":
+    [], "oifs": [], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "multirecv", "timestamp": 1623025802688}, {"namespace": "junos",
+    "hostname": "spine02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.5.1"], "oifs": ["em0.0"], "protocol": "access-internal", "source": "",
+    "preference": 12, "ipvers": 4, "action": "forward", "timestamp": 1623025802688},
+    {"namespace": "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688},
+    {"namespace": "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688},
+    {"namespace": "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0", "xe-0/0/2.0", "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["xe-0/0/2.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.255.5.118/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802688}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1623025802688}, {"namespace": "junos", "hostname": "spine02",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:c600/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:2e00/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["xe-0/0/3.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["xe-0/0/2.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0", "xe-0/0/2.0",
+    "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025802890}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"],
+    "oifs": ["em0.0"], "protocol": "access-internal", "source": "", "preference":
+    12, "ipvers": 4, "action": "forward", "timestamp": 1623025802890}, {"namespace":
+    "junos", "hostname": "spine01", "vrf": "default", "prefix": "10.255.5.117/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025802890}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.1/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": [], "oifs": ["xe-0/0/3.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30",
+    "nexthopIps": [], "oifs": ["xe-0/0/2.3"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "169.254.127.2/31", "nexthopIps": ["169.254.127.0"], "oifs": ["xe-0/0/3.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.254.8/30", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.254.9/32", "nexthopIps": [], "oifs": ["xe-0/0/2.4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:7400/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs": ["xe-0/0/3.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["10.0.0.32"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["xe-0/0/3.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.121/32", "nexthopIps":
+    [], "oifs": ["lo0.999"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.102/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.101/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan",
+    "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.255.5.251/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": ":vxlan", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs":
+    [], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action":
+    "multirecv", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "default", "prefix": "169.254.254.1/32", "nexthopIps": [], "oifs": ["xe-0/0/2.2"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.254.0/30", "nexthopIps": [], "oifs": ["xe-0/0/2.2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "evpn", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.5.1"], "oifs": ["em0.0"],
+    "protocol": "access-internal", "source": "", "preference": 12, "ipvers": 4, "action":
+    "forward", "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": [], "oifs": ["xe-0/0/2.3"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1623025803098}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "evpn", "source": "", "preference": 170,
+    "ipvers": 4, "action": "forward", "timestamp": 1623025803098}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "prefix": "10.255.5.251/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1623025803098}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.122/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["_nexthopVrf:default"], "protocol": "evpn", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1623025803098}]'
 - command: route show --prefixlen=">128" --format=json
   data-directory: tests/data/junos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen junos
 - command: route show --prefixlen="<0" --format=json
   data-directory: tests/data/junos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen junos
 - command: route show --prefixlen=">24 and !32" --format=json
   data-directory: tests/data/junos/parquet-out/
-  marks: route show filter prefixlen junos  
+  error:
+    error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
+      length'' (i.e. ''>= 24'')"}]'
+  marks: route show filter prefixlen junos
 - command: route summarize --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: route summarize junos

--- a/tests/integration/sqcmds/mixed-samples/route.yml
+++ b/tests/integration/sqcmds/mixed-samples/route.yml
@@ -1,5 +1,32 @@
 description: 'Testing verbs for route: show summarize unique lpm'
 tests:
+- command: route show --prefixlen=64 --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen=">128" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen="<0" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed
+- command: route show --prefixlen=">24 and !32" --format=json
+  data-directory: tests/data/mixed/parquet-out/
+  marks: route show filter prefixlen mixed  
 - command: route lpm --address='11.11.11.11' --columns='hostname nexthopIps' --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route lpm mixed

--- a/tests/integration/sqcmds/mixed-samples/route.yml
+++ b/tests/integration/sqcmds/mixed-samples/route.yml
@@ -3,30 +3,2590 @@ tests:
 - command: route show --prefixlen=64 --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route show filter prefixlen mixed
+  output: '[]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route show filter prefixlen mixed
+  output: '[{"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.6.0/30", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.5.1",
+    "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.2.5.0/30", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed",
+    "hostname": "leaf5-eos", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.2/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "vrf": "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.4.1"], "oifs":
+    ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.4.1",
+    "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs":
+    ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "172.29.151.6/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "11.11.11.11/32",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "22.22.22.22/32",
+    "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:8700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "3.3.3.3/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.3.1",
+    "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.2/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "172.29.151.5/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:1300/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.3.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.2.6.0/30", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "11.11.11.11/32", "nexthopIps": ["11.11.11.11", "11.11.11.11"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.1.1.2",
+    "10.1.2.2", "10.1.3.2", "10.1.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.5.2"],
+    "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "3.3.3.3/32",
+    "nexthopIps": ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "4.4.4.4/32", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "management", "prefix": "172.29.151.1/32", "nexthopIps": ["172.29.151.1"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps":
+    ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.1.1.2"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "6.6.6.6/32", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["Ethernet1/2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.2.1/32", "nexthopIps": ["10.1.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.1.1/32", "nexthopIps": ["10.1.1.1"],
+    "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.3.1/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["Ethernet1/3"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.2.0/30",
+    "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["Ethernet1/1"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.6.1/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1/6"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.6.1"], "oifs":
+    ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.1/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.1/32", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.0/30",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "2.2.2.2/32", "nexthopIps": ["10.2.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["22.22.22.22", "22.22.22.22"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.2.1.2",
+    "10.2.2.2", "10.2.3.2", "10.2.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.1/32", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.1/32", "nexthopIps":
+    ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.2.4.1/32", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.3.1/32", "nexthopIps": ["10.2.3.1"], "oifs":
+    ["Ethernet1/3"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.4.2"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "5.5.5.5/32", "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.1.1.0/30", "nexthopIps": ["10.2.1.2"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.2.2.2"], "oifs":
+    ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.2.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.5.0/30",
+    "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.1.6.0/30", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["Ethernet1/1"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.2.1/32", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.2.4.2"],
+    "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.1.1/32", "nexthopIps":
+    ["10.2.1.1"], "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "management", "prefix": "172.29.151.2/32",
+    "nexthopIps": ["172.29.151.2"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "172.29.151.4/32",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/7"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "1.1.1.1/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "2.2.2.2/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.6.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170}, {"namespace":
+    "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "1.1.1.1/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "2.2.2.2/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.1.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "172.29.151.3/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.2.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}]'
 - command: route show --prefixlen="<=24" --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route show filter prefixlen mixed
+  output: '[{"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default", "prefix":
+    "172.29.151.0/24", "nexthopIps": [], "oifs": ["Management1"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["Management1"],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["Management1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
+    ["Management1"], "protocol": "static", "source": "", "preference": 1, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "vrf": "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["em0.0"],
+    "protocol": "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["em0.0"],
+    "protocol": "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "management",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "management",
+    "prefix": "172.29.151.0/24", "nexthopIps": ["172.29.151.1"], "oifs": ["mgmt0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
+    ["_nexthopVrf:management"], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "management", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["_nexthopVrf:management"],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "management", "prefix": "172.29.151.0/24", "nexthopIps": ["172.29.151.2"],
+    "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "172.29.151.0/24", "nexthopIps": [],
+    "oifs": ["GigabitEthernet0/7"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170}, {"namespace":
+    "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "172.29.151.0/24",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/7"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1627395444959}]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route show filter prefixlen mixed
+  output: '[{"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.6.0/30", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.5.1",
+    "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.2.5.0/30", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed",
+    "hostname": "leaf5-eos", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.2/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "vrf": "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.4.1"], "oifs":
+    ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.4.1",
+    "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs":
+    ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "172.29.151.6/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "11.11.11.11/32",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "22.22.22.22/32",
+    "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:8700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "3.3.3.3/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.3.1",
+    "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.2/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "172.29.151.5/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:1300/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.3.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.2.6.0/30", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "11.11.11.11/32", "nexthopIps": ["11.11.11.11", "11.11.11.11"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.1.1.2",
+    "10.1.2.2", "10.1.3.2", "10.1.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.5.2"],
+    "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "3.3.3.3/32",
+    "nexthopIps": ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "4.4.4.4/32", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "management", "prefix": "172.29.151.1/32", "nexthopIps": ["172.29.151.1"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps":
+    ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.1.1.2"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "6.6.6.6/32", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["Ethernet1/2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.2.1/32", "nexthopIps": ["10.1.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.1.1/32", "nexthopIps": ["10.1.1.1"],
+    "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.3.1/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["Ethernet1/3"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.2.0/30",
+    "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["Ethernet1/1"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.6.1/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1/6"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.6.1"], "oifs":
+    ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.1/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.1/32", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.0/30",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "2.2.2.2/32", "nexthopIps": ["10.2.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["22.22.22.22", "22.22.22.22"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.2.1.2",
+    "10.2.2.2", "10.2.3.2", "10.2.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.1/32", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.1/32", "nexthopIps":
+    ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.2.4.1/32", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.3.1/32", "nexthopIps": ["10.2.3.1"], "oifs":
+    ["Ethernet1/3"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.4.2"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "5.5.5.5/32", "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.1.1.0/30", "nexthopIps": ["10.2.1.2"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.2.2.2"], "oifs":
+    ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.2.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.5.0/30",
+    "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.1.6.0/30", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["Ethernet1/1"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.2.1/32", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.2.4.2"],
+    "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.1.1/32", "nexthopIps":
+    ["10.2.1.1"], "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "management", "prefix": "172.29.151.2/32",
+    "nexthopIps": ["172.29.151.2"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "172.29.151.4/32",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/7"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "1.1.1.1/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "2.2.2.2/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.6.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170}, {"namespace":
+    "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "1.1.1.1/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "2.2.2.2/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.1.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "172.29.151.3/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.2.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}]'
 - command: route show --prefixlen=">=24" --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route show filter prefixlen mixed
+  output: '[{"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["Management1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos",
+    "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.6.1"], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.6.1",
+    "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437575},
+    {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.6.0/30", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.5.1",
+    "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.2.5.0/30", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf":
+    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["Management1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos",
+    "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.5.1"], "oifs":
+    ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.5.1",
+    "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "2.2.2.2/32",
+    "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet1"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.2/32", "nexthopIps": [], "oifs":
+    ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": [], "oifs":
+    ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "vrf": "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.4.1"], "oifs":
+    ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.4.1",
+    "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs":
+    ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "172.29.151.6/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "11.11.11.11/32",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "22.22.22.22/32",
+    "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "172.29.151.0/24",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:8700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "3.3.3.3/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.3.1",
+    "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.2/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "172.29.151.5/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:1300/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "172.29.151.0/24",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.3.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.2.6.0/30", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "11.11.11.11/32", "nexthopIps": ["11.11.11.11", "11.11.11.11"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.1.1.2",
+    "10.1.2.2", "10.1.3.2", "10.1.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "management", "prefix": "172.29.151.0/24", "nexthopIps":
+    ["172.29.151.1"], "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "2.2.2.2/32", "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "management", "prefix": "172.29.151.1/32", "nexthopIps": ["172.29.151.1"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps":
+    ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.1.1.2"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "6.6.6.6/32", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["Ethernet1/2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.2.1/32", "nexthopIps": ["10.1.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.1.1/32", "nexthopIps": ["10.1.1.1"],
+    "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.3.1/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["Ethernet1/3"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.2.0/30",
+    "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["Ethernet1/1"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.6.1/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1/6"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.6.1"], "oifs":
+    ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.1/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.1/32", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.0/30",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "2.2.2.2/32", "nexthopIps": ["10.2.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["22.22.22.22", "22.22.22.22"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.2.1.2",
+    "10.2.2.2", "10.2.3.2", "10.2.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.1/32", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.1/32", "nexthopIps":
+    ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.2.4.1/32", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.3.1/32", "nexthopIps": ["10.2.3.1"], "oifs":
+    ["Ethernet1/3"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.4.2"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "5.5.5.5/32", "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.1.1.0/30", "nexthopIps": ["10.2.1.2"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.2.2.2"], "oifs":
+    ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.2.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.5.0/30",
+    "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.1.6.0/30", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["Ethernet1/1"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.2.1/32", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.2.4.2"],
+    "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.1.1/32", "nexthopIps":
+    ["10.2.1.1"], "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "management", "prefix": "172.29.151.2/32",
+    "nexthopIps": ["172.29.151.2"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "management", "prefix":
+    "172.29.151.0/24", "nexthopIps": ["172.29.151.2"], "oifs": ["mgmt0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "172.29.151.4/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "2.2.2.2/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "3.3.3.3/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "4.4.4.4/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.1.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.6.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.2.2.2/32", "nexthopIps": [], "oifs":
+    ["GigabitEthernet0/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": [], "oifs":
+    ["GigabitEthernet0/1"], "protocol": "connected", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.2.1.0/30", "nexthopIps":
+    ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.2.4.0/30",
+    "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default",
+    "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "1.1.1.1/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "2.2.2.2/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "3.3.3.3/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "4.4.4.4/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/0"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "10.1.1.2/32",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "10.1.2.0/30",
+    "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default",
+    "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "172.29.151.3/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.2.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.1.1"], "oifs":
+    ["GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395444959}]'
 - command: route show --prefixlen="!24" --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route show filter prefixlen mixed
+  output: '[{"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.1.6.0/30", "nexthopIps": [], "oifs": ["Ethernet1"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs":
+    ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf6-eos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps":
+    ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437575}, {"namespace": "mixed", "hostname": "leaf6-eos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": [], "oifs":
+    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed", "hostname":
+    "leaf6-eos", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437575}, {"namespace": "mixed",
+    "hostname": "leaf5-eos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps":
+    ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620}, {"namespace":
+    "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps":
+    ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps": [], "oifs":
+    ["Ethernet2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.5.1"],
+    "oifs": ["Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed",
+    "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps":
+    ["10.1.5.1"], "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620}, {"namespace":
+    "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps":
+    [], "oifs": ["Loopback0"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395437620}, {"namespace":
+    "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps":
+    ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395437620}, {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.5.1", "10.2.5.1"], "oifs": ["Ethernet1",
+    "Ethernet2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395437620}, {"namespace": "mixed", "hostname":
+    "leaf5-eos", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.5.1",
+    "10.2.5.1"], "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.1.5.0/30",
+    "nexthopIps": [], "oifs": ["Ethernet1"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.2.6.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf5-eos", "vrf": "default", "prefix": "10.2.3.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395437620},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.6.0/30",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.5.0/30",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.2/32",
+    "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps":
+    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.4.1",
+    "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "5.5.5.5/32",
+    "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs":
+    ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "172.29.151.6/32",
+    "nexthopIps": [], "oifs": ["em0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.4.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "11.11.11.11/32",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "22.22.22.22/32",
+    "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426},
+    {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "224.0.0.5/32",
+    "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:8700/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438426}, {"namespace":
+    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438426}, {"namespace": "mixed",
+    "hostname": "leaf4-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438426}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": ["em0.0"], "protocol": "static", "source": "", "preference": 5, "ipvers":
+    4, "action": "forward", "timestamp": 1627395438426}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
+    ["em0.0"], "protocol": "static", "source": "", "preference": 5, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps":
+    ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf",
+    "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "3.3.3.3/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0",
+    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395438536}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.3.1",
+    "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.3.2/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["xe-0/0/0.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf":
+    "default", "prefix": "172.29.151.5/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1627395438536}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438536},
+    {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:1300/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
+    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
+    6, "action": "multirecv", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.3.2/32", "nexthopIps":
+    [], "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1627395438536}, {"namespace": "mixed",
+    "hostname": "leaf3-qfx", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["xe-0/0/0.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.2.6.0/30", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "11.11.11.11/32", "nexthopIps": ["11.11.11.11", "11.11.11.11"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.1.1.2",
+    "10.1.2.2", "10.1.3.2", "10.1.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.5.2"],
+    "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["172.29.151.254"], "oifs": ["_nexthopVrf:management"], "protocol": "static",
+    "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "management", "prefix": "172.29.151.1/32", "nexthopIps": ["172.29.151.1"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps":
+    ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.1.0/30",
+    "nexthopIps": ["10.1.1.2"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "6.6.6.6/32", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["Ethernet1/2"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.2.1/32", "nexthopIps": ["10.1.2.1"], "oifs":
+    ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.1.1/32", "nexthopIps": ["10.1.1.1"],
+    "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.3.1/32", "nexthopIps":
+    ["10.1.3.1"], "oifs": ["Ethernet1/3"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.2.2.0/30",
+    "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.1.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["Ethernet1/1"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "10.1.6.1/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1/6"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
+    "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.6.1"], "oifs":
+    ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.1/32", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace": "mixed",
+    "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.1/32", "nexthopIps":
+    ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "10.1.4.0/30",
+    "nexthopIps": ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "2.2.2.2/32", "nexthopIps": ["10.2.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "management",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "22.22.22.22/32", "nexthopIps": ["22.22.22.22", "22.22.22.22"], "oifs":
+    ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.2.1.2",
+    "10.2.2.2", "10.2.3.2", "10.2.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.1/32", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.1/32", "nexthopIps":
+    ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.5.0/30",
+    "nexthopIps": ["10.2.5.1"], "oifs": ["Ethernet1/5"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.2.4.1/32", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.3.1/32", "nexthopIps": ["10.2.3.1"], "oifs":
+    ["Ethernet1/3"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.4.2"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "5.5.5.5/32", "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.1.1.0/30", "nexthopIps": ["10.2.1.2"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.2.2.2"], "oifs":
+    ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.2.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed",
+    "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.2.3.2"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.1.5.0/30",
+    "nexthopIps": ["10.2.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.1.6.0/30", "nexthopIps": ["10.2.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["Ethernet1/1"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
+    ["_nexthopVrf:management"], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "10.2.2.0/30",
+    "nexthopIps": ["10.2.2.1"], "oifs": ["Ethernet1/2"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "10.2.2.1/32", "nexthopIps": ["10.2.2.1"], "oifs": ["Ethernet1/2"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default",
+    "prefix": "10.1.4.0/30", "nexthopIps": ["10.2.4.2"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "default", "prefix": "10.2.1.1/32", "nexthopIps": ["10.2.1.1"], "oifs":
+    ["Ethernet1/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "management", "prefix": "172.29.151.2/32", "nexthopIps":
+    ["172.29.151.2"], "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395440281}, {"namespace":
+    "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "172.29.151.4/32",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/7"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "1.1.1.1/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "2.2.2.2/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.1.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"], "protocol":
+    "connected", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170},
+    {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.6.0/30",
+    "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
+    "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
+    ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170}, {"namespace":
+    "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps":
+    ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "1.1.1.1/32",
+    "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "2.2.2.2/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "4.4.4.4/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs":
+    ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source": "",
+    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "6.6.6.6/32",
+    "nexthopIps": ["10.2.1.1", "10.1.1.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.1.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "172.29.151.3/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.1.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios",
+    "vrf": "default", "prefix": "10.2.1.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.1.1"], "oifs": ["GigabitEthernet0/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": [],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1627395444959}]'
 - command: route show --prefixlen=">128" --format=json
   data-directory: tests/data/mixed/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen mixed
 - command: route show --prefixlen="<0" --format=json
   data-directory: tests/data/mixed/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen mixed
 - command: route show --prefixlen=">24 and !32" --format=json
   data-directory: tests/data/mixed/parquet-out/
-  marks: route show filter prefixlen mixed  
+  error:
+    error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
+      length'' (i.e. ''>= 24'')"}]'
+  marks: route show filter prefixlen mixed
 - command: route lpm --address='11.11.11.11' --columns='hostname nexthopIps' --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: route lpm mixed

--- a/tests/integration/sqcmds/nxos-samples/route.yml
+++ b/tests/integration/sqcmds/nxos-samples/route.yml
@@ -1219,29 +1219,3833 @@ tests:
 - command: route show --prefixlen=64 --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route show filter prefixlen nxos
+  output: '[]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route show filter prefixlen nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source":
+    "10.255.2.204", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.39", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server301", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.140", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256093}, {"namespace": "nxos", "hostname": "firewall01", "vrf":
+    "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
+    "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109}, {"namespace":
+    "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.249",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["eth2.4"],
+    "protocol": "kernel", "source": "169.254.253.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.114", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "management", "prefix": "10.255.2.120/32",
+    "nexthopIps": ["10.255.2.120"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4",
+    "Ethernet1/5", "Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22", "10.0.0.22"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257123}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.134", "10.0.0.134"], "oifs": ["Lo1", "Lo1"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.203/32",
+    "nexthopIps": ["10.0.0.203", "10.0.0.203"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["Vlan20"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "management", "prefix": "10.255.2.190/32", "nexthopIps": ["10.255.2.190"], "oifs":
+    ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13", "10.0.0.13"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["172.16.2.201"], "oifs": ["Vlan20"],
+    "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"],
+    "oifs": ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12",
+    "10.0.0.12"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "management",
+    "prefix": "10.255.2.188/32", "nexthopIps": ["10.255.2.188"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.202", "10.0.0.202"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.6"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.221", "10.0.0.221"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.1/32",
+    "nexthopIps": ["169.254.254.1"], "oifs": ["Ethernet1/3.2"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "10.255.2.253/32", "nexthopIps": ["10.255.2.253"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.1"], "oifs":
+    ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": ["169.254.254.5"],
+    "oifs": ["Ethernet1/3.3"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.5"], "oifs":
+    ["Ethernet1/3.3"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.1"],
+    "oifs": ["Ethernet1/4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.1/32", "nexthopIps":
+    ["169.254.127.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.254.9/32", "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.31"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11",
+    "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2", "Ethernet1/3", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21", "10.0.0.21"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"],
+    "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "management",
+    "prefix": "10.255.2.119/32", "nexthopIps": ["10.255.2.119"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.11"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14", "10.0.0.14"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["Vlan20"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["172.16.2.201"], "oifs": ["Vlan20"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "management", "prefix": "10.255.2.191/32",
+    "nexthopIps": ["10.255.2.191"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.204", "10.0.0.204"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:3c00/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "10.255.2.250/32", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.127.3"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11", "10.0.0.11"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "management", "prefix": "10.255.2.189/32", "nexthopIps": ["10.255.2.189"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"], "oifs":
+    ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.201", "10.0.0.201"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.222", "10.0.0.222"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32", "10.0.0.32"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.3"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "169.254.127.3/32", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30", "nexthopIps": ["169.254.253.9"],
+    "oifs": ["Ethernet1/3.4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.9/32", "nexthopIps":
+    ["169.254.253.9"], "oifs": ["Ethernet1/3.4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.1"], "oifs":
+    ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": ["169.254.253.1"],
+    "oifs": ["Ethernet1/3.2"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "management", "prefix": "10.255.2.254/32", "nexthopIps":
+    ["10.255.2.254"], "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.5/32",
+    "nexthopIps": ["169.254.253.5"], "oifs": ["Ethernet1/3.3"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.5"], "oifs": ["Ethernet1/3.3"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}]'
 - command: route show --prefixlen="<=24" --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route show filter prefixlen nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source":
+    "10.255.2.204", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server101", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server101", "vrf": "default",
+    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server101", "vrf":
+    "default", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.39", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf":
+    "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"],
+    "protocol": "kernel", "source": "172.16.3.102", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1619275256085}, {"namespace": "nxos", "hostname":
+    "server102", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1619275256085}, {"namespace": "nxos", "hostname":
+    "server301", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.140", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093}, {"namespace":
+    "nxos", "hostname": "server301", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093},
+    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.201",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093},
+    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "10.255.2.249", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5",
+    "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109}, {"namespace":
+    "nxos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "server302", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.114",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "management", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.255.2.120"], "oifs": ["mgmt0"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "management", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": [], "protocol": "static", "source": "",
+    "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["172.16.2.254"], "oifs": ["Vlan20"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "management", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.255.2.190"], "oifs": ["mgmt0"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "management", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": [], "protocol": "static", "source": "",
+    "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "management", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": [], "protocol": "static", "source": "",
+    "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["172.16.1.254"], "oifs": ["Vlan10"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "management", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.255.2.188"], "oifs": ["mgmt0"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.254.6"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.254.6"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [], "protocol": "static",
+    "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.253"], "oifs": ["mgmt0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.254.6"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs": ["Null0"], "protocol":
+    "bgp", "source": "", "preference": 220, "ipvers": 4, "action": "drop", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs": ["Null0"], "protocol": "bgp",
+    "source": "", "preference": 220, "ipvers": 4, "action": "drop", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [], "oifs": ["Null0"], "protocol": "bgp", "source": "", "preference":
+    220, "ipvers": 4, "action": "drop", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.127.0"], "oifs": [], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": [], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "management", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.255.2.119"], "oifs": ["mgmt0"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257467},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["Vlan20"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.191"], "oifs":
+    ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04",
+    "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs":
+    [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs":
+    ["em0.0"], "protocol": "access-internal", "source": "", "preference": 12, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.189"], "oifs":
+    ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["Vlan10"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.10"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.253.10"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.253.10"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [], "oifs": ["Null0"], "protocol": "bgp", "source": "", "preference":
+    220, "ipvers": 4, "action": "drop", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    [], "oifs": ["Null0"], "protocol": "bgp", "source": "", "preference": 220, "ipvers":
+    4, "action": "drop", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs":
+    [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.254"],
+    "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs": ["Null0"],
+    "protocol": "bgp", "source": "", "preference": 220, "ipvers": 4, "action": "drop",
+    "timestamp": 1619275257722}]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route show filter prefixlen nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source":
+    "10.255.2.204", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.39", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server301", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.140", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256093}, {"namespace": "nxos", "hostname": "firewall01", "vrf":
+    "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
+    "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109}, {"namespace":
+    "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.249",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["eth2.4"],
+    "protocol": "kernel", "source": "169.254.253.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.114", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "management", "prefix": "10.255.2.120/32",
+    "nexthopIps": ["10.255.2.120"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4",
+    "Ethernet1/5", "Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22", "10.0.0.22"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257123}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.134", "10.0.0.134"], "oifs": ["Lo1", "Lo1"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.203/32",
+    "nexthopIps": ["10.0.0.203", "10.0.0.203"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["Vlan20"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "management", "prefix": "10.255.2.190/32", "nexthopIps": ["10.255.2.190"], "oifs":
+    ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13", "10.0.0.13"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["172.16.2.201"], "oifs": ["Vlan20"],
+    "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"],
+    "oifs": ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12",
+    "10.0.0.12"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "management",
+    "prefix": "10.255.2.188/32", "nexthopIps": ["10.255.2.188"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.202", "10.0.0.202"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.6"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.221", "10.0.0.221"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.1/32",
+    "nexthopIps": ["169.254.254.1"], "oifs": ["Ethernet1/3.2"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "10.255.2.253/32", "nexthopIps": ["10.255.2.253"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.1"], "oifs":
+    ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": ["169.254.254.5"],
+    "oifs": ["Ethernet1/3.3"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.5"], "oifs":
+    ["Ethernet1/3.3"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.1"],
+    "oifs": ["Ethernet1/4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.1/32", "nexthopIps":
+    ["169.254.127.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.254.9/32", "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.31"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11",
+    "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2", "Ethernet1/3", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21", "10.0.0.21"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"],
+    "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "management",
+    "prefix": "10.255.2.119/32", "nexthopIps": ["10.255.2.119"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.11"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14", "10.0.0.14"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["Vlan20"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["172.16.2.201"], "oifs": ["Vlan20"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "management", "prefix": "10.255.2.191/32",
+    "nexthopIps": ["10.255.2.191"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.204", "10.0.0.204"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:3c00/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "10.255.2.250/32", "nexthopIps": [], "oifs": ["em0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.127.3"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs":
+    ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11", "10.0.0.11"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "management", "prefix": "10.255.2.189/32", "nexthopIps": ["10.255.2.189"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"], "oifs":
+    ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.201", "10.0.0.201"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.222", "10.0.0.222"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32", "10.0.0.32"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.3"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "169.254.127.3/32", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30", "nexthopIps": ["169.254.253.9"],
+    "oifs": ["Ethernet1/3.4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.9/32", "nexthopIps":
+    ["169.254.253.9"], "oifs": ["Ethernet1/3.4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.1"], "oifs":
+    ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": ["169.254.253.1"],
+    "oifs": ["Ethernet1/3.2"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "management", "prefix": "10.255.2.254/32", "nexthopIps":
+    ["10.255.2.254"], "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.5/32",
+    "nexthopIps": ["169.254.253.5"], "oifs": ["Ethernet1/3.3"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.5"], "oifs": ["Ethernet1/3.3"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}]'
 - command: route show --prefixlen=">=24" --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route show filter prefixlen nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source":
+    "10.255.2.204", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275256085}, {"namespace": "nxos", "hostname": "server101", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.204", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server101", "vrf":
+    "default", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.39", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.39", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.3.102", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server301", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.140", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256093}, {"namespace": "nxos", "hostname": "server301", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.140", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256093}, {"namespace": "nxos", "hostname": "server301", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.2.201", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275256093}, {"namespace": "nxos", "hostname": "firewall01", "vrf":
+    "default", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["eth1.4"],
+    "protocol": "kernel", "source": "169.254.254.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
+    "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109}, {"namespace":
+    "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "dhcp", "source": "10.255.2.249", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "10.255.2.249", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5",
+    "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["eth2.3", "eth1.3"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": ["eth2.3", "eth1.3"], "protocol": "bgp", "source": "10.0.0.200", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109}, {"namespace":
+    "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["eth2.4"],
+    "protocol": "kernel", "source": "169.254.253.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "server302", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": [""],
+    "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204}, {"namespace":
+    "nxos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.114",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.114",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "management", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.255.2.120"], "oifs": ["mgmt0"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "management", "prefix": "10.255.2.120/32",
+    "nexthopIps": ["10.255.2.120"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4",
+    "Ethernet1/5", "Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22", "10.0.0.22"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257123}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.134", "10.0.0.134"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.203", "10.0.0.203"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["172.16.2.254"], "oifs": ["Vlan20"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.254/32", "nexthopIps": ["172.16.2.254"], "oifs":
+    ["Vlan20"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "management", "prefix": "10.255.2.190/32", "nexthopIps": ["10.255.2.190"], "oifs":
+    ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.190"],
+    "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13", "10.0.0.13"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["172.16.2.201"], "oifs":
+    ["Vlan20"], "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"],
+    "oifs": ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["Vlan10"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.188"], "oifs":
+    ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12", "10.0.0.12"], "oifs": ["Lo0", "Lo0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "management", "prefix": "10.255.2.188/32", "nexthopIps": ["10.255.2.188"], "oifs":
+    ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.202", "10.0.0.202"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.254.6"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.254.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.221", "10.0.0.221"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.1/32",
+    "nexthopIps": ["169.254.254.1"], "oifs": ["Ethernet1/3.2"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.253"], "oifs": ["mgmt0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "management", "prefix": "10.255.2.253/32", "nexthopIps": ["10.255.2.253"], "oifs":
+    ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.1"],
+    "oifs": ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps":
+    ["169.254.254.6"], "oifs": [], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.5/32",
+    "nexthopIps": ["169.254.254.5"], "oifs": ["Ethernet1/3.3"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": [], "oifs": ["Null0"], "protocol": "bgp",
+    "source": "", "preference": 220, "ipvers": 4, "action": "drop", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.5"],
+    "oifs": ["Ethernet1/3.3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps":
+    ["169.254.127.1"], "oifs": ["Ethernet1/4"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.1/32",
+    "nexthopIps": ["169.254.127.1"], "oifs": ["Ethernet1/4"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.254.9/32", "nexthopIps": ["169.254.254.9"],
+    "oifs": ["Ethernet1/3.4"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["169.254.254.10"], "oifs": [], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31", "10.0.0.31"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    [], "oifs": ["Null0"], "protocol": "bgp", "source": "", "preference": 220, "ipvers":
+    4, "action": "drop", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    [], "oifs": ["Null0"], "protocol": "bgp", "source": "", "preference": 220, "ipvers":
+    4, "action": "drop", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1/1", "Ethernet1/2",
+    "Ethernet1/3", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "protocol": "ospf",
+    "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21", "10.0.0.21"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"],
+    "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "management",
+    "prefix": "10.255.2.119/32", "nexthopIps": ["10.255.2.119"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.119"], "oifs":
+    ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs":
+    ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.11"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14", "10.0.0.14"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["172.16.3.202"],
+    "oifs": ["Vlan30"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["Vlan20"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["172.16.2.201"],
+    "oifs": ["Vlan20"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["Vlan20"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "management",
+    "prefix": "10.255.2.191/32", "nexthopIps": ["10.255.2.191"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.191"], "oifs":
+    ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.203/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.204", "10.0.0.204"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.3"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:3c00/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.127.3"], "oifs":
+    ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["xe-0/0/1.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.0/32", "nexthopIps": [],
+    "oifs": ["xe-0/0/0.0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [],
+    "oifs": ["xe-0/0/1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "local", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01",
+    "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.255.2.250/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.2.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.127.3"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11", "10.0.0.11"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.189"],
+    "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "management", "prefix": "10.255.2.189/32", "nexthopIps": ["10.255.2.189"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["Vlan10"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4,
+    "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"],
+    "oifs": ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["172.16.3.102"], "oifs":
+    ["Vlan30"], "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.254/32",
+    "nexthopIps": ["172.16.1.254"], "oifs": ["Vlan10"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.202/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.201", "10.0.0.201"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.222", "10.0.0.222"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.221/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32",
+    "10.0.0.32"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.0.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.127.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["Ethernet1/4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.3/32", "nexthopIps":
+    ["169.254.127.3"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
+    "nexthopIps": ["169.254.253.9"], "oifs": ["Ethernet1/3.4"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.9/32", "nexthopIps": ["169.254.253.9"], "oifs": ["Ethernet1/3.4"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.10"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [], "oifs": ["Null0"],
+    "protocol": "bgp", "source": "", "preference": 220, "ipvers": 4, "action": "drop",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [], "oifs":
+    ["Null0"], "protocol": "bgp", "source": "", "preference": 220, "ipvers": 4, "action":
+    "drop", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": ["169.254.253.1"], "oifs": ["Ethernet1/3.2"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "169.254.253.1/32", "nexthopIps": ["169.254.253.1"], "oifs": ["Ethernet1/3.2"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.2"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "management", "prefix": "10.255.2.0/24", "nexthopIps": ["10.255.2.254"],
+    "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "management", "prefix": "10.255.2.254/32", "nexthopIps": ["10.255.2.254"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "10.255.2.0/24", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.0.0/24", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.5/32", "nexthopIps": ["169.254.253.5"],
+    "oifs": ["Ethernet1/3.3"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    [], "oifs": ["Null0"], "protocol": "bgp", "source": "", "preference": 220, "ipvers":
+    4, "action": "drop", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.5"],
+    "oifs": ["Ethernet1/3.3"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}]'
 - command: route show --prefixlen="!24" --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route show filter prefixlen nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256085},
+    {"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.204",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256085},
+    {"namespace": "nxos", "hostname": "server101", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256085},
+    {"namespace": "nxos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.39",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256085},
+    {"namespace": "nxos", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256085},
+    {"namespace": "nxos", "hostname": "server102", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256085},
+    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.140",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093},
+    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093},
+    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256093},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9",
+    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.249",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "bgp", "source": "10.0.0.200",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.4/30",
+    "nexthopIps": [""], "oifs": ["eth2.3"], "protocol": "kernel", "source": "169.254.253.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": [""], "oifs": ["eth1.3"], "protocol": "kernel", "source": "169.254.254.6",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256109},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
+    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["eth2.4"],
+    "protocol": "kernel", "source": "169.254.253.10", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1619275256109}, {"namespace": "nxos", "hostname":
+    "server302", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1619275256204}, {"namespace": "nxos", "hostname":
+    "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.114", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204}, {"namespace":
+    "nxos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275256204},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "management", "prefix": "10.255.2.120/32",
+    "nexthopIps": ["10.255.2.120"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4",
+    "Ethernet1/5", "Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22", "10.0.0.22"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257123}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": [], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.201/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.134", "10.0.0.134"], "oifs": ["Lo1", "Lo1"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.203/32",
+    "nexthopIps": ["10.0.0.203", "10.0.0.203"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["Vlan20"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257228},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "management", "prefix": "10.255.2.190/32", "nexthopIps": ["10.255.2.190"], "oifs":
+    ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13", "10.0.0.13"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257228}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["172.16.2.201"], "oifs": ["Vlan20"],
+    "protocol": "hmm", "source": "", "preference": 190, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257228}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"],
+    "oifs": ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12",
+    "10.0.0.12"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "management",
+    "prefix": "10.255.2.188/32", "nexthopIps": ["10.255.2.188"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.202", "10.0.0.202"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257446}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257446},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.204/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.254.6"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.221", "10.0.0.221"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.1/32",
+    "nexthopIps": ["169.254.254.1"], "oifs": ["Ethernet1/3.2"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [], "protocol": "static",
+    "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "management",
+    "prefix": "10.255.2.253/32", "nexthopIps": ["10.255.2.253"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.254.6"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.1"], "oifs":
+    ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.254.6"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "169.254.254.5/32", "nexthopIps": ["169.254.254.5"],
+    "oifs": ["Ethernet1/3.3"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.254.2"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.5"], "oifs":
+    ["Ethernet1/3.3"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.1"],
+    "oifs": ["Ethernet1/4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.1/32", "nexthopIps":
+    ["169.254.127.1"], "oifs": ["Ethernet1/4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.127.0"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.254.9/32", "nexthopIps": ["169.254.254.9"], "oifs": ["Ethernet1/3.4"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.31"], "oifs": ["Lo0", "Lo0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257463},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257463}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257463}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.254.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257463}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11",
+    "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2", "Ethernet1/3", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21", "10.0.0.21"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"],
+    "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace": "nxos",
+    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257467}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf": "management",
+    "prefix": "10.255.2.119/32", "nexthopIps": ["10.255.2.119"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.12"], "oifs": ["Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.13"], "oifs": ["Ethernet1/3"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.14"], "oifs": ["Ethernet1/4"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.222/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["Ethernet1/6"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.11"], "oifs": ["Ethernet1/1"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14", "10.0.0.14"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["Vlan30"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["172.16.3.202"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.254/32",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["Vlan20"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["172.16.2.201"], "oifs": ["Vlan20"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "management",
+    "prefix": "10.255.2.191/32", "nexthopIps": ["10.255.2.191"], "oifs": ["mgmt0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.134", "10.0.0.134"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.203/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.204", "10.0.0.204"],
+    "oifs": ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "management", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [],
+    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257671}, {"namespace":
+    "nxos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["em0.0"], "protocol":
+    "access-internal", "source": "", "preference": 12, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
+    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:3c00/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.127.2/32", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.127.0/32", "nexthopIps": [], "oifs": ["xe-0/0/0.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.127.2/31", "nexthopIps": [], "oifs": ["xe-0/0/1.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs": ["em1.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.255.2.250/32", "nexthopIps": [], "oifs": ["em0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.127.3"], "oifs": ["xe-0/0/1.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "169.254.127.0/31", "nexthopIps": [], "oifs": ["xe-0/0/0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257671}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.202/32", "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11", "10.0.0.11"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.254/32", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["Vlan30"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "management",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": [], "protocol": "static",
+    "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.112", "10.0.0.112"], "oifs":
+    ["Lo1", "Lo1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "management", "prefix": "10.255.2.189/32", "nexthopIps": ["10.255.2.189"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.0.221"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.41/32", "nexthopIps":
+    ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source":
+    "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["10.0.0.221"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "prefix": "169.254.127.2/31", "nexthopIps": ["10.0.0.221"], "oifs":
+    ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference": 200, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.101/32", "nexthopIps": ["172.16.1.101"],
+    "oifs": ["Vlan10"], "protocol": "hmm", "source": "", "preference": 190, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.102/32",
+    "nexthopIps": ["172.16.3.102"], "oifs": ["Vlan30"], "protocol": "hmm", "source":
+    "", "preference": 190, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.204/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.254/32", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["Vlan10"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257674}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257674},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.201/32",
+    "nexthopIps": ["10.0.0.201", "10.0.0.201"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257674}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.201/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.202/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.222/32",
+    "nexthopIps": ["10.0.0.222", "10.0.0.222"], "oifs": ["Lo1", "Lo1"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.204/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.221/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.203/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32", "10.0.0.32"], "oifs": ["Lo0",
+    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1",
+    "Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["Ethernet1/1", "Ethernet1/2"],
+    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.2"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.2"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.102/32", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["_nexthopVrf:default"], "protocol": "bgp", "source": "", "preference":
+    200, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.202/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.127.2"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.127.3"], "oifs": ["Ethernet1/4"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "internet-vrf", "prefix": "169.254.127.3/32", "nexthopIps": ["169.254.127.3"],
+    "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30", "nexthopIps": ["169.254.253.9"],
+    "oifs": ["Ethernet1/3.4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.9/32", "nexthopIps":
+    ["169.254.253.9"], "oifs": ["Ethernet1/3.4"], "protocol": "local", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.201/32",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["_nexthopVrf:default"], "protocol": "bgp",
+    "source": "", "preference": 200, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
+    "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.1"], "oifs":
+    ["Ethernet1/3.2"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "prefix": "169.254.253.1/32", "nexthopIps": ["169.254.253.1"],
+    "oifs": ["Ethernet1/3.2"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": [], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1619275257722}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "management", "prefix": "10.255.2.254/32",
+    "nexthopIps": ["10.255.2.254"], "oifs": ["mgmt0"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.2"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.0/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.127.2/31",
+    "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1619275257722},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "169.254.253.5/32",
+    "nexthopIps": ["169.254.253.5"], "oifs": ["Ethernet1/3.3"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.6"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1619275257722}, {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.5"], "oifs": ["Ethernet1/3.3"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1619275257722}]'
 - command: route show --prefixlen=">128" --format=json
   data-directory: tests/data/nxos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen nxos
 - command: route show --prefixlen="<0" --format=json
   data-directory: tests/data/nxos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen nxos
 - command: route show --prefixlen=">24 and !32" --format=json
   data-directory: tests/data/nxos/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
+      length'' (i.e. ''>= 24'')"}]'
   marks: route show filter prefixlen nxos
 - command: route summarize --format=json
   data-directory: tests/data/nxos/parquet-out/

--- a/tests/integration/sqcmds/nxos-samples/route.yml
+++ b/tests/integration/sqcmds/nxos-samples/route.yml
@@ -1216,6 +1216,33 @@ tests:
     "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"},
     {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname":
     "exit02"}, {"hostname": "exit02"}]'
+- command: route show --prefixlen=64 --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen=">128" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen="<0" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
+- command: route show --prefixlen=">24 and !32" --format=json
+  data-directory: tests/data/nxos/parquet-out/
+  marks: route show filter prefixlen nxos
 - command: route summarize --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: route summarize nxos

--- a/tests/integration/sqcmds/vmx-samples/route.yml
+++ b/tests/integration/sqcmds/vmx-samples/route.yml
@@ -1,5 +1,32 @@
 description: 'Testing verbs for route: show summarize unique lpm'
 tests:
+- command: route show --prefixlen=64 --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen=">128" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen="<0" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
+- command: route show --prefixlen=">24 and !32" --format=json
+  data-directory: tests/data/vmx/parquet-out/
+  marks: route show filter prefixlen vmx
 - command: route lpm --address='172.16.1.11' --columns='hostname nexthopIps' --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route lpm vmx

--- a/tests/integration/sqcmds/vmx-samples/route.yml
+++ b/tests/integration/sqcmds/vmx-samples/route.yml
@@ -3,29 +3,557 @@ tests:
 - command: route show --prefixlen=64 --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route show filter prefixlen vmx
+  output: '[]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route show filter prefixlen vmx
+  output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix":
+    "172.26.145.151/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009086664},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009086664}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix": "172.26.145.154/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.0/29",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.3/32",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.0/29",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.3/32",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "172.16.21.254/32",
+    "nexthopIps": [], "oifs": ["irb.201"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "172.16.11.254/32",
+    "nexthopIps": [], "oifs": ["irb.101"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix": "172.26.145.153/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "172.16.20.254/32",
+    "nexthopIps": [], "oifs": ["irb.200"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.2/32",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "172.16.10.254/32",
+    "nexthopIps": [], "oifs": ["irb.100"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.2/32",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.0/29",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.0/29",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default", "prefix": "172.26.145.152/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087291}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087291}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "10.0.10.0/29",
+    "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "10.0.20.0/29", "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "10.0.100.0/32", "nexthopIps": [], "oifs": ["ge-0/0/2.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "172.26.145.155/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "10.0.100.0/31", "nexthopIps": [], "oifs": ["ge-0/0/2.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087742}]'
 - command: route show --prefixlen="<=24" --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route show filter prefixlen vmx
+  output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009086664}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default",
+    "prefix": "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009086664}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default",
+    "prefix": "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.10.1"], "oifs": ["ae1.10"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "172.16.10.0/24", "nexthopIps": ["10.0.10.2"], "oifs": ["ae1.10"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "172.16.11.0/24", "nexthopIps": [], "oifs": ["irb.101"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.20.1"], "oifs": ["ae1.20"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.20.0/24", "nexthopIps": ["10.0.20.2"], "oifs": ["ae1.20"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.21.0/24", "nexthopIps": [], "oifs": ["irb.201"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default",
+    "prefix": "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.21.0/24", "nexthopIps": ["10.0.20.3"], "oifs": ["ae1.20"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.20.0/24", "nexthopIps": [], "oifs": ["irb.200"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.20.1"], "oifs": ["ae1.20"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "172.16.11.0/24", "nexthopIps": ["10.0.10.3"], "oifs": ["ae1.10"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "172.16.10.0/24", "nexthopIps": [], "oifs": ["irb.100"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.10.1"], "oifs": ["ae1.10"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087291}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default",
+    "prefix": "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087291}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "172.16.11.0/24", "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "vrf": "default", "prefix": "172.16.10.0/24", "nexthopIps": ["10.0.100.1"], "oifs":
+    ["ge-0/0/2.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1631009087742}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "172.16.20.0/24", "nexthopIps":
+    ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "172.16.21.0/24",
+    "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}]'
 - command: route show --prefixlen=">24" --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route show filter prefixlen vmx
+  output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix":
+    "172.26.145.151/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009086664},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009086664}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix": "172.26.145.154/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.0/29",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.3/32",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.0/29",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.3/32",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "172.16.21.254/32",
+    "nexthopIps": [], "oifs": ["irb.201"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "172.16.11.254/32",
+    "nexthopIps": [], "oifs": ["irb.101"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix": "172.26.145.153/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "172.16.20.254/32",
+    "nexthopIps": [], "oifs": ["irb.200"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.2/32",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "172.16.10.254/32",
+    "nexthopIps": [], "oifs": ["irb.100"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.2/32",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.0/29",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix": "10.0.20.0/29",
+    "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default", "prefix": "172.26.145.152/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087291}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087291}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "10.0.10.0/29",
+    "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "10.0.20.0/29", "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "10.0.100.0/32", "nexthopIps": [], "oifs": ["ge-0/0/2.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "172.26.145.155/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "10.0.100.0/31", "nexthopIps": [], "oifs": ["ge-0/0/2.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087742}]'
 - command: route show --prefixlen=">=24" --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route show filter prefixlen vmx
+  output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix":
+    "172.26.145.151/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009086664},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009086664}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix": "172.26.145.154/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.0/29",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "10.0.10.3/32",
+    "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087173}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix": "172.16.10.0/24",
+    "nexthopIps": ["10.0.10.2"], "oifs": ["ae1.10"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "172.16.11.0/24", "nexthopIps": [], "oifs": ["irb.101"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "10.0.20.0/29", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "10.0.20.3/32", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "172.16.20.0/24", "nexthopIps": ["10.0.20.2"], "oifs": ["ae1.20"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.21.0/24", "nexthopIps": [], "oifs": ["irb.201"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.21.254/32", "nexthopIps": [], "oifs": ["irb.201"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "172.16.11.254/32", "nexthopIps": [], "oifs": ["irb.101"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix":
+    "172.26.145.153/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "172.16.21.0/24", "nexthopIps": ["10.0.20.3"], "oifs": ["ae1.20"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.20.254/32", "nexthopIps": [], "oifs": ["irb.200"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "172.16.20.0/24", "nexthopIps": [], "oifs": ["irb.200"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "10.0.20.2/32", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "172.16.10.254/32", "nexthopIps": [], "oifs": ["irb.100"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "172.16.11.0/24", "nexthopIps": ["10.0.10.3"], "oifs": ["ae1.10"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "172.16.10.0/24", "nexthopIps": [], "oifs": ["irb.100"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "10.0.10.2/32", "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "10.0.10.0/29", "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "10.0.20.0/29", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default", "prefix": "172.26.145.152/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087291}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087291}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "10.0.10.0/29",
+    "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "10.0.20.0/29", "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "172.16.11.0/24", "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "vrf": "default", "prefix": "10.0.100.0/32", "nexthopIps": [], "oifs": ["ge-0/0/2.0"],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "local",
+    "timestamp": 1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "vrf": "default", "prefix": "172.16.10.0/24", "nexthopIps": ["10.0.100.1"], "oifs":
+    ["ge-0/0/2.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1631009087742}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "172.16.20.0/24", "nexthopIps":
+    ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source": "", "preference":
+    170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "172.16.21.0/24",
+    "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"], "protocol": "bgp", "source":
+    "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "172.26.145.155/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "10.0.100.0/31", "nexthopIps": [], "oifs": ["ge-0/0/2.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087742}]'
 - command: route show --prefixlen="!24" --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: route show filter prefixlen vmx
+  output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009086664}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default",
+    "prefix": "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009086664}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default",
+    "prefix": "172.26.145.151/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009086664}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009086664},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix":
+    "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default",
+    "prefix": "172.26.145.154/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.0.10.1"], "oifs": ["ae1.10"], "protocol":
+    "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "10.0.10.0/29", "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "10.0.10.3/32", "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["10.0.20.1"], "oifs": ["ae1.20"], "protocol": "bgp",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "10.0.20.0/29", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087173}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "10.0.20.3/32", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "172.16.21.254/32", "nexthopIps": [], "oifs": ["irb.201"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "default", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "172.16.11.254/32", "nexthopIps": [], "oifs": ["irb.101"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087173},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix":
+    "172.26.145.153/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix":
+    "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "172.16.20.254/32", "nexthopIps": [], "oifs": ["irb.200"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "10.0.20.2/32", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "172.16.10.254/32", "nexthopIps": [], "oifs": ["irb.100"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["10.0.20.1"], "oifs": ["ae1.20"], "protocol": "bgp",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
+    "prefix": "10.0.10.2/32", "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "10.0.10.0/29", "nexthopIps": [], "oifs": ["ae1.10"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1631009087230},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["10.0.10.1"], "oifs": ["ae1.10"], "protocol": "bgp",
+    "source": "", "preference": 170, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B",
+    "prefix": "10.0.20.0/29", "nexthopIps": [], "oifs": ["ae1.20"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087230}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087291}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default",
+    "prefix": "172.26.144.0/22", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087291}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default",
+    "prefix": "172.26.145.152/32", "nexthopIps": [], "oifs": ["fxp0.0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "local", "timestamp":
+    1631009087291}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087291},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["172.26.147.254"], "oifs": ["fxp0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "prefix": "10.0.10.0/29", "nexthopIps": ["10.0.100.1"], "oifs": ["ge-0/0/2.0"],
+    "protocol": "bgp", "source": "", "preference": 170, "ipvers": 4, "action": "forward",
+    "timestamp": 1631009087742}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "vrf": "default", "prefix": "10.0.20.0/29", "nexthopIps": ["10.0.100.1"], "oifs":
+    ["ge-0/0/2.0"], "protocol": "bgp", "source": "", "preference": 170, "ipvers":
+    4, "action": "forward", "timestamp": 1631009087742}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "10.0.100.0/32", "nexthopIps":
+    [], "oifs": ["ge-0/0/2.0"], "protocol": "local", "source": "", "preference": 0,
+    "ipvers": 4, "action": "local", "timestamp": 1631009087742}, {"namespace": "vmx",
+    "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "172.26.144.0/22",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1631009087742}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "172.26.145.155/32",
+    "nexthopIps": [], "oifs": ["fxp0.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1631009087742}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix": "10.0.100.0/31",
+    "nexthopIps": [], "oifs": ["ge-0/0/2.0"], "protocol": "direct", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1631009087742},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1631009087742}]'
 - command: route show --prefixlen=">128" --format=json
   data-directory: tests/data/vmx/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen vmx
 - command: route show --prefixlen="<0" --format=json
   data-directory: tests/data/vmx/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen vmx
 - command: route show --prefixlen=">24 and !32" --format=json
   data-directory: tests/data/vmx/parquet-out/
+  error:
+    error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
+      length'' (i.e. ''>= 24'')"}]'
   marks: route show filter prefixlen vmx
 - command: route lpm --address='172.16.1.11' --columns='hostname nexthopIps' --format=json
   data-directory: tests/data/vmx/parquet-out/


### PR DESCRIPTION
This PR solves #115 adding the validation of the prefixlen filter expression, showing a help message whenever an expression with an incorrect form is specified.