### PR TITLE
Fix #476: Do not split AFI/SAFI more than once

### DIFF
--- a/suzieq/poller/worker/services/bgp.py
+++ b/suzieq/poller/worker/services/bgp.py
@@ -117,7 +117,7 @@ class BgpService(Service):
             afistr = (afistr
                       .replace('inet-vpn', 'vpnv4')
                       .replace('inet6-vpn', 'vpnv6')
-                      .replace('-', ' ')
+                      .replace('-', ' ', 1)
                       .replace('inet6', 'ipv6')
                       .replace('inet', 'ipv4')
                       .replace('flow', 'flowspec')


### PR DESCRIPTION
In Junos, when a BGP session has an AFI/SAFI string such as
inet-labeled-unicast, the code crashes because it doesn't expect to
see anything but a single AFI word and a single SAFI word.

This fix hndles the bug caused by this misconception.

Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>