### PR TITLE
Speed up test pipeline

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,26 +1,88 @@
 name: integration-tests
-on: [push, pull_request]
+on: [pull_request]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.7, 3.8]
-
+        group: [1, 2, 3, 4]
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install --upgrade pip
-        pip install poetry
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}
+
     - name: Install dependencies
-      run: |
-        poetry install -v
-        cp build/suzieq-cfg-travis.yml suzieq-cfg.yml
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root
+
+    - name: Install library
+      run: poetry install --no-interaction
+
+    - name: Set up suzieq config
+      run: cp build/suzieq-cfg-travis.yml suzieq-cfg.yml
+
+    - name: Install pytest split
+      run: poetry run pip install pytest-split
+
+    - name: Prepare dir for caching durations
+      run: mkdir test_durations
+
+    - name: Get durations from cache
+      uses: actions/cache@v2
+      with:
+        path: test_durations
+        # artificial cache miss to always save at the end of the job and avoid out of sync test runs
+        key: test-durations-split-${{ github.run_id }}-${{ github.run_number}}-${{ matrix.group }}-${{ matrix.python-version }}
+        restore-keys: |
+          test-durations
+
     - name: pytest
-      run: |
-        poetry run pytest
+      run: poetry run pytest --splits 4 --group ${{ matrix.group }} --store-durations --durations-path test_durations/.test_durations_${{ matrix.python-version }}
+
+    - name: Upload partial durations
+      uses: actions/upload-artifact@v2
+      with:
+        retention-days: 1
+        name: duration-chunk-${{ matrix.group }}-python-${{ matrix.python-version }}
+        path: test_durations
+
+  update_durations:
+    name: Merge and update test durations
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get durations from cache
+        uses: actions/cache@v2
+        with:
+          path: test_durations
+          # artificial cache miss to always save at the end of the job and avoid out of sync test runs
+          key: test-durations-${{ github.sha }}
+          restore-keys: |
+            test-durations
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Merge test durations
+        run: python3 tests/utilities/merge_test_durations_ci.py

--- a/tests/integration/sqcmds/cumulus-samples/badquery.yml
+++ b/tests/integration/sqcmds/cumulus-samples/badquery.yml
@@ -4,226 +4,226 @@ tests:
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: address badquery cumulus
+  marks: address show badquery cumulus
 - command: arpnd show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: arpnd badquery cumulus
+  marks: arpnd show badquery cumulus
 - command: bgp show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: bgp badquery cumulus
+  marks: bgp show badquery cumulus
 - command: device show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''mtu'' is not defined"}]'
-  marks: device badquery cumulus
+  marks: device show badquery cumulus
 - command: evpnVni show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: evpnVni badquery cumulus
+  marks: evpnVni show badquery cumulus
 - command: lldp show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: lldp badquery cumulus
+  marks: lldp show badquery cumulus
 - command: interface show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: interface badquery cumulus
+  marks: interface show badquery cumulus
 - command: mac show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: mac badquery cumulus
+  marks: mac badquery show cumulus
 - command: mlag show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: mlag badquery cumulus
+  marks: mlag show badquery cumulus
 - command: ospf show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: ospf badquery cumulus
+  marks: ospf show badquery cumulus
 - command: route show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: name ''vendor'' is not defined"}]'
-  marks: route badquery cumulus
+  marks: route show badquery cumulus
 - command: vlan show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: vlan badquery cumulus
+  marks: vlan show badquery cumulus
 - command: path show --src='172.16.1.101' --dest='172.16.3.202' --namespace='ospf-ibgp'
     --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
-  marks: path badquery cumulus
+  marks: path show badquery cumulus
   output: '[]'
 - command: topology show --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
-  marks: topology badquery cumulus
+  marks: topology show badquery cumulus
   output: '[]'
 - command: address summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: address badquery cumulus
+  marks: address summarize badquery cumulus
 - command: arpnd summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: arpnd badquery cumulus
+  marks: arpnd summarize badquery cumulus
 - command: bgp summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '{"error": {"0": "ERROR: UserQueryError: name ''vendor'' is not defined"}}'
-  marks: bgp badquery cumulus
+  marks: bgp summarize badquery cumulus
 - command: device summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''mtu'' is not defined"}]'
-  marks: device badquery cumulus
+  marks: device summarize badquery cumulus
 - command: evpnVni summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: evpnVni badquery cumulus
+  marks: evpnVni summarize badquery cumulus
 - command: lldp summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: lldp badquery cumulus
