### PR TITLE
Improve coalescer monitoring

### DIFF
--- a/suzieq/poller/worker/coalescer_launcher.py
+++ b/suzieq/poller/worker/coalescer_launcher.py
@@ -3,17 +3,15 @@ This module contains all the logic needed to start and monitor the coalescer
 """
 import asyncio
 import errno
-import fcntl
 import logging
-import os
-import signal
 from pathlib import Path
 import shlex
 from asyncio.subprocess import Process
 from typing import Dict
 
 from suzieq.poller.controller.utils.proc_utils import monitor_process
-from suzieq.shared.utils import ensure_single_instance, get_sq_install_dir
+from suzieq.shared.exceptions import PollingError
+from suzieq.shared.utils import get_sq_install_dir
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +24,8 @@ class CoalescerLauncher:
     def __init__(self,
                  config_file: str,
                  cfg: Dict,
-                 coalescer_bin: str = None) -> None:
+                 coalescer_bin: str = None,
+                 max_attempts: int = 3) -> None:
         """Initialize an instance of the CoalescerLauncher
 
         Args:
@@ -35,11 +34,21 @@ class CoalescerLauncher:
             cfg (dict): the Suzieq config dictionary
             coalescer_bin (str, optional): optional path to coalescer binary.
                 Defaults to None.
+            max_attempts (int, optional): the number of attepts to perform
+                for starting the coalescer. Defaults to 3
         """
         self.coalescer_process = None
 
         self.config_file = config_file
         self.cfg = cfg
+
+        self.max_attempts = max_attempts
+        if self.max_attempts <= 0:
+            raise PollingError(
+                'The number of attempts for starting the coalescer cannot be '
+                '0 or less'
+            )
+
         self.coalescer_bin = coalescer_bin
         if not coalescer_bin:
             sq_path = get_sq_install_dir()
@@ -78,48 +87,45 @@ class CoalescerLauncher:
         """This function calls _start_coalescer() and check if the process
         dies
         """
-        fd = 0
-        # Check to see file lock is possible
-        while not fd:
+
+        starting_attemps = 0
+
+        # We would like to attempt the coalescer startup self.max_attempts
+        # times
+        while starting_attemps < self.max_attempts:
             if not self.coalescer_process:
                 logger.info('Starting Coalescer')
             elif self.coalescer_process.returncode == errno.EBUSY:
                 logger.warning('Trying to start coalescer')
+            else:
+                logger.warning('Restarting the coalescer')
 
             # Try to start the coalescer process
             self.coalescer_process = await self._start_coalescer()
-
             if not self.coalescer_process:
-                os.kill(os.getpid(), signal.SIGTERM)
-                return
-
-            # Initial sleep to ensure that the coalescer starts up
-            await asyncio.sleep(10)
-            coalesce_dir = self.cfg.get('coalescer', {})\
-                .get('coalesce-directory',
-                     f'{self.cfg.get("data-directory")}/coalesced')
-
-            # In order to be sure the coalescer correctly started we need to
-            # check if it got the lock file, if so we are not able to acquire
-            # the lock and we can proceed monitoring the coalescer process,
-            # otherwise we release the lock and retry starting the process
-            fd = ensure_single_instance(f'{coalesce_dir}/.sq-coalescer.pid',
-                                        False)
-            if fd > 0:
-                # unlock and try to start process
-                try:
-                    fcntl.flock(fd, fcntl.F_UNLCK)
-                    os.close(fd)
-                except OSError:
-                    pass
-                continue
+                raise PollingError('Unable to start the coalescer')
 
             # Check if we have something from the stdout we need to log
             await monitor_process(self.coalescer_process, 'COALESCER')
 
+            # When the coalescer exists with EBUSY error, it means
+            # there already is another instance of the coalescer running
+            # we are fine with that, but we need to make sure it is always
+            # running, so we wait some time before retrying launching again
+            # the coalescer
             if self.coalescer_process.returncode == errno.EBUSY:
+                logger.warning(
+                    "There is a running coalescer instance, "
+                    "let's try again later"
+                )
                 await asyncio.sleep(10*60)
-            fd = 0
+            else:
+                # The coalescer died for any other reason let's increase the
+                # attempts counter
+                starting_attemps += 1
+        logger.error(
+            f'Maximum number of attempts reached {self.max_attempts}/'
+            f'{self.max_attempts}, the coalescer keep on crashing')
 
     async def _start_coalescer(self) -> Process:
         """Start the coalescer

