### PR TITLE
Allow pager disabling in the CLI

### DIFF
--- a/suzieq/cli/sqcmds/context_commands.py
+++ b/suzieq/cli/sqcmds/context_commands.py
@@ -67,6 +67,8 @@ def set_ctxt(
 
     if pager == 'on':
         plugin_ctx.pager = True
+    elif pager == 'off':
+        plugin_ctx.pager = False
 
 
 @command("clear")


### PR DESCRIPTION
At the moment, after enabling the pager calling `set pager=on`, the inverse command `set pager=off` has not any effect, so it is not possible to disable it. This PR solves this problem by handling the cases in which the user wants to disable the pager.