### PR TITLE
Poller debug mode and worker and coalescer log in stdout

### DIFF
--- a/suzieq/poller/controller/controller.py
+++ b/suzieq/poller/controller/controller.py
@@ -56,6 +56,10 @@ class Controller:
         #                    inventory from a source
         self._run_once = args.run_once
 
+        # If the debug mode is active we need to run the controller only once
+        if args.debug:
+            self._run_once = 'debug'
+
         self._input_dir = args.input_dir
         if self._input_dir:
             self._run_once = 'input-dir'
@@ -103,6 +107,7 @@ class Controller:
 
         manager_args = {'config': sq_get_config_file(args.config),
                         'config-dict': config_data,
+                        'debug': args.debug,
                         'input-dir': self._input_dir,
                         'exclude-services': args.exclude_services,
                         'no-coalescer': self._no_coalescer,

--- a/suzieq/poller/controller/controller.py
+++ b/suzieq/poller/controller/controller.py
@@ -108,6 +108,9 @@ class Controller:
                         'no-coalescer': self._no_coalescer,
                         'output-dir': args.output_dir,
                         'outputs': args.outputs,
+                        # We are intentionally passing the run_once argument
+                        # since we do not want to give internal values as
+                        # arguments of the poller workers
                         'run-once': args.run_once,
                         'service-only': args.service_only,
                         'ssh-config-file': args.ssh_config_file,

--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -106,14 +106,14 @@ class StaticManager(Manager, InventoryAsyncPlugin):
         # and only after all terminated, it is possible to restart them with
         # the new inventory
         pollers_to_launch = []
-        inventory_len = len(inventory_chunks)
-        if inventory_len != self._workers_count:
+        n_chunks = len(inventory_chunks)
+        if n_chunks != self._workers_count:
             raise PollingError(
                 'The number of chunks is different than the number of workers'
             )
 
         if not self._active_chunks:
-            pollers_to_launch = [*range(inventory_len)]
+            pollers_to_launch = [*range(n_chunks)]
         else:
             for i, chunk in enumerate(inventory_chunks):
                 if chunk != self._active_chunks[i]:
@@ -134,14 +134,23 @@ class StaticManager(Manager, InventoryAsyncPlugin):
             await asyncio.gather(*tasks)
 
             # Launch all the pollers we need to launch
-            launch_tasks = [self._launch_poller(i) for i in pollers_to_launch]
-            res = await asyncio.gather(*launch_tasks, return_exceptions=True)
-            # Check if there are exceptions
-            for r in res:
-                if r is not None and isinstance(r, Exception):
-                    raise r
-
-            self._active_chunks = copy.deepcopy(inventory_chunks)
+            # If the mode is debug we do not need to launch the pollers
+            if self._run_once != 'debug':
+                launch_tasks = [self._launch_poller(i)
+                                for i in pollers_to_launch]
+                res = await asyncio.gather(
+                    *launch_tasks, return_exceptions=True)
+                # Check if there are exceptions
+                for r in res:
+                    if r is not None and isinstance(r, Exception):
+                        raise r
+                # Copy the active inventory chunks in order to be able
+                # to detect any following modifications
+                self._active_chunks = copy.deepcopy(inventory_chunks)
+            else:
+                # When the debug mode is enabled print the instructions to
+                # manually launch the workers
+                self._print_poller_launch_instructions(n_chunks)
             self._poller_tasks_ready.set()
 
     async def launch_with_dir(self):
@@ -307,6 +316,29 @@ class StaticManager(Manager, InventoryAsyncPlugin):
         if not process:
             raise PollingError('Unable to start the poller process')
         self._waiting_workers[poller_id] = process
+
+    def _print_poller_launch_instructions(self, n_chunks: int):
+        """Print the commands to execute in order to manually launch
+        the poller workers for debugging purpose.
+
+        Args:
+            n_chunks (int): the number of chunks the inventory is splitted into
+        """
+
+        print(f'{n_chunks} inventory chunks generated, you can '
+              'now manually start the workers with the following '
+              'commands:')
+
+        for i in range(n_chunks):
+            print()  # Print an empty line
+            env_to_print = ['SQ_CONTROLLER_POLLER_CRED',
+                            'SQ_INVENTORY_PATH']
+            for e in env_to_print:
+                print(f'export {e}={os.environ[e]}')
+            sq_dir = get_sq_install_dir()
+            print(
+                f'python {sq_dir}/poller/worker/sq_worker.py --worker-id {i}'
+            )
 
     async def _stop_poller(self, poller_id: int):
         """Kill the poller with the given id. The function first calls a

--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -53,6 +53,10 @@ class StaticManager(Manager, InventoryAsyncPlugin):
         self._run_once = config_data.get('run-once', None)
         self._no_coalescer = config_data.get('no-coalescer', False)
 
+        # If the debug mode is active we need to set run_once
+        if config_data.get('debug'):
+            self._run_once = 'debug'
+
         if not self._no_coalescer:
             self._coalescer_launcher = CoalescerLauncher(
                 config_data['config'],

--- a/suzieq/poller/controller/utils/proc_utils.py
+++ b/suzieq/poller/controller/utils/proc_utils.py
@@ -1,0 +1,32 @@
+import asyncio
+from asyncio.subprocess import Process
+
+
+async def monitor_process(process: Process, label: str):
+    """Wait and monitor the process given as input printing the stdout and
+    stderr content
+
+    Args:
+        process (Process): the process to wait and monitor
+        label (str): the label identifying the process
+    """
+    stdout_read = asyncio.create_task(process.stdout.readline())
+    stderr_read = asyncio.create_task(process.stderr.readline())
+    tasks = [stdout_read, stderr_read]
+    while tasks:
+        done, pending = await asyncio.wait(
+            tasks,
+            return_when=asyncio.FIRST_COMPLETED
+        )
+        tasks = list(pending)
+        for d in done:
+            if d.result():
+                print(f'[{label}]: {d.result().decode()[:-1]}')
+                if d == stdout_read:
+                    stdout_read = asyncio.create_task(
+                        process.stdout.readline())
+                    tasks.append(stdout_read)
+                else:
+                    stderr_read = asyncio.create_task(
+                        process.stderr.readline())
+                    tasks.append(stderr_read)

--- a/suzieq/poller/sq_poller.py
+++ b/suzieq/poller/sq_poller.py
@@ -83,6 +83,12 @@ def controller_main():
     )
 
     parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Build the node list and exit without polling the nodes'
+    )
+
+    parser.add_argument(
         '-x',
         '--exclude-services',
         type=str,
@@ -117,15 +123,13 @@ def controller_main():
     parser.add_argument(
         '--run-once',
         type=str,
-        choices=['gather', 'process', 'update', 'debug'],
+        choices=['gather', 'process', 'update'],
         help=('''The poller do not run forever, three modes are available:
         (1) gather: store the output as it has been collected,
         (2) process: performs some processing on the data.
         Both cases store the results in a plain output file,
         one for each service, and exit.
-        (3) update: poll the nodes only once, write the result and stop
-        (4) debug: build the device list and exit without polling
-        the nodes.''')
+        (3) update: poll the nodes only once, write the result and stop''')
     )
 
     parser.add_argument(
@@ -160,7 +164,7 @@ def controller_main():
         '-V',
         '--version',
         action='store_true',
-        help='print suzieq version'
+        help='Print suzieq version'
     )
 
     args = parser.parse_args()

--- a/suzieq/poller/sq_poller.py
+++ b/suzieq/poller/sq_poller.py
@@ -117,11 +117,15 @@ def controller_main():
     parser.add_argument(
         '--run-once',
         type=str,
-        choices=['gather', 'process', 'update'],
-        help=('Collect the data from the sources and terminates. gather store '
-              'the output as it has been collected, process performs some '
-              'processing on the data. Both cases store the results in a '
-              'plain output file, one for each service.')
+        choices=['gather', 'process', 'update', 'debug'],
+        help=('''The poller do not run forever, three modes are available:
+        (1) gather: store the output as it has been collected,
+        (2) process: performs some processing on the data.
+        Both cases store the results in a plain output file,
+        one for each service, and exit.
+        (3) update: poll the nodes only once, write the result and stop
+        (4) debug: build the device list and exit without polling
+        the nodes.''')
     )
 
     parser.add_argument(
@@ -149,7 +153,7 @@ def controller_main():
         '-w',
         '--workers',
         type=int,
-        help='Maximum number of workers to execute',
+        help='The number of workers polling the nodes',
     )
 
     parser.add_argument(


### PR DESCRIPTION
This PR makes the poller debug simpler, introducing the following features:
- When `log-stdout` is true for poller in the configuration file, the log of each worker is shown in the stdout
- When `log-stdout` is true for the coalescer, the stdout of the poller shows the log of the coalescer
- Add `run-once=debug` allowing to generate the inventory without automatically starting the workers, i.e.:
  ```
  $ sq-poller -I ./sq-inventory.yml -w 2 --run-once debug
  2 inventory chunks generated, you can now manually start the workers with the following commands:

  export SQ_CONTROLLER_POLLER_CRED=vtMcqttxk5_2AZW9BNK4XbtV2FTxO_a2D46DrKAs1v0=
  export SQ_INVENTORY_PATH=/tmp/.suzieq/inventory.59752
  python /suzieq/poller/worker/sq_worker.py --worker-id 0

  export SQ_CONTROLLER_POLLER_CRED=vtMcqttxk5_2AZW9BNK4XbtV2FTxO_a2D46DrKAs1v0=
  export SQ_INVENTORY_PATH=/tmp/.suzieq/inventory.59752
  python /suzieq/poller/worker/sq_worker.py --worker-id 1
  ```