### PR TITLE
SqPlugin: Make get_plugins work without any additional params for a p…

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,872 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.7
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+
+enable = 
+	blacklisted-name,
+	line-too-long,
+	
+	abstract-class-instantiated,
+	abstract-method,
+	access-member-before-definition,
+	anomalous-backslash-in-string,
+	anomalous-unicode-escape-in-string,
+	arguments-differ,
+	assert-on-tuple,
+	assigning-non-slot,
+	assignment-from-no-return,
+	assignment-from-none,
+	attribute-defined-outside-init,
+	bad-except-order,
+	bad-format-character,
+	bad-format-string-key,
+	bad-format-string,
+	bad-open-mode,
+	bad-reversed-sequence,
+	bad-staticmethod-argument,
+	bad-str-strip-call,
+	bad-super-call,
+	binary-op-exception,
+	boolean-datetime,
+	catching-non-exception,
+	cell-var-from-loop,
+	confusing-with-statement,
+	continue-in-finally,
+	cyclical-import,
+	dangerous-default-value,
+	dict-items-not-iterating,
+	dict-keys-not-iterating,
+	dict-values-not-iterating,
+	duplicate-argument-name,
+	duplicate-bases,
+	duplicate-except,
+	duplicate-key,
+	eq-without-hash,
+	exception-escape,
+	exception-message-attribute,
+	expression-not-assigned,
+	filter-builtin-not-iterating,
+	format-combined-specification,
+	format-needs-mapping,
+	function-redefined,
+	global-variable-undefined,
+	import-error,
+	import-self,
+	inconsistent-mro,
+	indexing-exception,
+	inherit-non-class,
+	init-is-generator,
+	invalid-all-object,
+	invalid-encoded-data,
+	invalid-format-index,
+	invalid-length-returned,
+	invalid-sequence-index,
+	invalid-slice-index,
+	invalid-slots-object,
+	invalid-slots,
+	invalid-str-codec,
+	invalid-unary-operand-type,
+	logging-too-few-args,
+	logging-too-many-args,
+	logging-unsupported-format,
+	lost-exception,
+	map-builtin-not-iterating,
+	method-hidden,
+	misplaced-bare-raise,
+	misplaced-future,
+	missing-format-argument-key,
+	missing-format-attribute,
+	missing-format-string-key,
+	missing-super-argument,
+	mixed-fomat-string,
+	model-unicode-not-callable,
+	no-member,
+	no-method-argument,
+	no-name-in-module,
+	no-self-argument,
+	no-value-for-parameter,
+	non-iterator-returned,
+	non-parent-method-called,
+	nonexistent-operator,
+	nonimplemented-raised,
+	nonstandard-exception,
+	not-a-mapping,
+	not-an-iterable,
+	not-callable,
+	not-context-manager,
+	not-in-loop,
+	pointless-statement,
+	pointless-string-statement,
+	property-on-old-class,
+	raising-bad-type,
+	raising-non-exception,
+	raising-string,
+	range-builtin-not-iterating,
+	redefined-builtin,
+	redefined-in-handler,
+	redefined-outer-name,
+	redefined-variable-type,
+	redundant-keyword-arg,
+	relative-import,
+	repeated-keyword,
+	return-arg-in-generator,
+	return-in-init,
+	return-outside-function,
+	signature-differs,
+	slots-on-old-class,
+	super-method-not-called,
+	super-on-old-class,
+	syntax-error,
+	sys-max-int,
+	test-inherits-tests,
+	too-few-format-args,
+	too-many-format-args,
+	translation-of-non-string,
+	truncated-format-string,
+	unbalance-tuple-unpacking,
+	undefined-all-variable,
+	undefined-loop-variable,
+	undefined-variable,
+	unexpected-keyword-arg,
+	unexpected-special-method-signature,
+	unpacking-non-sequence,
+	unreachable,
+	unsubscriptable-object,
+	unsupported-binary-operation,
+	unsupported-membership-test,
+	unused-format-string-argument,
+	unused-format-string-key,
+	used-before-assignment,
+	using-constant-test,
+	yield-outside-function,
+	zip-builtin-not-iterating,
+	
+	astroid-error,
+	django-not-available-placeholder,
+	django-not-available,
+	fatal,
+	method-check-failed,
+	parse-error,
+	raw-checker-failed,
+	
+	empty-docstring,
+	invalid-characters-in-docstring,
+	missing-docstring,
+	wrong-spelling-in-comment,
+	wrong-spelling-in-docstring,
+	
+	unused-argument,
+	unused-import,
+	unused-variable,
+	
+	eval-used,
+	exec-used,
+	
+	bad-classmethod-argument,
+	bad-mcs-classmethod-argument,
+	bad-mcs-method-argument,
+	bad-whitespace,
+	bare-except,
+	broad-except,
+	consider-iterating-dictionary,
+	consider-using-enumerate,
+	global-at-module-level,
+	global-variable-not-assigned,
+	literal-used-as-attribute,
+	logging-format-interpolation,
+	logging-not-lazy,
+	metaclass-assignment,
+	model-has-unicode,
+	model-missing-unicode,
+	model-no-explicit-unicode,
+	multiple-imports,
+	multiple-statements,
+	no-classmethod-decorator,
+	no-staticmethod-decorator,
+	old-raise-syntax,
+	old-style-class,
+	protected-access,
+	redundant-unittest-assert,
+	reimported,
+	simplifiable-if-statement,
+	simplifiable-range,
+	singleton-comparison,
+	superfluous-parens,
+	unidiomatic-typecheck,
+	unnecessary-lambda,
+	unnecessary-pass,
+	unnecessary-semicolon,
+	unneeded-not,
+	useless-else-on-loop,
+	wrong-assert-type,
+	
+	deprecated-method,
+	deprecated-module,
+	
+	too-many-boolean-expressions,
+	too-many-nested-blocks,
+	too-many-statements,
+	
+	wildcard-import,
+	wrong-import-order,
+	wrong-import-position,
+	
+	missing-final-newline,
+	mixed-indentation,
+	mixed-line-endings,
+	trailing-newlines,
+	trailing-whitespace,
+	unexpected-line-ending-format,
+	
+	bad-inline-option,
+	bad-option-value,
+	deprecated-pragma,
+	unrecognized-inline-option,
+	useless-suppression,
+	
+	cmp-method,
+	coerce-method,
+	delslice-method,
+	dict-iter-method,
+	dict-view-method,
+	div-method,
+	getslice-method,
+	hex-method,
+	idiv-method,
+	next-method-called,
+	next-method-defined,
+	nonzero-method,
+	oct-method,
+	rdiv-method,
+	setslice-method,
+	using-cmp-argument,
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable = 
+	bad-continuation,
+	bad-indentation,
+	consider-using-f-string,
+	duplicate-code,
+	file-ignored,
+	fixme,
+	global-statement,
+	invalid-name,
+	locally-disabled,
+	locally-enabled,
+	lowercase-l-suffix,
+	misplaced-comparison-constant,
+	missing-module-docstring,
+	no-else-return,
+	no-init,
+	no-self-use,
+	suppressed-message,
+	too-few-public-methods,
+	too-many-ancestors,
+	too-many-arguments,
+	too-many-branches,
+	too-many-instance-attributes,
+	too-many-lines,
+	too-many-locals,
+	too-many-public-methods,
+	too-many-return-statements,
+	too-many-function-args,
+	ungrouped-imports,
+	unspecified-encoding,
+	unused-wildcard-import,
+	use-maxsplit-arg,
+	
+	feature-toggle-needs-doc,
+	illegal-waffle-usage,
+	
+	apply-builtin,
+	backtick,
+	bad-python3-import,
+	basestring-builtin,
+	buffer-builtin,
+	cmp-builtin,
+	coerce-builtin,
+	deprecated-itertools-function,
+	deprecated-operator-function,
+	deprecated-str-translate-call,
+	deprecated-string-function,
+	deprecated-sys-function,
+	deprecated-types-field,
+	deprecated-urllib-function,
+	execfile-builtin,
+	file-builtin,
+	import-star-module-level,
+	input-builtin,
+	intern-builtin,
+	long-builtin,
+	long-suffix,
+	no-absolute-import,
+	non-ascii-bytes-literal,
+	old-division,
+	old-ne-operator,
+	old-octal-literal,
+	parameter-unpacking,
+	print-statement,
+	raw_input-builtin,
+	reduce-builtin,
+	reload-builtin,
+	round-builtin,
+	standarderror-builtin,
+	super-init-not-called,
+	unichr-builtin,
+	unicode-builtin,
+	unpacking-in-except,
+	xrange-builtin,
+	
+	logging-fstring-interpolation,
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the 'python-enchant' package.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# class is considered mixin if its name matches the mixin-class-rgx option.
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/pytest.ini
+++ b/pytest.ini
@@ -50,5 +50,6 @@ markers =
     rest
     vmx
     schema
