### PR TITLE
Fix #509

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1430,7 +1430,7 @@ class SonicNode(Node):
 
 
 class PanosNode(Node):
-
+    '''Node object representing access to a Palo Alto Networks FW'''
     async def _init(self, **kwargs):
         super()._init(**kwargs)
         self.devtype = "panos"
@@ -1559,6 +1559,7 @@ class PanosNode(Node):
         await self.exec_cmd(self._parse_boottime_hostname,
                             ["show system info"], None, 'text')
 
+    # pylint: disable=unused-argument
     async def _parse_boottime_hostname(self, output, cb_token) -> None:
         """Parse the uptime command output"""
         if output[0]["status"] == 0:


### PR DESCRIPTION
Instead of using hostnamectl, if we can use /bin/hostname, we get everything we need including addressing the issue raised by the user in issue 509, but avoid calling a Cumulus-specific command (net show system), and use a standard command to get the same info. This however means that the way we extract the version string and device type needed to change. 

Finally a couple of pylint fixes related to Panos node code, unrelated to this fix.

Resolves #509 