### PR TITLE
Removing deprecated ssl validation

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -133,16 +133,56 @@ Now you can set the path of the ansible inventory in the source:
 ### <a name='source-netbox'></a>Netbox
 
 [Netbox](https://netbox.readthedocs.io/en/stable/) is often used to store devices type, management address and other useful information to be used in network automation. Suzieq can pull device data from Netbox selecting them by tag (currently only one per each source). To do so a token to access the netbox API is required as well as the netbox instance url.
-Since Netbox is a _dynamic source_, the data are periodically pulled, the period can be set to any desired number in seconds (default is 3600.
+Since Netbox is a _dynamic source_, the data are periodically pulled, the period can be set to any desired number in seconds (default is 3600).
+
+!!!Info
+    Each netbox source contains a parameter called `ssl-verify`.
+    This parameter is used to specify whether perform ssl certificate verify or not. By default `ssl-verify` is set to _true_ if the url contains an https host.
+    If the user manually sets `ssl-verify: true` with an http netbox server, an error will be notified.
 
 Here is an example of the configuration of a netbox type source:
 ```yaml
 - name: netbox-dc-01
   type: netbox
   token: your-api-token-here
-  url: http://127.0.0.1:8000
+  url: https://127.0.0.1:8000
   tag: suzieq-demo    # if not present, default is "suzieq"
-  period: 3600 # How frequently Netbox should be polled
+  period: 3600        # How frequently Netbox should be polled
+  ssl-verify: false   # Netbox certificate validation will be skipped
+```
+
+Moreover, netbox type source is capable to assign each device to a namespace which corresponds to the device's sitename.
+To obtain this behaviour, we need to declare a `namespace` object with `name: netbox-sitename`.
+
+Here is an example:
+```yaml
+sources:
+- name: netbox-dc-01
+  type: netbox
+  token: your-api-token-here
+  url: http://127.0.0.1:8000
+  tag: suzieq-demo
+
+- name: netbox-dc-02
+  type: netbox
+  token: your-api-token-here
+  url: http://127.0.0.1:9000
+  tag: suzieq
+
+auths:
+- name: auth-st
+  username: user
+  passowrd: my-password
+
+namespaces:
+- name: netbox-sitename # devices namespaces equal to their site names
+  source: netbox-dc-01
+  auth: auth-st
+
+- name: namespace01     # devices namespaces equal to 'namespace01'
+  source: netbox-dc-02
+  auth: auth-st
+
 ```
 
 !!! warning

--- a/suzieq/poller/controller/source/netbox.py
+++ b/suzieq/poller/controller/source/netbox.py
@@ -115,10 +115,16 @@ class Netbox(Source, InventoryAsyncPlugin):
             headers ([dict]): headers to initialize the session
         """
         if not self._session:
-            self._session = aiohttp.ClientSession(
-                headers=headers,
-                connector=aiohttp.TCPConnector(verify_ssl=self._ssl_verify)
-            )
+            if self._ssl_verify:
+                self._session = aiohttp.ClientSession(
+                    headers=headers,
+                    connector=aiohttp.TCPConnector(ssl=None)
+                )
+            else:
+                self._session = aiohttp.ClientSession(
+                    headers=headers,
+                    connector=aiohttp.TCPConnector(ssl=False)
+                )
 
     def _token_auth_header(self) -> Dict:
         """Generate the token authorization header

--- a/suzieq/poller/controller/source/netbox.py
+++ b/suzieq/poller/controller/source/netbox.py
@@ -54,9 +54,7 @@ class Netbox(Source, InventoryAsyncPlugin):
         if not input_data:
             raise InventorySourceError('no netbox_config provided')
 
-        url = input_data.get('url', '')
-        if not url:
-            raise InventorySourceError(f'{self._name}: <url> not provided')
+        url = input_data.get('url')
 
         url_data = urlparse(url)
         self._protocol = url_data.scheme or 'http'
@@ -67,10 +65,10 @@ class Netbox(Source, InventoryAsyncPlugin):
             raise InventorySourceError(f'{self._name}: invalid url provided')
 
         self._tag = input_data.get('tag', 'null')
-        self._namespace = input_data.get('namespace', 'site.name')
+        self._namespace = input_data.get('namespace')
         self._period = input_data.get('period', 3600)
         self._run_once = input_data.get('run_once', False)
-        self._token = input_data.get('token', None)
+        self._token = input_data.get('token')
         self._ssl_verify = input_data.get('ssl-verify', None)
         if self._ssl_verify is None:
             if self._protocol == 'http':
@@ -78,6 +76,9 @@ class Netbox(Source, InventoryAsyncPlugin):
             elif self._protocol == 'https':
                 self._ssl_verify = True
         else:
+            if not isinstance(self._ssl_verify, bool):
+                raise InventorySourceError(
+                    f'{self.name} ssl-verify parameter must be a boolean')
             if self._ssl_verify and self._protocol == 'http':
                 raise InventorySourceError(
                     f"{self._name}: ssl-verify can be use only with https"
@@ -101,7 +102,8 @@ class Netbox(Source, InventoryAsyncPlugin):
 
         super()._validate_config(input_data)
 
-        miss_fields = [x for x in ['token', 'url'] if x not in input_data]
+        miss_fields = [x for x in ['token', 'url', 'namespace']
+                       if x not in input_data]
 
         if miss_fields:
             raise InventorySourceError(
@@ -213,7 +215,7 @@ class Netbox(Source, InventoryAsyncPlugin):
             ipv6 = get_field_value(device, 'primary_ip6.address')
             hostname = get_field_value(device, 'name')
             site_name = get_field_value(device, 'site.name')
-            if self._namespace == 'site.name':
+            if self._namespace == 'netbox-sitename':
                 namespace = site_name
             else:
                 namespace = self._namespace

--- a/suzieq/poller/controller/source/netbox.py
+++ b/suzieq/poller/controller/source/netbox.py
@@ -117,16 +117,11 @@ class Netbox(Source, InventoryAsyncPlugin):
             headers ([dict]): headers to initialize the session
         """
         if not self._session:
-            if self._ssl_verify:
-                self._session = aiohttp.ClientSession(
-                    headers=headers,
-                    connector=aiohttp.TCPConnector(ssl=None)
-                )
-            else:
-                self._session = aiohttp.ClientSession(
-                    headers=headers,
-                    connector=aiohttp.TCPConnector(ssl=False)
-                )
+            ssl_option = None if self._ssl_verify else False
+            self._session = aiohttp.ClientSession(
+                headers=headers,
+                connector=aiohttp.TCPConnector(ssl=ssl_option)
+            )
 
     def _token_auth_header(self) -> Dict:
         """Generate the token authorization header


### PR DESCRIPTION
While testing I found that the parameter `verify_ssl` is deprecated. You need to use `ssl` instead.