### PR TITLE
Fix handling of query-str with double quotes

### DIFF
--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -87,7 +87,7 @@ class SqCommand(SqPlugin):
             # This happens because nubia strips off the trailing quote
             # if not followed by a blank
             query_str += '"'
-        if query_str.count("'") % 2 != 0:
+        elif query_str.count("'") % 2 != 0:
             # This happens because nubia strips off the trailing quote
             # if not followed by a blank
             query_str += "'"

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -87,6 +87,10 @@ class SqCommand(SqPlugin):
             # This happens because nubia strips off the trailing quote
             # if not followed by a blank
             query_str += '"'
+        if query_str.count("'") % 2 != 0:
+            # This happens because nubia strips off the trailing quote
+            # if not followed by a blank
+            query_str += "'"
         self.query_str = query_str.strip()
 
         if not isinstance(namespace, str):

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -80,9 +80,6 @@ class SqPandasEngine(SqEngineObj):
             pd.DataFrame: dataframe post query
         """
         if query_str:
-            if query_str.startswith('"') and query_str.endswith('"'):
-                query_str = query_str[1:-1]
-
             try:
                 df = df.query(query_str).reset_index(drop=True)
             except Exception as ex:


### PR DESCRIPTION
This PR fixed #505 adding a workaround for a known behavior of Nubia which strips the trailing single/double quote in case is the last character of the query string.

It also removes unused code in `engineobj` since double quotes are already stripped when the string gets there.