+    plugin
     
 xfail_strict = True

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -3,16 +3,18 @@ import time
 import ast
 from dataclasses import dataclass
 import inspect
+from io import StringIO
+import shutil
 
 import pandas as pd
 from nubia import command, argument, context
-from io import StringIO
-import shutil
+
 from prompt_toolkit import prompt
 from natsort import natsort_keygen
 from colorama import Fore, Style
 
 from suzieq.exceptions import UserQueryError
+from suzieq.shared.sq_plugin import SqPlugin
 
 
 @dataclass
@@ -56,7 +58,7 @@ class ArgHelpClass(object):
     description=("Trailing blank terminated pandas query format to "
                  "further filter the output",)
 )
-class SqCommand:
+class SqCommand(SqPlugin):
     """Base Command Class for use with all verbs"""
 
     def __init__(
@@ -253,6 +255,7 @@ class SqCommand:
                      if inspect.ismethod(x[1]) and not x[0].startswith('_')}
             print(f"{self.sqobj.table}: " + Fore.CYAN + f"{self.__doc__}" +
                   Style.RESET_ALL)
+            verbs = {x: verbs[x] for x in verbs if x != 'get_plugins'}
             print("\nSupported verbs are: ")
             for verb in verbs:
                 docstr = inspect.getdoc(verbs[verb])

