### PR TITLE
Fix unexpected pager enabling

### DIFF
--- a/suzieq/cli/sqcmds/context_commands.py
+++ b/suzieq/cli/sqcmds/context_commands.py
@@ -29,7 +29,7 @@ from termcolor import cprint, colored
     description="Set the data directory for the command"
 )
 def set_ctxt(
-        pager: str = 'on',
+        pager: str = "",
         hostname: typing.List[str] = [],
         start_time: str = "",
         end_time: str = "",


### PR DESCRIPTION
Since the default value for pager on the "set" command was `on`, whenever a set commands is called in the CLI, it enables the pager. This PR fixes this problem, setting the default value to blank.