+  marks: lldp summarize badquery cumulus
 - command: interface summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: interface badquery cumulus
+  marks: interface summarize badquery cumulus
 - command: mac summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: mac badquery cumulus
+  marks: mac summarize badquery cumulus
 - command: mlag summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: mlag badquery cumulus
+  marks: mlag summarize badquery cumulus
 - command: ospf summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '{"error": {"0": "ERROR: UserQueryError: name ''vendor'' is not defined"}}'
-  marks: ospf badquery cumulus
+  marks: ospf summarize badquery cumulus
 - command: route summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '{"error": {"0": "ERROR: name ''vendor'' is not defined"}}'
-  marks: route badquery cumulus
+  marks: route summarize badquery cumulus
 - command: vlan summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: vlan badquery cumulus
+  marks: vlan summarize badquery cumulus
 - command: path summarize --src='172.16.1.101' --dest='172.16.3.202' --namespace='ospf-ibgp'
     --query-str='vendor == "Cisco" and mtu==1500' --format=json
   data-directory: tests/data/multidc/parquet-out/
-  marks: path badquery cumulus
+  marks: path summarize badquery cumulus
   output: '[]'
 - command: topology summarize --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
-  marks: topology badquery cumulus
+  marks: topology summarize badquery cumulus
   output: '[]'
 - command: address unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: address badquery cumulus
+  marks: address unique badquery cumulus
 - command: arpnd unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: arpnd badquery cumulus
+  marks: arpnd unique badquery cumulus
 - command: bgp unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: bgp badquery cumulus
+  marks: bgp unique badquery cumulus
 - command: device unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''mtu'' is not defined"}]'
-  marks: device badquery cumulus
+  marks: device unique badquery cumulus
 - command: evpnVni unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: evpnVni badquery cumulus
+  marks: evpnVni unique badquery cumulus
 - command: lldp unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: lldp badquery cumulus
+  marks: lldp unique badquery cumulus
 - command: interface unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: interface badquery cumulus
+  marks: interface unique badquery cumulus
 - command: mac unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: mac badquery cumulus
+  marks: mac unique badquery cumulus
 - command: mlag unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: mlag badquery cumulus
+  marks: mlag unique badquery cumulus
 - command: ospf unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: ospf badquery cumulus
+  marks: ospf unique badquery cumulus
 - command: route unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: name ''vendor'' is not defined"}]'
-  marks: route badquery cumulus
+  marks: route unique badquery cumulus
 - command: vlan unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: UserQueryError: name ''vendor'' is not defined"}]'
-  marks: vlan badquery cumulus
+  marks: vlan unique badquery cumulus
 - command: path unique --src='172.16.1.101' --dest='172.16.3.202' --namespace='ospf-ibgp'
     --query-str='vendor == "Cisco" and mtu==1500' --format=json --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
-  marks: path badquery cumulus
+  marks: path unique badquery cumulus
   output: '[]'
 - command: topology unique --query-str='vendor == "Cisco" and mtu==1500' --format=json
     --columns='hostname'
   data-directory: tests/data/multidc/parquet-out/
-  marks: topology badquery cumulus
+  marks: topology unique badquery cumulus
   output: '[]'
 - command: route lpm --address='172.16.1.101' --query-str='vendor == "Cisco" and mtu==1500'
     --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: name ''vendor'' is not defined"}]'
-  marks: route badquery cumulus
+  marks: route lpm badquery cumulus

--- a/tests/integration/sqcmds/cumulus-samples/path.yml
+++ b/tests/integration/sqcmds/cumulus-samples/path.yml
@@ -541,6 +541,7 @@ tests:
     "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616352404640}]'
 - command: path show --src=172.16.1.101 --dest=172.16.253.1 --namespace=dual-evpn
     --format=json
+  marks: path show cumulus
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
@@ -799,7 +800,6 @@ tests:
       "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
       1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
       "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003}]'
-  marks: path show cumulus
 - command: path summarize --dest=172.16.2.104 --src=172.16.1.101 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/multidc/parquet-out/
@@ -811,6 +811,7 @@ tests:
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"error": "ERROR: Must specify namespace to run the trace in"}]'
+  marks: path show cumulus
 - command: path show --dest=172.16.4.104 --src=172.16.1.101 --namespace=dual-bgp --format=json
   data-directory: tests/data/basic_dual_bgp/parquet-out/
   error:
