### PR TITLE
Poller worker: avoid manual asyncio loop stop

### DIFF
--- a/suzieq/poller/worker/poller.py
+++ b/suzieq/poller/worker/poller.py
@@ -133,9 +133,8 @@ class Poller:
                     break
                 except asyncio.CancelledError:
                     break
-        finally:
-            logger.warning('sq-poller: Received terminate signal. Terminating')
-            loop.stop()
+        except asyncio.CancelledError:
+            logger.warning('Received terminate signal. Terminating...')
 
     async def _add_poller_task(self, tasks):
         """Add new tasks to be executed in the poller run loop."""

--- a/suzieq/poller/worker/writers/output_worker_manager.py
+++ b/suzieq/poller/worker/writers/output_worker_manager.py
@@ -54,7 +54,9 @@ class OutputWorkerManager:
             try:
                 data = await self._output_queue.get()
             except asyncio.CancelledError:
-                logger.error("Writer thread received task cancel")
+                logger.error(
+                    'OutputWorkerManager: received signal to terminate'
+                )
                 return
 
             if not self._output_workers:


### PR DESCRIPTION
When the poller worker terminates, we manually stop the asyncio event loop. However, this is not necessary, as we are using `asyncio.run(...)`, which (according to https://docs.python.org/3.7/library/asyncio-task.html#asyncio.run) automatically manage the event loop. Moreover, this might create some problems, since we stop the loop before being able to cancel the remaining tasks, for example, when calling `sq-poller --run-once update`, this is what the worker log reports:

```
2022-01-03 15:47:34,393 - asyncio - ERROR - Task was destroyed but it is pending!
task: <Task pending name='Task-284' coro=<Node.run() done, defined at .../suzieq/poller/worker/nodes/node.py:628> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f589c16ed00>()]> cb=[gather.<locals>._done_callback() at .../.pyenv/versions/3.7.12/lib/python3.7/asyncio/tasks.py:769]>
```

This PR prevent the poller worker from manually stopping the asyncio event loop.