### PR TITLE
Route origin

### DIFF
--- a/suzieq/cli/sqcmds/RouteCmd.py
+++ b/suzieq/cli/sqcmds/RouteCmd.py
@@ -57,11 +57,13 @@ class RouteCmd(SqCommand):
 
     @command("show")
     @argument("prefix", description="Prefix, in quotes, to filter show on")
+    @argument("origin",
+              description="Shows all devices which generated a route")
     @argument("vrf", description="VRF to qualify")
     @argument("protocol", description="routing protocol to qualify")
     @argument("prefixlen", description="must be of the form "
               "[<|<=|>=|>|!] length")
-    def show(self, prefix: str = "", vrf: str = '', protocol: str = "",
+    def show(self, prefix: str = "", origin: str = '', vrf: str = '', protocol: str = "",
              prefixlen: str = ""):
         """Show Routing table info
         """
@@ -80,6 +82,7 @@ class RouteCmd(SqCommand):
                                 hostname=self.hostname,
                                 prefix=prefix.split(),
                                 vrf=vrf.split(),
+                                origin=origin.split(),
                                 protocol=protocol.split(),
                                 columns=self.columns,
                                 namespace=self.namespace,

--- a/suzieq/engines/pandas/bgp.py
+++ b/suzieq/engines/pandas/bgp.py
@@ -27,7 +27,7 @@ class BgpObj(SqPandasEngine):
         fields = sch.get_display_fields(columns)
 
         for col in ['peerIP', 'updateSource', 'state', 'namespace', 'vrf',
-                    'peer', 'hostname']:
+                    'peer', 'hostname', 'afi', 'safi']:
             if col not in fields:
                 addnl_fields.append(col)
                 drop_cols.append(col)

--- a/suzieq/sqobjects/routes.py
+++ b/suzieq/sqobjects/routes.py
@@ -9,10 +9,13 @@ class RoutesObj(SqObject):
         self._addnl_filter = 'metric != 4278198272'
         self._valid_get_args = ['namespace', 'hostname', 'columns', 'prefix',
                                 'vrf', 'protocol', 'prefixlen', 'ipvers',
-                                'add_filter', 'address', 'query_str']
+                                'add_filter', 'address', 'query_str', 'origin']
         self._unique_def_column = ['prefix']
 
     def validate_get_input(self, **kwargs):
+        if kwargs.get('prefix', []) and kwargs.get('origin', []):
+            raise AttributeError("Cannot specify origin and prefix together")
+
         if kwargs.get('prefixlen', ''):
             p_match = re.fullmatch(r'([<>][=]?|[!])?[ ]?([0-9]+)',
                                    kwargs['prefixlen'])

--- a/suzieq/sqobjects/routes.py
+++ b/suzieq/sqobjects/routes.py
@@ -31,6 +31,12 @@ class RoutesObj(SqObject):
                 raise ValueError("Invalid prefixlen: "
                                  "value should be between 0 and 128")
 
+        if kwargs.get('origin', []):
+            for item in kwargs['origin']:
+                if "/" in item:
+                    raise ValueError("Invalid origin addresses: accepts only "
+                                     "IPs without network")
+
         return super().validate_get_input(**kwargs)
 
     def lpm(self, **kwargs):

--- a/suzieq/sqobjects/routes.py
+++ b/suzieq/sqobjects/routes.py
@@ -31,11 +31,6 @@ class RoutesObj(SqObject):
                 raise ValueError("Invalid prefixlen: "
                                  "value should be between 0 and 128")
 
-        if kwargs.get('origin', []):
-            for item in kwargs['origin']:
-                if "/" in item:
-                    raise ValueError("Invalid origin addresses: accepts only "
-                                     "IPs without network")
 
         return super().validate_get_input(**kwargs)
 


### PR DESCRIPTION
This PR aims to fix [issue 166](https://github.com/netenglabs/suzieq/issues/116).
I added the option `origin` to `route` command. This option accepts a list of ip networks (either ipv6 or ipv4) and returns all the routes generated from these ip addresses.
The steps to retrieve this information are:
1. retrieve all "namespace, hostname" with an interface in "origin" network
2. retrieve bgp and ospf devices which match the previous "namespace, hostname" list
3. filter the routes with this "namespace, hostname" present in bgp and/or ospf
(?) 4. Set prefix=origin and run the prefix on this filtered dataset

Questions:
- I saw a problem in which `bgp.get` was returning also 'afi' and 'safi' even when not requested. This error was not visible from the cli because the file command.py was filtering these fields. I saw that `pandas/network.py` uses `bgp.get` but I don't see any problems after my modification

TODO:
- add tests for `route show origin=...`
- test with REST