--- a/suzieq/poller/worker/coalescer_launcher.py
+++ b/suzieq/poller/worker/coalescer_launcher.py
@@ -88,11 +88,11 @@ class CoalescerLauncher:
         dies
         """
 
-        starting_attemps = 0
+        starting_attempts = 0
 
         # We would like to attempt the coalescer startup self.max_attempts
         # times
-        while starting_attemps < self.max_attempts:
+        while starting_attempts < self.max_attempts:
             if not self.coalescer_process:
                 logger.info('Starting Coalescer')
             elif self.coalescer_process.returncode == errno.EBUSY:
@@ -122,7 +122,7 @@ class CoalescerLauncher:
             else:
                 # The coalescer died for any other reason let's increase the
                 # attempts counter
-                starting_attemps += 1
+                starting_attempts += 1
         logger.error(
             f'Maximum number of attempts reached {self.max_attempts}/'
             f'{self.max_attempts}, the coalescer keep on crashing')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,11 +130,11 @@ def data_to_write():
     return pickle.load(open(DATA_TO_STORE_FILE, 'rb'))
 
 
-def get_async_task_mock():
+def get_async_task_mock(result=None):
     """Mock for the add tasks method in the Poller class
     """
     fn_res = asyncio.Future()
-    fn_res.set_result(None)
+    fn_res.set_result(result)
     return MagicMock(return_value=fn_res)
 
 

--- a/tests/unit/poller/shared/coalescer_mock.py
+++ b/tests/unit/poller/shared/coalescer_mock.py
@@ -4,9 +4,6 @@ A simple application listening on a TCP port waiting for connections
 """
 import argparse
 import asyncio
-import os
-
-from suzieq.shared.utils import ensure_single_instance, load_sq_config
 
 
 async def wait_for_test(reader, writer):
@@ -25,26 +22,14 @@ async def main():
     parser.add_argument(
         "-c",
         "--config",
-        default=f'{os.getenv("HOME")}/.suzieq/suzieq-cfg.yml',
         type=str, help="alternate config file"
     )
-    userargs = parser.parse_args()
 
     server = await asyncio.start_server(wait_for_test, '127.0.0.1', 8303)
 
     print('Waiting for connection')
 
-    # Create the file lock so that it is possible to check if there is a
-    # coalescer running
-    cfg = load_sq_config(config_file=userargs.config)
-    coalesce_dir = cfg.get('coalescer', {})\
-        .get('coalesce-directory',
-             f'{cfg.get("data-directory")}/coalesced')
-
-    # Run the server only if we are able to acquire the lock
-    if ensure_single_instance(f'{coalesce_dir}/.sq-coalescer.pid', False) > 0:
-        async with server:
-            await server.serve_forever()
+    await server.serve_forever()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/tests/unit/poller/test_coalescer_launcher.py
+++ b/tests/unit/poller/test_coalescer_launcher.py
@@ -5,13 +5,14 @@ Test the CoalescerLauncher component
 
 import asyncio
 import os
-import signal
-from contextlib import suppress
+from unittest.mock import MagicMock, patch
 
 import pytest
+import suzieq.poller.worker.coalescer_launcher as coalescer_launcher_module
 from suzieq.poller.worker.coalescer_launcher import CoalescerLauncher
-from suzieq.shared.utils import ensure_single_instance, load_sq_config
-from tests.conftest import create_dummy_config_file
+from suzieq.shared.exceptions import PollingError
+from suzieq.shared.utils import load_sq_config
+from tests.conftest import create_dummy_config_file, get_async_task_mock
 
 MOCK_COALESCER = './tests/unit/poller/shared/coalescer_mock.py'
 
@@ -71,20 +72,13 @@ async def test_coalescer_start(coalescer_cfg):
     # Start coalescer
     task = asyncio.create_task(cl.start_and_monitor_coalescer())
     # Waiting for coalescer to start
