### PR TITLE
Fix poller inventory construction

### DIFF
--- a/suzieq/poller/worker/inventory/inventory.py
+++ b/suzieq/poller/worker/inventory/inventory.py
@@ -143,7 +143,7 @@ class Inventory(SqPlugin):
             else:
                 logger.info(f"Added node {newnode.hostname}:{newnode.port}")
 
-            nodes_list.update({self.get_node_key(new_node): newnode})
+            nodes_list.update({self.get_node_key(newnode): newnode})
 
         return nodes_list
 


### PR DESCRIPTION
When the poller builds the inventory all the nodes override the same record of the inventory. This PR fixes this problem due to a typo.