### PR TITLE
Break out IPv4 and IPv6 in arpnd summarize

### DIFF
--- a/suzieq/engines/pandas/arpnd.py
+++ b/suzieq/engines/pandas/arpnd.py
@@ -57,14 +57,14 @@ class ArpndObj(SqPandasEngine):
             ('arpNdEntriesCnt', 'ipAddress', 'count')]
 
         self._summarize_on_add_with_query = [
-            ('arpNdV4EntriesCnt', '@self._check_ipvers(ipAddress, 4)',
+            ('arpEntriesCnt', '@self._check_ipvers(ipAddress, 4)',
                 'ipAddress'),
-            ('arpNdV6EntriesCnt', '@self._check_ipvers(ipAddress, 6)',
+            ('v6NDEntriesCnt', '@self._check_ipvers(ipAddress, 6)',
                 'ipAddress'),
-            ('arpNdV6GlobalEntriesCnt',
+            ('v6NDGlobalEntriesCnt',
                 '@self._check_ipvers(ipAddress, 6) and'
                 '@self._is_in_subnet(ipAddress, "fe80::/10")', 'ipAddress'),
-            ('arpNdV6LLAEntriesCnt',
+            ('v6NDLLAEntriesCnt',
                 '@self._check_ipvers(ipAddress, 6) and not '
                 '@self._is_in_subnet(ipAddress, "fe80::/10")',
                 'ipAddress'),

--- a/suzieq/engines/pandas/arpnd.py
+++ b/suzieq/engines/pandas/arpnd.py
@@ -8,12 +8,6 @@ class ArpndObj(SqPandasEngine):
     def table_name():
         return 'arpnd'
 
-    def _check_ipvers(self,  addr: pd.Series, version: int) -> list:
-
-        return addr.apply(lambda a: (
-            True if self._get_ipvers(a) == version else False)
-            )
-
     def get(self, **kwargs) -> pd.DataFrame:
         """Retrieve the arpnd table info providing address prefix filtering"""
 

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -92,6 +92,22 @@ class SqPandasEngine(SqEngineObj):
             False if not a else ip_address(a.split("/")[0]) in network)
         )
 
+    def _check_ipvers(self,  addr: pd.Series, version: int) -> pd.Series:
+        """Check if the IP version of addresses in a Pandas dataframe
+        correspond to the given version
+
+        Args:
+            addr (PandasObject): the collection of ip addresses to check
+            version: (int): IP version (4 or 6)
+
+        Returns:
+            PandasObject: A collection of bool reporting the result
+        """
+
+        return addr.apply(lambda a: (
+            True if self._get_ipvers(a) == version else False)
+            )
+
     def get_valid_df(self, table: str, **kwargs) -> pd.DataFrame:
         """The heart of the engine: retrieving the data from the backing store
 

--- a/tests/integration/sqcmds/cumulus-samples/arpnd.yml
+++ b/tests/integration/sqcmds/cumulus-samples/arpnd.yml
@@ -1444,19 +1444,9 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/multidc/parquet-out/
   marks: arpnd summarize
-  output: '{"ospf-single": {"deviceCnt": 14, "arpNdEntriesCnt": 55, "macaddrCnt":
-    55, "oifCnt": 55, "uniqueOifCnt": 9, "remoteEntriesCnt": 0, "staticEntriesCnt":
-    0, "failedEntryCnt": 0}, "dual-evpn": {"deviceCnt": 14, "arpNdEntriesCnt": 196,
-    "macaddrCnt": 196, "oifCnt": 196, "uniqueOifCnt": 21, "remoteEntriesCnt": 0, "staticEntriesCnt":
-    36, "failedEntryCnt": 0}, "ospf-ibgp": {"deviceCnt": 14, "arpNdEntriesCnt": 186,
-    "macaddrCnt": 186, "oifCnt": 186, "uniqueOifCnt": 23, "remoteEntriesCnt": 0, "staticEntriesCnt":
-    44, "failedEntryCnt": 0}}'
 - command: arpnd summarize --namespace=dual-evpn --format=json
   data-directory: tests/data/multidc/parquet-out/
   marks: arpnd summarize
-  output: '{"dual-evpn": {"deviceCnt": 14, "arpNdEntriesCnt": 196, "macaddrCnt": 196,
-    "oifCnt": 196, "uniqueOifCnt": 21, "remoteEntriesCnt": 0, "staticEntriesCnt":
-    36, "failedEntryCnt": 0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/multidc/parquet-out/
   marks: arpnd unique
@@ -1487,6 +1477,3 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out
   marks: arpnd summarize
-  output: '{"dual-bgp": {"deviceCnt": 14, "arpNdEntriesCnt": 138, "macaddrCnt": 138,
-    "oifCnt": 138, "uniqueOifCnt": 17, "remoteEntriesCnt": 0, "staticEntriesCnt":
-    52, "failedEntryCnt": 0}}'

--- a/tests/integration/sqcmds/cumulus-samples/arpnd.yml
+++ b/tests/integration/sqcmds/cumulus-samples/arpnd.yml
@@ -1444,9 +1444,27 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/multidc/parquet-out/
   marks: arpnd summarize
+  output: '{"ospf-single": {"deviceCnt": 14, "macaddrCnt": 55, "oifCnt": 55, "uniqueOifCnt":
+    9, "arpNdEntriesCnt": 55, "arpNdV4EntriesCnt": 46, "arpNdV6EntriesCnt": 9, "arpNdV6GlobalEntriesCnt":
+    9, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 0,
+    "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 0, "failedV6EntryCnt":
+    0}, "dual-evpn": {"deviceCnt": 14, "macaddrCnt": 196, "oifCnt": 196, "uniqueOifCnt":
+    21, "arpNdEntriesCnt": 196, "arpNdV4EntriesCnt": 132, "arpNdV6EntriesCnt": 64,
+    "arpNdV6GlobalEntriesCnt": 64, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt":
+    0, "staticV4EntriesCnt": 28, "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt":
+    8, "failedV6EntryCnt": 0}, "ospf-ibgp": {"deviceCnt": 14, "macaddrCnt": 186, "oifCnt":
+    186, "uniqueOifCnt": 23, "arpNdEntriesCnt": 186, "arpNdV4EntriesCnt": 148, "arpNdV6EntriesCnt":
+    38, "arpNdV6GlobalEntriesCnt": 38, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt":
+    0, "staticV4EntriesCnt": 34, "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt":
+    10, "failedV6EntryCnt": 0}}'
 - command: arpnd summarize --namespace=dual-evpn --format=json
   data-directory: tests/data/multidc/parquet-out/
   marks: arpnd summarize
+  output: '{"dual-evpn": {"deviceCnt": 14, "macaddrCnt": 196, "oifCnt": 196, "uniqueOifCnt":
+    21, "arpNdEntriesCnt": 196, "arpNdV4EntriesCnt": 132, "arpNdV6EntriesCnt": 64,
+    "arpNdV6GlobalEntriesCnt": 64, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt":
+    0, "staticV4EntriesCnt": 28, "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt":
+    8, "failedV6EntryCnt": 0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/multidc/parquet-out/
   marks: arpnd unique
@@ -1477,3 +1495,8 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out
   marks: arpnd summarize
+  output: '{"dual-bgp": {"deviceCnt": 14, "macaddrCnt": 138, "oifCnt": 138, "uniqueOifCnt":
+    17, "arpNdEntriesCnt": 138, "arpNdV4EntriesCnt": 78, "arpNdV6EntriesCnt": 60,
+    "arpNdV6GlobalEntriesCnt": 52, "arpNdV6LLAEntriesCnt": 8, "remoteV4EntriesCnt":
+    0, "staticV4EntriesCnt": 36, "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt":
+    16, "failedV6EntryCnt": 0}}'

--- a/tests/integration/sqcmds/eos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/eos-samples/arpnd.yml
@@ -366,6 +366,11 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: arpnd summarize eos
+  output: '{"eos": {"deviceCnt": 14, "macaddrCnt": 82, "oifCnt": 82, "uniqueOifCnt":
+    26, "arpNdEntriesCnt": 82, "arpNdV4EntriesCnt": 77, "arpNdV6EntriesCnt": 5, "arpNdV6GlobalEntriesCnt":
+    5, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 0,
+    "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 0, "failedV6EntryCnt":
+    0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: arpnd unique eos

--- a/tests/integration/sqcmds/eos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/eos-samples/arpnd.yml
@@ -366,9 +366,6 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: arpnd summarize eos
-  output: '{"eos": {"deviceCnt": 14, "arpNdEntriesCnt": 82, "macaddrCnt": 82, "oifCnt":
-    82, "uniqueOifCnt": 26, "remoteEntriesCnt": 0, "staticEntriesCnt": 0, "failedEntryCnt":
-    0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: arpnd unique eos

--- a/tests/integration/sqcmds/junos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/junos-samples/arpnd.yml
@@ -355,6 +355,11 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: arpnd summarize junos
+  output: '{"junos": {"deviceCnt": 12, "macaddrCnt": 68, "oifCnt": 68, "uniqueOifCnt":
+    20, "arpNdEntriesCnt": 68, "arpNdV4EntriesCnt": 63, "arpNdV6EntriesCnt": 5, "arpNdV6GlobalEntriesCnt":
+    5, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 0,
+    "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 0, "failedV6EntryCnt":
+    0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: arpnd unique junos

--- a/tests/integration/sqcmds/junos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/junos-samples/arpnd.yml
@@ -355,9 +355,6 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: arpnd summarize junos
-  output: '{"junos": {"deviceCnt": 12, "arpNdEntriesCnt": 68, "macaddrCnt": 68, "oifCnt":
-    68, "uniqueOifCnt": 20, "remoteEntriesCnt": 0, "staticEntriesCnt": 0, "failedEntryCnt":
-    0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/junos/parquet-out/
   marks: arpnd unique junos

--- a/tests/integration/sqcmds/mixed-samples/arpnd.yml
+++ b/tests/integration/sqcmds/mixed-samples/arpnd.yml
@@ -293,14 +293,9 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: arpnd summarize mixed
-  output: '{"mixed": {"deviceCnt": 8, "arpNdEntriesCnt": 34, "macaddrCnt": 34, "oifCnt":
-    34, "uniqueOifCnt": 17, "remoteEntriesCnt": 0, "staticEntriesCnt": 0, "failedEntryCnt":
-    0}}'
 - command: arpnd summarize --namespace=dual-evpn --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: arpnd summarize mixed
-  output: '{"namespace": {}, "hostname": {}, "ipAddress": {}, "oif": {}, "macaddr":
-    {}, "state": {}, "remote": {}, "timestamp": {}, "active": {}}'
 - command: arpnd unique --columns=hostname --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: arpnd unique mixed

--- a/tests/integration/sqcmds/mixed-samples/arpnd.yml
+++ b/tests/integration/sqcmds/mixed-samples/arpnd.yml
@@ -293,9 +293,16 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: arpnd summarize mixed
+  output: '{"mixed": {"deviceCnt": 8, "macaddrCnt": 34, "oifCnt": 34, "uniqueOifCnt":
+    17, "arpNdEntriesCnt": 34, "arpNdV4EntriesCnt": 34, "arpNdV6EntriesCnt": 0, "arpNdV6GlobalEntriesCnt":
+    0, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 0,
+    "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 0, "failedV6EntryCnt":
+    0}}'
 - command: arpnd summarize --namespace=dual-evpn --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: arpnd summarize mixed
+  output: '{"namespace": {}, "hostname": {}, "ipAddress": {}, "oif": {}, "macaddr":
+    {}, "state": {}, "remote": {}, "timestamp": {}, "active": {}}'
 - command: arpnd unique --columns=hostname --format=json
   data-directory: tests/data/mixed/parquet-out/
   marks: arpnd unique mixed

--- a/tests/integration/sqcmds/nxos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/nxos-samples/arpnd.yml
@@ -203,6 +203,11 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: arpnd summarize nxos
+  output: '{"nxos": {"deviceCnt": 14, "macaddrCnt": 74, "oifCnt": 74, "uniqueOifCnt":
+    25, "arpNdEntriesCnt": 74, "arpNdV4EntriesCnt": 73, "arpNdV6EntriesCnt": 1, "arpNdV6GlobalEntriesCnt":
+    1, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 0,
+    "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 0, "failedV6EntryCnt":
+    0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: arpnd unique nxos

--- a/tests/integration/sqcmds/nxos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/nxos-samples/arpnd.yml
@@ -203,9 +203,6 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: arpnd summarize nxos
-  output: '{"nxos": {"deviceCnt": 14, "arpNdEntriesCnt": 74, "macaddrCnt": 74, "oifCnt":
-    74, "uniqueOifCnt": 25, "remoteEntriesCnt": 0, "staticEntriesCnt": 0, "failedEntryCnt":
-    0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/nxos/parquet-out/
   marks: arpnd unique nxos

--- a/tests/integration/sqcmds/vmx-samples/arpnd.yml
+++ b/tests/integration/sqcmds/vmx-samples/arpnd.yml
@@ -207,14 +207,9 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: arpnd summarize vmx
-  output: '{"vmx": {"deviceCnt": 5, "arpNdEntriesCnt": 23, "macaddrCnt": 23, "oifCnt":
-    23, "uniqueOifCnt": 9, "remoteEntriesCnt": 0, "staticEntriesCnt": 0, "failedEntryCnt":
-    0}}'
 - command: arpnd summarize --namespace=dual-evpn --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: arpnd summarize vmx
-  output: '{"namespace": {}, "hostname": {}, "ipAddress": {}, "oif": {}, "macaddr":
-    {}, "state": {}, "remote": {}, "timestamp": {}, "active": {}}'
 - command: arpnd unique --columns=hostname --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: arpnd unique vmx

--- a/tests/integration/sqcmds/vmx-samples/arpnd.yml
+++ b/tests/integration/sqcmds/vmx-samples/arpnd.yml
@@ -207,9 +207,16 @@ tests:
 - command: arpnd summarize --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: arpnd summarize vmx
+  output: '{"vmx": {"deviceCnt": 5, "macaddrCnt": 23, "oifCnt": 23, "uniqueOifCnt":
+    9, "arpNdEntriesCnt": 23, "arpNdV4EntriesCnt": 23, "arpNdV6EntriesCnt": 0, "arpNdV6GlobalEntriesCnt":
+    0, "arpNdV6LLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 0,
+    "failedV4EntryCnt": 0, "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 0, "failedV6EntryCnt":
+    0}}'
 - command: arpnd summarize --namespace=dual-evpn --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: arpnd summarize vmx
+  output: '{"namespace": {}, "hostname": {}, "ipAddress": {}, "oif": {}, "macaddr":
+    {}, "state": {}, "remote": {}, "timestamp": {}, "active": {}}'
 - command: arpnd unique --columns=hostname --format=json
   data-directory: tests/data/vmx/parquet-out/
   marks: arpnd unique vmx


### PR DESCRIPTION
This PR brings the enhancement described in #162 to break out IPv4 and IPv6 entries.

```
claudious> arpnd summarize namespace=dual-evpn
                         dual-evpn
deviceCnt                       14
macaddrCnt                     196
oifCnt                         196
uniqueOifCnt                    21
arpNdEntriesCnt                196
arpNdV4EntriesCnt              132
arpNdV6EntriesCnt               64
arpNdV6GlobalEntriesCnt         64
arpNdV6LLAEntriesCnt             0
remoteV4EntriesCnt               0
staticV4EntriesCnt              28
failedV4EntryCnt                 0
remoteV6EntriesCnt               0
staticV6EntriesCnt               8
failedV6EntryCnt                 0
```