-    await asyncio.sleep(11)
+    await asyncio.sleep(1)
     try:
         # Try to reach the coalescer mock
         _, writer = await asyncio.open_connection(
             '127.0.0.1', 8303)
         writer.close()
         await writer.wait_closed()
-        # Check if it is possible to get the file lock, if the coalescer
-        # is properly running, we should not be able to acquire the lock
-        coalesce_dir = cfg.get('coalescer', {})\
-            .get('coalesce-directory',
-                 f'{cfg.get("data-directory")}/coalesced')
-        assert ensure_single_instance(
-            f'{coalesce_dir}/.sq-coalescer.pid', False) == 0
 
         # Check if the task is still running
         if task.done():
@@ -97,7 +91,48 @@ async def test_coalescer_start(coalescer_cfg):
     finally:
         task.cancel()
         await task
-        coalescer_pid = cl.coalescer_pid
-        if coalescer_pid:
-            with suppress(OSError):
-                os.kill(cl.coalescer_pid, signal.SIGKILL)
+
+
+@pytest.mark.poller
+@pytest.mark.poller_unit_tests
+@pytest.mark.coalescer_launcher
+@pytest.mark.asyncio
+async def test_coalescer_keep_on_failing(coalescer_cfg):
+    """Try to start a coalescer which keep on failing
+    """
+    cfg_file = coalescer_cfg
+    cfg = load_sq_config(config_file=cfg_file)
+    cl = CoalescerLauncher(cfg_file, cfg, MOCK_COALESCER)
+
+    monitor_process_fn = get_async_task_mock()
+    dummy_process = MagicMock()
+    dummy_process.returncode = 1
+    start_coalescer_fn = get_async_task_mock(dummy_process)
+
+    try:
+        with patch.multiple(CoalescerLauncher,
+                            _start_coalescer=start_coalescer_fn), \
+            patch.multiple(coalescer_launcher_module,
+                           monitor_process=monitor_process_fn):
+            await asyncio.wait_for(cl.start_and_monitor_coalescer(), 5)
+        # Check if multiple attempts have been performed
+        attempts_done = start_coalescer_fn.call_count
+        assert attempts_done == cl.max_attempts, \
+            f'Expected {cl.max_attempts} attempts, {attempts_done} done'
+    except asyncio.TimeoutError:
+        pytest.fail(
+            'The coalescer launcher task expected to file but it does not')
+
+
+@pytest.mark.poller
+@pytest.mark.poller_unit_tests
+@pytest.mark.coalescer_launcher
+@pytest.mark.asyncio
+async def test_coalescer_wrong_attempts_number(coalescer_cfg):
+    """Test if an exception is raised if a wrong number of attempts is passed
+    to the coalescer launcher
+    """
+    cfg_file = coalescer_cfg
+    cfg = load_sq_config(config_file=cfg_file)
+    with pytest.raises(PollingError, match=r'The number of attempts*'):
+        CoalescerLauncher(cfg_file, cfg, MOCK_COALESCER, max_attempts=0)

--- a/tests/unit/poller/test_coalescer_launcher.py
+++ b/tests/unit/poller/test_coalescer_launcher.py
@@ -121,7 +121,7 @@ async def test_coalescer_keep_on_failing(coalescer_cfg):
             f'Expected {cl.max_attempts} attempts, {attempts_done} done'
     except asyncio.TimeoutError:
         pytest.fail(
-            'The coalescer launcher task expected to file but it does not')
+            'The coalescer launcher task expected to fail but it does not')
 
 
 @pytest.mark.poller


### PR DESCRIPTION
Currently when there is another instance of the coalescer running, the coalescer launcher task terminates without logging anything. The aim of this PR is improving the way in which the coalescer is monitored:
- Removed the file lock acquire: this check is not needed, provided we monitor the status of the coalescer process. Indeed, whenever there is another instance of the coalescer running, the launched coalescer terminates with a EBUSY error state. Moreover, not acquiring the lock prevents the poller from waiting some seconds before checking the status of the coalescer.
- Set a maximum number of attempts for coalescer startup: when the coalescer terminates for a reason different than "another coalescer instance running", we increase an attempt counter and retry, until the counter reaches the maximum value