@@ -1662,8 +1663,7 @@ tests:
       "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
       1616644822254}]'
   marks: path show cumulus bridged
-- command: path show --src=172.16.1.101 --dest=172.16.253.1 --namespace=ospf-ibgp
-    --format=json
+- command: path show --src=172.16.1.101 --dest=172.16.253.1 --namespace=ospf-ibgp --format=json
   data-directory: tests/data/multidc/parquet-out/
   error:
     error: '[{"pathid": 1, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",

--- a/tests/integration/sqcmds/cumulus-samples/top.yml
+++ b/tests/integration/sqcmds/cumulus-samples/top.yml
@@ -338,7 +338,7 @@ tests:
     1616681064000, "timestamp": 1616681581441}]'
 - command: evpnVni top --what=vni --format=json
   data-directory: tests/data/multidc/parquet-out/
-  mark: evpnVni top
+  marks: evpnVni top
   output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 104001, "type":
     "L3", "vlan": 0, "state": "down", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0,
     "priVtepIp": "0.0.0.0", "secVtepIp": "", "timestamp": 1616644822033}, {"namespace":
@@ -355,7 +355,7 @@ tests:
     "", "timestamp": 1616644822169}]'
 - command: network top --what=deviceCnt --format=json
   data-directory: tests/data/multidc/parquet-out/
-  mark: network top
+  marks: network top
   output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
     0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
     1639161298729}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt": 18,
@@ -365,28 +365,28 @@ tests:
     false, "hasMlag": false, "lastUpdate": 1639161366022}]'
 - command: bgp top --what=numChanges --count=1 --format=json
   data-directory: tests/data/multidc/parquet-out/
-  mark: bgp top
+  marks: bgp top
   output: '[{"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer":
     "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
     "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
     1, "estdTime": 1616644608000, "timestamp": 1616644822492}]'
 - command: ospf top --what=numChanges --count=1 --format=json
   data-directory: tests/data/multidc/parquet-out/
-  mark: ospf top
+  marks: ospf top
   output: '[{"namespace": "ospf-single", "hostname": "spine02", "vrf": "default",
     "ifname": "swp6", "peerHostname": "exit01", "area": "0.0.0.0", "ifState": "up",
     "nbrCount": 1, "adjState": "full", "peerIP": "10.0.0.101", "numChanges": 5.0,
     "lastChangeTime": 1616352030000, "timestamp": 1616352403216}]'
 - command: interface top --what=numChanges --count=1 --format=json
   data-directory: tests/data/multidc/parquet-out/
-  mark: interface top
+  marks: interface top
   output: '[{"namespace": "ospf-single", "hostname": "server102", "ifname": "eth0",
     "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
     "master": "", "ipAddressList": ["10.255.2.68/24"], "ip6AddressList": [], "numChanges":
     0, "timestamp": 1616352402674}]'
 - command: network top --what=deviceCnt --count=1 --format=json
   data-directory: tests/data/multidc/parquet-out/
-  mark: network top
+  marks: network top
   output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
     0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
     1639161298729}]'

--- a/tests/integration/sqcmds/eos-samples/interface.yml
+++ b/tests/integration/sqcmds/eos-samples/interface.yml
@@ -1015,7 +1015,7 @@ tests:
     "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176024}]'
 - command: interface show --type='vrf vlan' --hostname='leaf01 spine01' --format=json
   data-directory: tests/data/eos/parquet-out/
-  marks: interface top eos
+  marks: interface show eos
   output: '[{"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan1006", "state":
     "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006, "master":
     "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":

--- a/tests/integration/sqcmds/eos-samples/route.yml
+++ b/tests/integration/sqcmds/eos-samples/route.yml
@@ -1271,7 +1271,7 @@ tests:
     28}, {"prefixlen": 24, "numRows": 78}, {"prefixlen": 32, "numRows": 136}]'
 - command: route show --prefix='172.16.1.101' --format=json
   data-directory: tests/data/eos/parquet-out/
-  marks: route unique eos
+  marks: route show eos
   output: '[{"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix":
     "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
     "protocol": "ibgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",

--- a/tests/integration/sqcmds/nxos-samples/interface.yml
+++ b/tests/integration/sqcmds/nxos-samples/interface.yml
@@ -2314,7 +2314,7 @@ tests:
     [], "ip6AddressList": [], "timestamp": 1619275260177}]'
 - command: interface show --type='vrf vlan' --hostname='leaf01 spine01' --format=json
   data-directory: tests/data/nxos/parquet-out/
