### PR TITLE
sq-poller: terminate the coalescer only if it is still running

### DIFF
--- a/suzieq/poller/worker/coalescer_launcher.py
+++ b/suzieq/poller/worker/coalescer_launcher.py
@@ -63,7 +63,10 @@ class CoalescerLauncher:
         except asyncio.CancelledError:
             pass
         finally:
-            if self.coalescer_process:
+            # If the coalescer is still runnning we always need to terminate
+            # it before exiting
+            if self.coalescer_process and \
+               self.coalescer_process.returncode is None:
                 self.coalescer_process.terminate()
                 try:
                     logger.warning('Waiting coalescer termination...')


### PR DESCRIPTION
Whenever the poller terminates, we need to stop the coalescer. However, if we cannot stop it if already terminated, as otherwise an exception is raised. This PR solves this problem checking if the coalescer terminated and returned something, before terminating it.