--- a/suzieq/db/base_db.py
+++ b/suzieq/db/base_db.py
@@ -4,9 +4,12 @@ from typing import List
 from dataclasses import dataclass
 
 import pandas as pd
+import pyarrow as pa
+
+from suzieq.shared.sq_plugin import SqPlugin
 
 
-class SqDB(ABC):
+class SqDB(SqPlugin, ABC):
     def __init__(self, cfg: dict, logger: logging.Logger):
         """Initialize the database
 
@@ -43,7 +46,8 @@ class SqDB(ABC):
 
     @abstractmethod
     def write(self, table_name: str, data_format: str,
-              data, **kwargs) -> int:
+              data, coalesced: bool, schema: pa.lib.Schema,
+              filename_cb, **kwargs) -> int:
         """Write the data supplied as a dataframe in the appropriate format
 
         :param cfg: Suzieq configuration
@@ -59,7 +63,8 @@ class SqDB(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def coalesce(self, tables: List[str] = None, period: str = '') -> None:
+    def coalesce(self, tables: List[str] = None, period: str = '',
+                 ign_sqpoller: bool = False) -> None:
         """Coalesce the database files in specified folder.
 
         :param tables: List[str], List of specific tables to coalesce, empty

--- a/suzieq/db/dblib.py
+++ b/suzieq/db/dblib.py
@@ -1,9 +1,8 @@
 import logging
 from typing import List
-from importlib import import_module
-import inspect
 
 from suzieq.exceptions import DBNotFoundError
+from suzieq.db.base_db import SqDB
 
 
 def get_sqdb_engine(cfg: dict, table_name: str, dbname: str,
@@ -21,31 +20,21 @@ def get_sqdb_engine(cfg: dict, table_name: str, dbname: str,
     :returns: the class that is the reader for this object
     :rtype:
     """
-    # Load the available engines
-    avail_db = ['parquet']
-
-    use_db = None
+    use_db = 'parquet'
     if table_name and table_name in cfg.get('db', {}):
         use_db = cfg['db'][table_name]
-    elif dbname and dbname in avail_db:
+    elif dbname:
         use_db = dbname
-    else:
-        use_db = 'parquet'      # The default
 
     if not use_db:
         logger.error(f'Unable to find a DB for {table_name}/{dbname}')
         return None
 
-    try:
-        eng_mod = import_module(f'suzieq.db.{use_db}')
-    except ModuleNotFoundError:
-        return None
+    eng_mod = SqDB.get_plugins(use_db)
+    if not eng_mod:
+        raise DBNotFoundError('DB {use_db} not found')
 
-    for mbr in inspect.getmembers(eng_mod):
-        if mbr[0] == 'get_sqdb' and inspect.isfunction(mbr[1]):
-            return mbr[1](cfg, logger)
-
-    return None
+    return eng_mod[use_db](cfg, logger)
 
 
 def do_coalesce(cfg: dict, tables: List[str], period: str = '1h',

--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -4,7 +4,6 @@ from time import time
 from typing import List
 import logging
 from pathlib import Path
-import pyarrow.dataset as ds
 from datetime import datetime, timedelta, timezone
 from contextlib import suppress
 from shutil import rmtree
@@ -13,13 +12,15 @@ from collections import defaultdict
 import pandas as pd
 import numpy as np
 import pyarrow as pa
+import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 
 from suzieq.db.base_db import SqDB, SqCoalesceStats
 from suzieq.utils import Schema, SchemaForTable
 
-from .pq_coalesce import SqCoalesceState, coalesce_resource_table
-from .migratedb import get_migrate_fn
+from suzieq.db.parquet.pq_coalesce import (SqCoalesceState,
+                                           coalesce_resource_table)
+from suzieq.db.parquet.migratedb import get_migrate_fn
 
 
 class SqParquetDB(SqDB):
@@ -746,16 +747,16 @@ class SqParquetDB(SqDB):
 
         """
         if coalesced:
-            dir = self.cfg.get('coalescer', {})\
+            folder = self.cfg.get('coalescer', {})\
                 .get('coalesce-directory',
                      f'{self.cfg.get("data-directory")}/coalesced')
         else:
-            dir = f'{self.cfg.get("data-directory")}'
+            folder = f'{self.cfg.get("data-directory")}'
 
         if table_name:
-            return f'{dir}/{table_name}'
+            return f'{folder}/{table_name}'
         else:
-            return dir
+            return folder
 
     def _get_default_vals(self) -> dict:
         return({

--- a/suzieq/engines/__init__.py
+++ b/suzieq/engines/__init__.py
@@ -1,22 +1,33 @@
-from importlib import import_module
-import inspect
 
-name = "sqengines"
+from suzieq.engines.base_engine import SqEngineObj
 
 
 def get_sqengine(engine_name: str, table_name: str):
+    """Return either the top level engine obj or a specific engine obj
 
-    # Lets load the available engines
-    try:
-        eng_mod = import_module(f'suzieq.engines.{engine_name}')
-    except ModuleNotFoundError:
-        return None
+    Args:
+        engine_name (str): Name of the engine
+        table_name (str): Table specific engine object
 
-    for mbr in inspect.getmembers(eng_mod):
-        if mbr[0] == 'get_engine_object' and inspect.isfunction(mbr[1]):
-            return mbr[1]
+    Raises:
+        Exception: ModuleNotFoundError if the engine is not found
 
-    return None
+    Returns:
+        [class]: SqEngineObj
+    """
+    engine_obj = SqEngineObj.get_plugins(engine_name).get(engine_name, None)
+    if not engine_obj:
+        raise ModuleNotFoundError(f"Engine {engine_name} not found")
+
+    if table_name:
+        table_obj = engine_obj.get_plugins(table_name).get(table_name, None)
+    else:
+        table_obj = engine_obj
+
+    if not table_obj:
+        raise ModuleNotFoundError(f"Table {table_name} not found for "
+                                  f"engine {engine_name}")
+    return table_obj
 
 
-__all__ = [get_sqengine]
+__all__ = ['get_sqengine']

--- a/suzieq/engines/base_engine.py
+++ b/suzieq/engines/base_engine.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from suzieq.shared.sq_plugin import SqPlugin
 
 
-class SqEngineObj(ABC):
+class SqEngineObj(SqPlugin, ABC):
     '''Interface class for adding analyzer engine to Suzieq'''
 
     def __init__(self):

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -1,13 +1,16 @@
+from ipaddress import ip_address, ip_network
+
 import pandas as pd
 import numpy as np
+
+import dateparser
+from pandas.core.groupby import DataFrameGroupBy
+
 from suzieq.utils import SchemaForTable, humanize_timestamp, Schema
 from suzieq.engines.base_engine import SqEngineObj
 from suzieq.sqobjects import get_sqobject
 from suzieq.db import get_sqdb_engine
 from suzieq.exceptions import UserQueryError
-import dateparser
-from pandas.core.groupby import DataFrameGroupBy
-from ipaddress import ip_address, ip_network
 
 
 class SqPandasEngine(SqEngineObj):
@@ -20,6 +23,7 @@ class SqPandasEngine(SqEngineObj):
         self._summarize_on_add_list_or_count = []
         self._summarize_on_add_stat = []
         self._summarize_on_perdevice_stat = []
+        self._check_empty_col = 'namespace'
         self._dbeng = get_sqdb_engine(baseobj.ctxt.cfg, baseobj.table, '',
                                       None)
 
@@ -106,7 +110,7 @@ class SqPandasEngine(SqEngineObj):
 
         return addr.apply(lambda a: (
             True if self._get_ipvers(a) == version else False)
-            )
+        )
 
     def get_valid_df(self, table: str, **kwargs) -> pd.DataFrame:
         """The heart of the engine: retrieving the data from the backing store

--- a/suzieq/engines/pandas/network.py
+++ b/suzieq/engines/pandas/network.py
@@ -1,6 +1,6 @@
 from typing import List
 import pandas as pd
-from .engineobj import SqPandasEngine
+from suzieq.engines.pandas.engineobj import SqPandasEngine
 from suzieq.utils import convert_macaddr_format_to_colon
 
 

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -2,7 +2,7 @@ from ipaddress import IPv4Network
 import pandas as pd
 import numpy as np
 
-from .engineobj import SqPandasEngine
+from suzieq.engines.pandas.engineobj import SqPandasEngine
 from suzieq.utils import SchemaForTable, build_query_str, humanize_timestamp
 
 
@@ -18,7 +18,8 @@ class OspfObj(SqPandasEngine):
         columns = kwargs.pop('columns', ['default'])
         state = kwargs.pop('state', '')
         addnl_fields = kwargs.pop('addnl_fields', self.iobj._addnl_fields)
-        addnl_nbr_fields = self.iobj._addnl_nbr_fields
+        addnl_nbr_fields = getattr(
+            self.iobj, '._addnl_nbr_fields', ['state'])
         user_query = kwargs.pop('query_str', '')
         hostname = kwargs.pop('hostname', [])
 
@@ -395,7 +396,7 @@ class OspfObj(SqPandasEngine):
 
         # Fill up a single assert column now indicating pass/fail
         ospf_df['assert'] = ospf_df.apply(lambda x: 'pass'
-                                          if not len(x['assertReason'])
+                                          if len(x['assertReason'] == 0)
                                           else 'fail', axis=1)
 
         result = (

--- a/suzieq/poller/nodes/node.py
+++ b/suzieq/poller/nodes/node.py
@@ -38,7 +38,7 @@ def get_hostsdata_from_hostsfile(hosts_file) -> dict:
         sys.exit(1)
 
     if not os.access(hosts_file, os.R_OK):
-        logger.error("Suzieq inventory file is not readable: {}", hosts_file)
+        logger.error(f"Suzieq inventory file is not readable: {hosts_file}")
         print("ERROR: hosts Suzieq inventory file is not readable: {}",
               hosts_file)
         sys.exit(1)
@@ -48,7 +48,7 @@ def get_hostsdata_from_hostsfile(hosts_file) -> dict:
             data = f.read()
             hostsconf = yaml.safe_load(data)
         except Exception as e:
-            logger.error("Invalid Suzieq inventory file:{}", e)
+            logger.error(f"Invalid Suzieq inventory file:{e}")
             print("Invalid Suzieq inventory file:{}", e)
             sys.exit(1)
 
@@ -557,7 +557,7 @@ class Node(object):
                 self.logger.error(
                     f'Cannot parse version from {self.address}:{self.port}')
 
-    async def _parse_device_type_hostname(self, output, cb_token) -> None:
+    async def _parse_device_type_hostname(self, output, _) -> None:
         devtype = ""
         hostname = None
 
@@ -646,7 +646,7 @@ class Node(object):
             self.set_hostname(hostname)
             self.current_exception = None
 
-    async def _parse_boottime_hostname(self, output, cb_token) -> None:
+    async def _parse_boottime_hostname(self, output, _) -> None:
         """Parse the uptime command output"""
 
         if self.sigend:
@@ -767,7 +767,7 @@ class Node(object):
                 await self._terminate()
                 return
 
-            while (len(tasks) < self.batch_size):
+            while len(tasks) < self.batch_size:
                 try:
                     request = await self._service_queue.get()
                 except asyncio.CancelledError:
@@ -783,7 +783,7 @@ class Node(object):
                     break
 
             if tasks:
-                done, pending = await asyncio.wait(
+                _, pending = await asyncio.wait(
                     tasks, return_when=asyncio.FIRST_COMPLETED)
 
                 tasks = list(pending)
@@ -967,7 +967,7 @@ class Node(object):
             return result
 
         oformat = use.get('format', 'json')
-        if type(cmd) is not list:
+        if not isinstance(cmd, list):
             if use.get('textfsm'):
                 oformat = 'text'
             cmdlist = [cmd]

--- a/suzieq/shared/sq_plugin.py
+++ b/suzieq/shared/sq_plugin.py
@@ -10,7 +10,6 @@ from pkgutil import iter_modules
 from typing import Dict, Type
 
 
-# pylint: disable=too-few-public-methods
 class SqPlugin:
     """SqPlugin is the base common class inherited by all the
     Suzieq plugins
@@ -21,20 +20,18 @@ class SqPlugin:
 
     @classmethod
     def get_plugins(cls,
-                    search_pkg: str = None,
-                    transitive=False) -> Dict[str, Type]:
+                    plugin_name: str = None,
+                    search_pkg: str = None) -> Dict[str, Type]:
         """Discover all the plugins in the search_pkg package, inheriting
         the current base class.
 
         Args:
+            plugin_name (str): The name of a specific plugin to extract
             search_pkg (str): The package where to look for the plugins.
                 Note that if the specified package contains other packages,
                 the function will scan only their content, without accessing
                 to other nested packages and ignoring all the files inside
                 search_pkg.
-            transitive (bool, optional): If False returns a plugin only if
-                it is a direct descendant of the base class.
-                Defaults to False.
 
         Returns:
             Dict[str, Type]: a dictionary containing all
@@ -45,6 +42,7 @@ class SqPlugin:
 
         if not search_pkg:
             search_pkg = '.'.join(cls.__module__.split('.')[:-1])
+
         # Collect the list of packages where to search
         search_path = search_pkg.replace('.', '/')
         packages = [f'{search_pkg}.{m.name}'
@@ -57,24 +55,33 @@ class SqPlugin:
             use_pkg_name = True
 
         for pkg in packages:
+            found_plugin = False
             if use_pkg_name:
                 use_name = pkg.split('.')[-1]
             pspec = find_spec(pkg)
             if pspec and pspec.loader:
-                mfound = [x.split('.')[0] for x in pspec.loader.contents()
-                          if not x.startswith('_')]
+                try:
+                    mfound = [x.split('.')[0] for x in pspec.loader.contents()
+                              if not x.startswith('_') and x.endswith(".py")]
+                except Exception:
+                    mfound = []
                 for minfo in mfound:
                     if not use_pkg_name:
                         use_name = minfo.split('.')[0]
                         mname = f'{pkg}.{use_name}'
                     else:
                         mname = f'{pkg}.{minfo}'
+                    if plugin_name and plugin_name != use_name:
+                        continue
                     mod = import_module(mname)
                     for mbr in getmembers(mod, isclass):
                         if (mbr[1].__module__ == mname
-                           and (transitive or getmro(mbr[1])[1] == cls)
+                           and getmro(mbr[1])[1] == cls
                            and issubclass(mbr[1], cls)
                            and mbr[1] != cls):
                             classes[use_name] = mbr[1]
+                            found_plugin = True
+            if plugin_name and found_plugin:
+                break
 
         return classes

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,0 +1,59 @@
+import pytest
+from suzieq.sqobjects.basicobj import SqObject
+from suzieq.engines.base_engine import SqEngineObj
+from suzieq.sqobjects.vlan import VlanObj
+from suzieq.sqobjects import get_tables, get_sqobject
+from suzieq.engines import get_sqengine
+from suzieq.db import get_sqdb_engine
+from suzieq.exceptions import DBNotFoundError
+
+
+@pytest.mark.plugin
+def test_plugin():
+    """Ensure that we can get the plugins we need correctly
+    """
+
+    # Validate base engine stuff works for sqobjects
+    assert SqObject.get_plugins()
+    assert SqObject.get_plugins('vlan')['vlan'] == VlanObj
+    assert not SqObject.get_plugins('foobar')
+
+    # Validate engine stuff works for engines
+    assert SqEngineObj.get_plugins()
+    assert SqEngineObj.get_plugins('pandas')
+    assert not SqEngineObj.get_plugins('foobar')
+
+    # Now validate the APIs
+    assert get_tables()
+    assert get_sqobject('vlan') == VlanObj
+    try:
+        get_sqobject('foobar')
+        assert False
+    except ModuleNotFoundError:
+        pass
+
+    assert get_sqengine('pandas', '')
+    try:
+        get_sqengine('foobar', '')
+        assert False
+    except ModuleNotFoundError:
+        pass
+
+    assert get_sqengine('pandas', 'vlan')
+    try:
+        get_sqengine('pandas', 'foobar')
+        assert False
+    except ModuleNotFoundError:
+        pass
+
+    assert get_sqdb_engine({}, 'foobar', 'parquet', None)
+    try:
+        get_sqdb_engine({'foobar': 'parquet'}, 'foobar', None, None)
+    except DBNotFoundError:
+        assert False, 'parquet DB engine not found in config'
+
+    try:
+        get_sqdb_engine({'db': {'foobar': 'bar'}}, 'foobar', None, None)
+        assert False
+    except DBNotFoundError:
+        pass


### PR DESCRIPTION
…lugin

SqPlugin has a class method called get_plugins that returns all the
plugins associated with a plugin type. However this required an additional
parameter called search_pkg which was not really necessary. It can be
derived automatically from the module name. This patch does that.

Additionally, the name of the plugin returned when the plugin was in
a subdir as opposed to the same dir was not correct. This patch fixes
that as well.

The method signature isn't changed, and so if a caller wants to specify
the search path that still works

Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>