-  marks: interface top nxos
+  marks: interface show nxos
   output: '[{"namespace": "nxos", "hostname": "leaf01", "ifname": "default", "state":
     "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":

--- a/tests/integration/sqcmds/nxos-samples/path.yml
+++ b/tests/integration/sqcmds/nxos-samples/path.yml
@@ -568,7 +568,7 @@ tests:
     {"nxos": 1500}, {"nxos": false}, {"nxos": false}]'
 - command: path unique --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=nxos
   data-directory: tests/data/nxos/parquet-out/
-  marks: path show nxos
+  marks: path unique nxos
   output: '[{"hostname": "leaf01", "numRows": 4}, {"hostname": "leaf02", "numRows":
     4}, {"hostname": "leaf03", "numRows": 4}, {"hostname": "leaf04", "numRows": 4},
     {"hostname": "server101", "numRows": 8}, {"hostname": "server302", "numRows":
@@ -577,7 +577,7 @@ tests:
 - command: path unique --dest=172.16.3.202 --src=172.16.1.101 --format=json --count=True
     --namespace=nxos
   data-directory: tests/data/nxos/parquet-out/
-  marks: path show nxos
+  marks: path unique nxos
   output: '[{"hostname": "leaf01", "numRows": 4}, {"hostname": "leaf02", "numRows":
     4}, {"hostname": "leaf03", "numRows": 4}, {"hostname": "leaf04", "numRows": 4},
     {"hostname": "server101", "numRows": 8}, {"hostname": "server302", "numRows":

--- a/tests/integration/sqcmds/nxos-samples/route.yml
+++ b/tests/integration/sqcmds/nxos-samples/route.yml
@@ -5353,7 +5353,7 @@ tests:
     30}, {"prefixlen": 31}, {"prefixlen": 32}, {"prefixlen": 128}]'
 - command: route show --prefix='172.16.1.101' --format=json
   data-directory: tests/data/nxos/parquet-out/
-  marks: route unique nxos
+  marks: route show nxos
   output: '[{"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix":
     "172.16.1.101/32", "nexthopIps": ["10.0.0.112"], "oifs": ["_nexthopVrf:default"],
     "protocol": "bgp", "source": "", "preference": 200, "ipvers": 4, "action": "forward",

--- a/tests/integration/test_parsing_arpnd.py
+++ b/tests/integration/test_parsing_arpnd.py
@@ -22,7 +22,7 @@ def validate_arpnd_tbl(df: pd.DataFrame):
 
 
 @ pytest.mark.parsing
-@ pytest.mark.lldp
+@ pytest.mark.arpnd
 @ pytest.mark.parametrize('table', ['arpnd'])
 @ pytest.mark.parametrize('datadir', DATADIR)
 def test_arpnd_parsing(table, datadir, get_table_data):

--- a/tests/integration/test_sqcmds.py
+++ b/tests/integration/test_sqcmds.py
@@ -18,6 +18,7 @@ from .utils import assert_df_equal
 verbs = ['show', 'summarize', 'describe', 'help']
 
 
+@pytest.mark.sqcmds
 @pytest.mark.slow
 @pytest.mark.parametrize("command",  [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -48,7 +49,7 @@ def _test_command(cmd, verb, arg, filter=None):
     assert isinstance(s, int)
     return s
 
-
+@pytest.mark.sqcmds
 def test_summary_exception(setup_nubia):
     s = None
     with pytest.raises(AttributeError):
@@ -56,6 +57,7 @@ def test_summary_exception(setup_nubia):
     assert s is None
 
 
+@pytest.mark.sqcmds
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
     for cmd in cli_commands])
