### PR TITLE
sq-coalescer: fix incorrect error log when period is in 'm' and remove default config file

### DIFF
--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -295,7 +295,7 @@ class SqParquetDB(SqDB):
                 run_int = timedelta(minutes=timeint)
                 state.prefix = 'sqc-m-'
                 state.ign_pfx = ['.', '_', 'sqc-']
-            if time_unit == 'h':
+            elif time_unit == 'h':
                 run_int = timedelta(hours=timeint)
                 state.prefix = 'sqc-h-'
                 state.ign_pfx = ['.', '_', 'sqc-y-', 'sqc-d-', 'sqc-w-',

--- a/suzieq/utilities/sq_coalescer.py
+++ b/suzieq/utilities/sq_coalescer.py
@@ -124,8 +124,8 @@ def coalescer_main():
     parser.add_argument(
         "-c",
         "--config",
-        default=f'{os.getenv("HOME")}/.suzieq/suzieq-cfg.yml',
-        type=str, help="alternate config file"
+        type=str,
+        help="alternate config file"
     )
     parser.add_argument(
         "--run-once",


### PR DESCRIPTION
This PR contains two small fixes in the coalescer code:
- When period is in minutes the log reports the following (incorrect) error:
  ```
  ERROR - Invalid unit for period, m, must be one of m/h/d/w
  ```
- Remove default config file in the argument parsing, so following the priority defined in the `sq_get_config_file()` function used by all the other components