@@ -65,6 +67,7 @@ def test_all_columns(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -76,6 +79,7 @@ def test_hostname_show_filter(setup_nubia, get_cmd_object_dict, cmd):
         assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -86,6 +90,7 @@ def test_engine_show_filter(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -96,6 +101,7 @@ def test_namespace_show_filter(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -105,6 +111,7 @@ def test_view_show_filter(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -115,6 +122,7 @@ def test_start_time_show_filter(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.fast
 @pytest.mark.parametrize("cmd", [
@@ -127,6 +135,7 @@ def test_columns_show_filter(setup_nubia, get_cmd_object_dict, cmd):
         assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -136,6 +145,7 @@ def test_bad_show_hostname_filter(setup_nubia, get_cmd_object_dict, cmd):
     _ = _test_bad_show_filter(get_cmd_object_dict[cmd], filter)
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -145,6 +155,7 @@ def test_bad_show_engine_filter(setup_nubia, get_cmd_object_dict, cmd):
     _ = _test_bad_show_filter_w_assert(get_cmd_object_dict[cmd], filter)
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -156,6 +167,7 @@ def test_bad_start_time_filter(setup_nubia, get_cmd_object_dict, cmd):
 
 # TODO
 # this is just like hostname filtering
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize("cmd", [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -191,6 +203,7 @@ good_filters = [{'hostname': ['leaf01']}]
 # TODO?
 #  these only check good cases, I'm assuming the bad cases work the same
 #  as the rest of the filtering, and that is too messy to duplicate right now
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize('cmd', [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -201,6 +214,7 @@ def test_context_filtering(setup_nubia, get_cmd_object_dict, cmd):
         assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize('cmd', [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -213,6 +227,7 @@ def test_context_namespace_filtering(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.filter
 @pytest.mark.parametrize('cmd', [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -222,6 +237,7 @@ def test_context_engine_filtering(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.fast
 @pytest.mark.parametrize('cmd', [
     pytest.param(cmd, marks=MarkDecorator(Mark(cmd, [], {})))
@@ -233,12 +249,14 @@ def test_context_start_time_filtering(setup_nubia, get_cmd_object_dict, cmd):
     assert s == 0
 
 
+@pytest.mark.sqcmds
 @pytest.mark.parametrize('table', tables)
 def test_table_describe(setup_nubia, table):
     out = _test_command('TableCmd', 'describe', {"table": table})
     assert out == 0
 
 
+@pytest.mark.sqcmds
 @ pytest.mark.parametrize('table',
                           [pytest.param(
                               x,
@@ -293,6 +311,7 @@ def test_sqcmds_regex_hostname(table, datadir):
                                                      'exit01', 'exit02'])
 
 
+@pytest.mark.sqcmds
 @ pytest.mark.parametrize('table',
                           [pytest.param(
                               x,

--- a/tests/utilities/merge_test_durations_ci.py
+++ b/tests/utilities/merge_test_durations_ci.py
@@ -1,0 +1,45 @@
+import json
+import re
+from pathlib import Path
+
+
+def merge_durations(duration_files: list, output_suffix: str):
+    '''Merge duration files listed in the input arg in an output
+    file withthe given suffix
+    '''
+    outname = f'test_durations/.test_durations_{output_suffix}'
+    durations_path = Path(outname)
+    try:
+        previous_durations = json.loads(durations_path.read_text())
+    except FileNotFoundError:
+        previous_durations = {}
+    new_durations = previous_durations.copy()
+
+    for path in duration_files:
+        d = Path(path)
+        durations = json.loads(d.read_text())
+        new_durations.update(
+            {
+                name: duration
+                for (name, duration) in durations.items()
+                if previous_durations.get(name) != duration
+            }
+        )
+
+    durations_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(outname, 'w') as o:
+        o.writelines(json.dumps(new_durations))
+
+
+if __name__ == '__main__':
+    regex = re.compile(r'.*python-((\d+\.?)+).*')
+    files = Path('.').glob('duration-chunk-*/*')
+    versions = {}
+    for f in files:
+        m = regex.match(str(f))
+        if m:
+            versions[m.group(1)] = [m.group(0)] + versions.get(m.group(1), [])
+
+    for py_vers, file_list in versions.items():
+        merge_durations(file_list, py_vers)


### PR DESCRIPTION
This PR is a major rework of the test pipeline aimed at speeding up from 30 min runs to < 10 mins. The speedup is achieved by splitting up pytest in multiple parallel jobs and leveraging the build matrix strategy of github actions.

Additionally the pipeline is run only on PRs, is not run anymore on every push event.

The major bottleneck in tests are the sqcmds integration tests and therefore have been split in several pieces. Parsing tests, rest tests and other are fairly quick.

To speed up the tests, pytest-split is used to generate the test duration files on which is based the splitting in order to obtain chunks that run approximately for the same duration. The test duration is stored using the github action's cache since its size is ~2 MB and would only add size to the repo.

Each job runs a chunk and generate a duration file which store the duration of each executed test. Duration are then uploaded as artifact so that they can be used in the final job that merges all the duration in a single file. The artifacts expire after 1 day since they are useless after the job run.

Currently tests are split into 4 chunk which are executed for both 3.7 and 3.8 versions of python. It is possible to further reduce the run time increasing the number of chunks.