### PR TITLE
Include panos tests in sqcmds

### DIFF
--- a/tests/integration/sqcmds/panos-samples/address.yml
+++ b/tests/integration/sqcmds/panos-samples/address.yml
@@ -639,414 +639,528 @@ tests:
     {"hostname": "server301"}, {"hostname": "server302"}, {"hostname": "spine01"},
     {"hostname": "spine02"}]'
 - command: address summarize --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address summarize panos
-  output: '{"dual-bgp": {"deviceCnt": 14, "addressCnt": 138, "uniqueV4AddressCnt":
-    48, "uniqueV6AddressCnt": 13, "uniqueIfMacCnt": 77, "deviceWithv4AddressCnt":
-    14, "deviceWithv6AddressCnt": 13, "subnetsUsed": ["24", "32", "30", "8", "31"],
-    "subnetTopCounts": [{"24": 26}, {"32": 13}, {"30": 12}]}}'
+  output: '{"panos": {"deviceCnt": 14, "addressCnt": 167, "uniqueV4AddressCnt": 50,
+    "uniqueV6AddressCnt": 3, "uniqueIfMacCnt": 103, "deviceWithv4AddressCnt": 14,
+    "deviceWithv6AddressCnt": 10, "subnetsUsed": ["32", "24", "30", "8", "31"], "subnetTopCounts":
+    [{"32": 38}, {"24": 25}, {"30": 12}]}}'
 - command: address show --address="10.0.0.21" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "spine01", "ifname": "lo", "ipAddressList":
-    "10.0.0.21/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::21/128",
-    "::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638471112}]'
+  output: '[{"namespace": "panos", "hostname": "spine01", "ifname": "swp6", "ipAddressList":
+    ["10.0.0.21/32"], "macaddr": "52:54:00:c4:54:00", "ip6AddressList": ["fe80::5054:ff:fec4:5400/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254852}, {"namespace": "panos",
+    "hostname": "spine01", "ifname": "swp5", "ipAddressList": ["10.0.0.21/32"], "macaddr":
+    "52:54:00:f5:f0:96", "ip6AddressList": ["fe80::5054:ff:fef5:f096/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
+    "spine01", "ifname": "swp4", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:a0:82:3d",
+    "ip6AddressList": ["fe80::5054:ff:fea0:823d/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname":
+    "swp3", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:d3:be:93", "ip6AddressList":
+    ["fe80::5054:ff:fed3:be93/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp2",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:41:6f:13", "ip6AddressList":
+    ["fe80::5054:ff:fe41:6f13/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:83:d9:77", "ip6AddressList":
+    ["fe80::5054:ff:fe83:d977/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "lo",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254852}]'
 - command: address show --address="10.0.0.11/32" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "lo", "ipAddressList":
-    "10.0.0.11/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::11/128",
-    "::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638471143}]'
+  output: '[{"namespace": "panos", "hostname": "leaf01", "ifname": "lo", "ipAddressList":
+    ["10.0.0.11/32", "10.0.0.112/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace":
+    "panos", "hostname": "leaf01", "ifname": "swp2", "ipAddressList": ["10.0.0.11/32"],
+    "macaddr": "52:54:00:89:13:56", "ip6AddressList": ["fe80::5054:ff:fe89:1356/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "swp1", "ipAddressList": ["10.0.0.11/32"], "macaddr":
+    "52:54:00:c4:19:83", "ip6AddressList": ["fe80::5054:ff:fec4:1983/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254854}]'
 - command: address show --address="10.0.0.2" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
   output: '[]'
 - command: address show --address="10.0.0.21 172.16.1.101"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0",
-    "ipAddressList": "172.16.1.101/24", "macaddr": "52:54:00:d6:66:41", "ip6AddressList":
-    ["2001:db8:0:1::101/64"], "state": "up", "vrf": "default", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "spine01", "ifname": "lo", "ipAddressList":
-    "10.0.0.21/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::21/128",
-    "::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638471112}]'
+  output: '[{"namespace": "panos", "hostname": "server101", "ifname": "bond0", "ipAddressList":
+    ["172.16.1.101/24"], "macaddr": "26:76:20:42:e2:c6", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1639476254006}, {"namespace": "panos", "hostname":
+    "spine01", "ifname": "swp6", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:c4:54:00",
+    "ip6AddressList": ["fe80::5054:ff:fec4:5400/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname":
+    "swp5", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:f5:f0:96", "ip6AddressList":
+    ["fe80::5054:ff:fef5:f096/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp4",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:a0:82:3d", "ip6AddressList":
+    ["fe80::5054:ff:fea0:823d/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp3",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:d3:be:93", "ip6AddressList":
+    ["fe80::5054:ff:fed3:be93/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp2",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:41:6f:13", "ip6AddressList":
+    ["fe80::5054:ff:fe41:6f13/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:83:d9:77", "ip6AddressList":
+    ["fe80::5054:ff:fe83:d977/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "lo",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254852}]'
 - command: address show --address="11.0.0.21 172.16.1.101"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0",
-    "ipAddressList": "172.16.1.101/24", "macaddr": "52:54:00:d6:66:41", "ip6AddressList":
-    ["2001:db8:0:1::101/64"], "state": "up", "vrf": "default", "timestamp": 1616638470198}]'
+  output: '[{"namespace": "panos", "hostname": "server101", "ifname": "bond0", "ipAddressList":
+    ["172.16.1.101/24"], "macaddr": "26:76:20:42:e2:c6", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1639476254006}]'
 - command: address show --address=""  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "ifname": "lo", "ipAddressList":
-    ["10.0.0.100/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server103", "ifname": "lo", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "server103", "ifname": "eth0", "ipAddressList":
-    ["192.168.121.222/24"], "macaddr": "52:54:00:d0:d4:9f", "ip6AddressList": [],
-    "state": "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server103", "ifname": "eth1", "ipAddressList": [], "macaddr": "52:54:00:f9:0d:6e",
-    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "server103", "ifname": "eth2", "ipAddressList":
-    [], "macaddr": "52:54:00:f9:0d:6e", "ip6AddressList": [], "state": "up", "vrf":
-    "bond0", "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "server103",
-    "ifname": "bond0", "ipAddressList": ["172.16.3.103/24"], "macaddr": "52:54:00:f9:0d:6e",
-    "ip6AddressList": ["2001:db8:0:3::103/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "server104", "ifname": "lo",
-    "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server104", "ifname": "eth0", "ipAddressList": ["192.168.121.180/24"],
-    "macaddr": "52:54:00:8f:82:c0", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "server104",
-    "ifname": "eth2", "ipAddressList": [], "macaddr": "52:54:00:0c:bf:b3", "ip6AddressList":
-    [], "state": "up", "vrf": "bond0", "timestamp": 1616638470002}, {"namespace":
-    "dual-bgp", "hostname": "server104", "ifname": "bond0", "ipAddressList": ["172.16.4.104/24"],
-    "macaddr": "52:54:00:0c:bf:b3", "ip6AddressList": ["2001:db8:0:4::104/64"], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server104", "ifname": "eth1", "ipAddressList": [], "macaddr": "52:54:00:0c:bf:b3",
-    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "edge01", "ifname": "eth1", "ipAddressList":
-    [], "macaddr": "52:54:00:a8:38:3d", "ip6AddressList": [], "state": "up", "vrf":
-    "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "ifname": "eth0", "ipAddressList": ["192.168.121.103/24"], "macaddr":
-    "52:54:00:96:94:6e", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "edge01", "ifname": "eth2",
-    "ipAddressList": [], "macaddr": "52:54:00:d7:58:57", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "edge01", "ifname": "eth1.2", "ipAddressList": ["169.254.254.2/30"],
-    "macaddr": "52:54:00:a8:38:3d", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "edge01", "ifname":
-    "eth2.2", "ipAddressList": ["169.254.253.2/30"], "macaddr": "52:54:00:d7:58:57",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "edge01", "ifname": "eth2.4", "ipAddressList":
-    ["169.254.253.10/30"], "macaddr": "52:54:00:d7:58:57", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "edge01", "ifname": "eth1.4", "ipAddressList": ["169.254.254.10/30"],
-    "macaddr": "52:54:00:a8:38:3d", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "server101",
-    "ifname": "bond0", "ipAddressList": ["172.16.1.101/24"], "macaddr": "52:54:00:d6:66:41",
-    "ip6AddressList": ["2001:db8:0:1::101/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638470198}, {"namespace": "dual-bgp", "hostname": "server101", "ifname": "eth2",
-    "ipAddressList": [], "macaddr": "52:54:00:d6:66:41", "ip6AddressList": [], "state":
-    "up", "vrf": "bond0", "timestamp": 1616638470198}, {"namespace": "dual-bgp", "hostname":
-    "server101", "ifname": "eth1", "ipAddressList": [], "macaddr": "52:54:00:d6:66:41",
-    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "server101", "ifname": "eth0", "ipAddressList":
-    ["192.168.121.233/24"], "macaddr": "52:54:00:5a:70:0e", "ip6AddressList": [],
-    "state": "up", "vrf": "default", "timestamp": 1616638470198}, {"namespace": "dual-bgp",
-    "hostname": "server101", "ifname": "lo", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "server102", "ifname": "lo", "ipAddressList":
+  output: '[{"namespace": "panos", "hostname": "server102", "ifname": "bond0", "ipAddressList":
+    ["172.16.3.102/24"], "macaddr": "2a:b4:fa:73:2a:0d", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1639476253769}, {"namespace": "panos", "hostname":
+    "server102", "ifname": "eth2", "ipAddressList": [], "macaddr": "2a:b4:fa:73:2a:0d",
+    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1639476253769},
+    {"namespace": "panos", "hostname": "server102", "ifname": "lo", "ipAddressList":
     [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state": "up", "vrf":
-    "default", "timestamp": 1616638470218}, {"namespace": "dual-bgp", "hostname":
-    "server102", "ifname": "eth2", "ipAddressList": [], "macaddr": "52:54:00:52:13:14",
-    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1616638470218},
-    {"namespace": "dual-bgp", "hostname": "server102", "ifname": "eth0", "ipAddressList":
-    ["192.168.121.254/24"], "macaddr": "52:54:00:f8:25:80", "ip6AddressList": [],
-    "state": "up", "vrf": "default", "timestamp": 1616638470218}, {"namespace": "dual-bgp",
-    "hostname": "server102", "ifname": "bond0", "ipAddressList": ["172.16.2.102/24"],
-    "macaddr": "52:54:00:52:13:14", "ip6AddressList": ["2001:db8:0:2::102/64"], "state":
-    "up", "vrf": "default", "timestamp": 1616638470218}, {"namespace": "dual-bgp",
-    "hostname": "server102", "ifname": "eth1", "ipAddressList": [], "macaddr": "52:54:00:52:13:14",
-    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1616638470218},
-    {"namespace": "dual-bgp", "hostname": "spine02", "ifname": "swp3", "ipAddressList":
-    [], "macaddr": "52:54:00:d6:94:80", "ip6AddressList": ["fe80::5054:ff:fed6:9480/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638470639}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "ifname": "swp6", "ipAddressList": [], "macaddr": "52:54:00:d3:cd:00",
-    "ip6AddressList": ["fe80::5054:ff:fed3:cd00/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638470639}, {"namespace": "dual-bgp", "hostname": "spine02",
-    "ifname": "swp5", "ipAddressList": [], "macaddr": "52:54:00:14:09:81", "ip6AddressList":
-    ["fe80::5054:ff:fe14:981/64"], "state": "up", "vrf": "default", "timestamp": 1616638470639},
-    {"namespace": "dual-bgp", "hostname": "spine02", "ifname": "lo", "ipAddressList":
-    ["10.0.0.22/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::22/128",
-    "::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638470639}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "ifname": "swp1", "ipAddressList": [], "macaddr":
-    "52:54:00:38:a3:29", "ip6AddressList": ["fe80::5054:ff:fe38:a329/64"], "state":
-    "up", "vrf": "default", "timestamp": 1616638470639}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "ifname": "swp2", "ipAddressList": [], "macaddr": "52:54:00:a1:30:72",
-    "ip6AddressList": ["fe80::5054:ff:fea1:3072/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638470639}, {"namespace": "dual-bgp", "hostname": "spine02",
-    "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:dc:80:3b", "ip6AddressList":
-    ["fe80::5054:ff:fedc:803b/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638470639}, {"namespace": "dual-bgp", "hostname": "spine02", "ifname": "eth0",
-    "ipAddressList": ["192.168.121.186/24"], "macaddr": "52:54:00:5e:ec:b7", "ip6AddressList":
-    ["fe80::5054:ff:fe5e:ecb7/64"], "state": "up", "vrf": "mgmt", "timestamp": 1616638470639},
-    {"namespace": "dual-bgp", "hostname": "spine02", "ifname": "mgmt", "ipAddressList":
-    ["127.0.0.1/8"], "macaddr": "2a:89:e4:ac:3a:ca", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470639}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "internet-vrf", "ipAddressList": ["10.0.0.101/32"],
-    "macaddr": "d6:f4:51:5f:6b:77", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname":
-    "swp1", "ipAddressList": [], "macaddr": "52:54:00:40:03:86", "ip6AddressList":
-    ["fe80::5054:ff:fe40:386/64"], "state": "up", "vrf": "default", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "swp2", "ipAddressList":
-    [], "macaddr": "52:54:00:8c:5b:4d", "ip6AddressList": ["fe80::5054:ff:fe8c:5b4d/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "ifname": "swp3", "ipAddressList": [], "macaddr": "52:54:00:61:91:8e",
-    "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "swp4", "ipAddressList":
-    [], "macaddr": "52:54:00:61:91:8e", "ip6AddressList": [], "state": "up", "vrf":
-    "peerlink", "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname":
-    "leaf02", "ifname": "swp6", "ipAddressList": [], "macaddr": "52:54:00:dd:97:00",
-    "ip6AddressList": [], "state": "up", "vrf": "bond02", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "vlan13", "ipAddressList":
-    ["172.16.1.1/24"], "macaddr": "52:54:00:61:91:8e", "ip6AddressList": ["2001:db8:0:1::1/64",
-    "fe80::5054:ff:fe61:918e/64"], "state": "up", "vrf": "default", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "vlan24", "ipAddressList":
-    ["172.16.2.1/24"], "macaddr": "52:54:00:61:91:8e", "ip6AddressList": ["2001:db8:0:2::1/64",
-    "fe80::5054:ff:fe61:918e/64"], "state": "up", "vrf": "default", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "eth0", "ipAddressList":
-    ["192.168.121.94/24"], "macaddr": "52:54:00:a5:d3:9f", "ip6AddressList": ["fe80::5054:ff:fea5:d39f/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr":
-    "ba:4a:8d:58:32:dc", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01", "ifname": "swp1",
-    "ipAddressList": [], "macaddr": "52:54:00:f1:8d:28", "ip6AddressList": ["fe80::5054:ff:fef1:8d28/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "ifname": "lo", "ipAddressList": ["10.0.0.21/32"], "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::21/128", "::1/128"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "swp5.4", "ipAddressList": ["169.254.254.9/30"],
-    "macaddr": "52:54:00:41:f9:4d", "ip6AddressList": ["fe80::5054:ff:fe41:f94d/64"],
-    "state": "up", "vrf": "internet-vrf", "timestamp": 1616638471112}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "ifname": "swp6", "ipAddressList": ["169.254.127.1/31"],
-    "macaddr": "52:54:00:31:e6:f2", "ip6AddressList": ["fe80::5054:ff:fe31:e6f2/64"],
-    "state": "up", "vrf": "internet-vrf", "timestamp": 1616638471112}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "ifname": "eth0", "ipAddressList": ["192.168.121.164/24"],
-    "macaddr": "52:54:00:7f:7a:90", "ip6AddressList": ["fe80::5054:ff:fe7f:7a90/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr":
-    "1e:39:2f:19:6b:80", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "peerlink.4094",
-    "ipAddressList": ["169.254.1.2/30"], "macaddr": "52:54:00:61:91:8e", "ip6AddressList":
-    ["fe80::5054:ff:fe61:918e/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "peerlink",
-    "ipAddressList": [], "macaddr": "52:54:00:61:91:8e", "ip6AddressList": [], "state":
-    "up", "vrf": "bridge", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "ifname": "swp5", "ipAddressList": [], "macaddr": "52:54:00:d8:a2:27",
-    "ip6AddressList": [], "state": "up", "vrf": "bond01", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "bridge", "ipAddressList":
-    [], "macaddr": "52:54:00:61:91:8e", "ip6AddressList": ["fe80::5054:ff:fe61:918e/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "lo", "ipAddressList": ["10.0.0.101/32"], "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname":
-    "swp1", "ipAddressList": [], "macaddr": "52:54:00:d7:13:17", "ip6AddressList":
-    ["fe80::5054:ff:fed7:1317/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname": "swp2",
-    "ipAddressList": [], "macaddr": "52:54:00:d6:12:38", "ip6AddressList": ["fe80::5054:ff:fed6:1238/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "ifname": "lo", "ipAddressList": ["10.0.0.12/32"], "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::12/128", "::1/128"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:da:45:f9",
-    "ip6AddressList": ["fe80::5054:ff:feda:45f9/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname":
-    "swp5", "ipAddressList": [], "macaddr": "52:54:00:41:f9:4d", "ip6AddressList":
-    ["fe80::5054:ff:fe41:f94d/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname": "swp5.2",
-    "ipAddressList": ["169.254.254.1/30"], "macaddr": "52:54:00:41:f9:4d", "ip6AddressList":
-    ["fe80::5054:ff:fe41:f94d/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01", "ifname": "mgmt",
-    "ipAddressList": ["127.0.0.1/8"], "macaddr": "96:82:91:f8:fb:c3", "ip6AddressList":
-    [], "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "ifname": "swp3", "ipAddressList": [], "macaddr":
-    "52:54:00:32:c3:37", "ip6AddressList": ["fe80::5054:ff:fe32:c337/64"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "ifname": "swp6", "ipAddressList": [], "macaddr": "52:54:00:5f:e8:d4",
-    "ip6AddressList": ["fe80::5054:ff:fe5f:e8d4/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "ifname": "swp5", "ipAddressList": [], "macaddr": "52:54:00:f6:f0:5d", "ip6AddressList":
-    ["fe80::5054:ff:fef6:f05d/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01", "ifname": "swp4",
-    "ipAddressList": [], "macaddr": "52:54:00:8d:ff:ce", "ip6AddressList": ["fe80::5054:ff:fe8d:ffce/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "ifname": "swp3", "ipAddressList": [], "macaddr": "52:54:00:db:b0:8e",
-    "ip6AddressList": ["fe80::5054:ff:fedb:b08e/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "ifname": "swp2", "ipAddressList": [], "macaddr": "52:54:00:6c:9d:f3", "ip6AddressList":
-    ["fe80::5054:ff:fe6c:9df3/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "bond01",
-    "ipAddressList": [], "macaddr": "52:54:00:d8:a2:27", "ip6AddressList": [], "state":
-    "up", "vrf": "bridge", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "ifname": "bond02", "ipAddressList": [], "macaddr": "52:54:00:dd:97:00",
-    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "spine01", "ifname": "eth0", "ipAddressList":
-    ["192.168.121.51/24"], "macaddr": "52:54:00:83:72:c9", "ip6AddressList": ["fe80::5054:ff:fe83:72c9/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "swp2", "ipAddressList": [], "macaddr": "52:54:00:33:c7:3d",
-    "ip6AddressList": ["fe80::5054:ff:fe33:c73d/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "leaf04", "ifname":
-    "swp3", "ipAddressList": [], "macaddr": "52:54:00:62:dc:88", "ip6AddressList":
-    [], "state": "up", "vrf": "peerlink", "timestamp": 1616638471115}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "ifname": "swp4", "ipAddressList": [], "macaddr":
-    "52:54:00:62:dc:88", "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp":
-    1616638471115}, {"namespace": "dual-bgp", "hostname": "leaf04", "ifname": "swp5",
-    "ipAddressList": [], "macaddr": "52:54:00:4e:04:fd", "ip6AddressList": [], "state":
-    "up", "vrf": "bond01", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "swp6", "ipAddressList": [], "macaddr": "52:54:00:eb:18:a7",
-    "ip6AddressList": [], "state": "up", "vrf": "bond02", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "ifname": "vlan13", "ipAddressList":
-    ["172.16.3.1/24"], "macaddr": "52:54:00:4e:04:fd", "ip6AddressList": ["2001:db8:0:3::1/64",
-    "fe80::5054:ff:fe4e:4fd/64"], "state": "up", "vrf": "default", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "internet", "ifname": "swp1", "ipAddressList":
-    ["169.254.127.0/31"], "macaddr": "52:54:00:7c:b7:33", "ip6AddressList": ["fe80::5054:ff:fe7c:b733/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "eth0", "ipAddressList": ["192.168.121.132/24"],
-    "macaddr": "52:54:00:1c:0e:57", "ip6AddressList": ["fe80::5054:ff:fe1c:e57/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
+    "default", "timestamp": 1639476253769}, {"namespace": "panos", "hostname": "server102",
+    "ifname": "eth0", "ipAddressList": ["10.255.2.76/24"], "macaddr": "52:54:00:74:49:da",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476253769},
+    {"namespace": "panos", "hostname": "server102", "ifname": "eth1", "ipAddressList":
+    [], "macaddr": "2a:b4:fa:73:2a:0d", "ip6AddressList": [], "state": "up", "vrf":
+    "bond0", "timestamp": 1639476253769}, {"namespace": "panos", "hostname": "server301",
+    "ifname": "eth2", "ipAddressList": [], "macaddr": "9e:f7:6f:94:05:0c", "ip6AddressList":
+    [], "state": "up", "vrf": "bond0", "timestamp": 1639476253889}, {"namespace":
+    "panos", "hostname": "server301", "ifname": "bond0", "ipAddressList": ["172.16.2.201/24"],
+    "macaddr": "9e:f7:6f:94:05:0c", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1639476253889}, {"namespace": "panos", "hostname": "server301", "ifname":
+    "eth1", "ipAddressList": [], "macaddr": "9e:f7:6f:94:05:0c", "ip6AddressList":
+    [], "state": "up", "vrf": "bond0", "timestamp": 1639476253889}, {"namespace":
+    "panos", "hostname": "server301", "ifname": "eth0", "ipAddressList": ["10.255.2.241/24"],
+    "macaddr": "52:54:00:9a:f9:e3", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1639476253889}, {"namespace": "panos", "hostname": "server301", "ifname":
+    "lo", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [],
+    "state": "up", "vrf": "default", "timestamp": 1639476253889}, {"namespace": "panos",
+    "hostname": "server302", "ifname": "lo", "ipAddressList": [], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476253942},
+    {"namespace": "panos", "hostname": "server302", "ifname": "eth0", "ipAddressList":
+    ["10.255.2.103/24"], "macaddr": "52:54:00:2e:b2:fa", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1639476253942}, {"namespace": "panos", "hostname":
+    "server302", "ifname": "eth1", "ipAddressList": [], "macaddr": "4e:01:f3:25:8c:7a",
+    "ip6AddressList": [], "state": "up", "vrf": "bond0", "timestamp": 1639476253942},
+    {"namespace": "panos", "hostname": "server302", "ifname": "eth2", "ipAddressList":
+    [], "macaddr": "4e:01:f3:25:8c:7a", "ip6AddressList": [], "state": "up", "vrf":
+    "bond0", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "server302",
+    "ifname": "bond0", "ipAddressList": ["172.16.3.202/24"], "macaddr": "4e:01:f3:25:8c:7a",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476253942},
+    {"namespace": "panos", "hostname": "server101", "ifname": "eth2", "ipAddressList":
+    [], "macaddr": "26:76:20:42:e2:c6", "ip6AddressList": [], "state": "up", "vrf":
+    "bond0", "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "server101",
+    "ifname": "eth1", "ipAddressList": [], "macaddr": "26:76:20:42:e2:c6", "ip6AddressList":
+    [], "state": "up", "vrf": "bond0", "timestamp": 1639476254006}, {"namespace":
+    "panos", "hostname": "server101", "ifname": "eth0", "ipAddressList": ["10.255.2.9/24"],
+    "macaddr": "52:54:00:0f:01:38", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "server101", "ifname":
+    "lo", "ipAddressList": [], "macaddr": "00:00:00:00:00:00", "ip6AddressList": [],
+    "state": "up", "vrf": "default", "timestamp": 1639476254006}, {"namespace": "panos",
+    "hostname": "server101", "ifname": "bond0", "ipAddressList": ["172.16.1.101/24"],
+    "macaddr": "26:76:20:42:e2:c6", "ip6AddressList": [], "state": "up", "vrf": "default",
+    "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "firewall01",
+    "ifname": "ethernet1/1.2", "ipAddressList": ["169.254.254.2/30"], "macaddr": "",
+    "ip6AddressList": ["fe80::b8db:eeff:fefb:ad10/64", "2001:1::1/127"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
+    "firewall01", "ifname": "ethernet1/2", "ipAddressList": [], "macaddr": "52:54:00:8e:ea:75",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254171},
+    {"namespace": "panos", "hostname": "firewall01", "ifname": "loopback", "ipAddressList":
+    ["10.0.0.200/32"], "macaddr": "ba:db:ee:fb:ad:03", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
+    "firewall01", "ifname": "ethernet1/1.3", "ipAddressList": ["169.254.254.6/30"],
+    "macaddr": "", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
+    1639476254171}, {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2.2",
+    "ipAddressList": ["169.254.253.2/30"], "macaddr": "", "ip6AddressList": ["fe80::b8db:eeff:fefb:ad11/64",
+    "2001:2::1/127"], "state": "up", "vrf": "default", "timestamp": 1639476254171},
+    {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2.3", "ipAddressList":
+    ["169.254.253.6/30"], "macaddr": "", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1639476254171}, {"namespace": "panos", "hostname": "firewall01",
+    "ifname": "ethernet1/2.4", "ipAddressList": ["169.254.253.10/30"], "macaddr":
+    "", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254171},
+    {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/1", "ipAddressList":
+    [], "macaddr": "52:54:00:11:a4:14", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1639476254171}, {"namespace": "panos", "hostname": "firewall01",
+    "ifname": "ethernet1/1.4", "ipAddressList": ["169.254.254.10/30"], "macaddr":
+    "", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254171},
+    {"namespace": "panos", "hostname": "firewall01", "ifname": "Management Interface",
+    "ipAddressList": ["10.255.2.141"], "macaddr": "52:54:00:0d:c8:77", "ip6AddressList":
+    ["fe80::5054:ff:fe0d:c877/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254171}, {"namespace": "panos", "hostname": "dcedge01", "ifname": "lo",
+    "ipAddressList": ["10.0.0.41/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254659}, {"namespace":
+    "panos", "hostname": "dcedge01", "ifname": "swp1", "ipAddressList": ["169.254.127.0/31"],
+    "macaddr": "52:54:00:89:e4:e1", "ip6AddressList": ["fe80::5054:ff:fe89:e4e1/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254659}, {"namespace": "panos",
+    "hostname": "dcedge01", "ifname": "swp2", "ipAddressList": ["169.254.127.2/31"],
+    "macaddr": "52:54:00:ba:b7:e0", "ip6AddressList": ["fe80::5054:ff:feba:b7e0/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254659}, {"namespace": "panos",
+    "hostname": "dcedge01", "ifname": "eth0", "ipAddressList": ["10.255.2.250/24"],
+    "macaddr": "44:38:39:01:03:fe", "ip6AddressList": ["fe80::4638:39ff:fe01:3fe/64"],
+    "state": "up", "vrf": "mgmt", "timestamp": 1639476254659}, {"namespace": "panos",
+    "hostname": "dcedge01", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr":
+    "66:9e:f3:a8:13:42", "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254659}, {"namespace": "panos", "hostname": "exit02", "ifname":
+    "swp3.4", "ipAddressList": ["169.254.253.9/30"], "macaddr": "52:54:00:36:33:d9",
+    "ip6AddressList": ["fe80::5054:ff:fe36:33d9/64"], "state": "up", "vrf": "internet-vrf",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname":
+    "vlan999", "ipAddressList": [], "macaddr": "44:39:39:ff:41:95", "ip6AddressList":
+    ["fe80::4639:39ff:feff:4195/64"], "state": "up", "vrf": "evpn-vrf", "timestamp":
+    1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.3",
+    "ipAddressList": ["169.254.254.5/30"], "macaddr": "52:54:00:de:82:68", "ip6AddressList":
+    ["fe80::5054:ff:fede:8268/64"], "state": "up", "vrf": "evpn-vrf", "timestamp":
+    1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "evpn-vrf",
+    "ipAddressList": [], "macaddr": "9e:d8:75:87:06:00", "ip6AddressList": [], "state":
+    "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+    "exit01", "ifname": "vni999", "ipAddressList": [], "macaddr": "da:02:77:48:60:af",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1639476254817},
+    {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.2", "ipAddressList":
+    ["169.254.254.1/30"], "macaddr": "52:54:00:de:82:68", "ip6AddressList": ["fe80::5054:ff:fede:8268/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "exit01", "ifname": "swp2", "ipAddressList": ["10.0.0.31/32"], "macaddr":
+    "52:54:00:24:8c:0b", "ip6AddressList": ["fe80::5054:ff:fe24:8c0b/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+    "exit01", "ifname": "internet-vrf", "ipAddressList": [], "macaddr": "12:1e:84:c1:0e:83",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254817},
+    {"namespace": "panos", "hostname": "exit02", "ifname": "internet-vrf", "ipAddressList":
+    [], "macaddr": "76:10:45:cf:55:05", "ip6AddressList": [], "state": "up", "vrf":
+    "default", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01",
+    "ifname": "lo", "ipAddressList": ["10.0.0.31/32"], "macaddr": "00:00:00:00:00:00",
+    "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254817},
+    {"namespace": "panos", "hostname": "exit01", "ifname": "bridge", "ipAddressList":
+    [], "macaddr": "da:02:77:48:60:af", "ip6AddressList": ["fe80::d802:77ff:fe48:60af/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "exit01", "ifname": "swp3", "ipAddressList": [], "macaddr": "52:54:00:de:82:68",
+    "ip6AddressList": ["fe80::5054:ff:fede:8268/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname":
+    "swp3.4", "ipAddressList": ["169.254.254.9/30"], "macaddr": "52:54:00:de:82:68",
+    "ip6AddressList": ["fe80::5054:ff:fede:8268/64"], "state": "up", "vrf": "internet-vrf",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname":
+    "swp1", "ipAddressList": ["10.0.0.31/32"], "macaddr": "52:54:00:53:4c:f5", "ip6AddressList":
+    ["fe80::5054:ff:fe53:4cf5/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "eth0",
+    "ipAddressList": ["10.255.2.251/24"], "macaddr": "44:38:39:01:03:01", "ip6AddressList":
+    ["fe80::4638:39ff:fe01:301/64"], "state": "up", "vrf": "mgmt", "timestamp": 1639476254817},
+    {"namespace": "panos", "hostname": "exit01", "ifname": "swp4", "ipAddressList":
+    ["169.254.127.1/31"], "macaddr": "52:54:00:de:df:7d", "ip6AddressList": ["fe80::5054:ff:fede:df7d/64"],
+    "state": "up", "vrf": "internet-vrf", "timestamp": 1639476254817}, {"namespace":
+    "panos", "hostname": "exit02", "ifname": "swp4", "ipAddressList": ["169.254.127.3/31"],
+    "macaddr": "52:54:00:e4:4d:a4", "ip6AddressList": ["fe80::5054:ff:fee4:4da4/64"],
+    "state": "up", "vrf": "internet-vrf", "timestamp": 1639476254817}, {"namespace":
+    "panos", "hostname": "exit02", "ifname": "eth0", "ipAddressList": ["10.255.2.252/24"],
+    "macaddr": "44:38:39:01:03:02", "ip6AddressList": ["fe80::4638:39ff:fe01:302/64"],
+    "state": "up", "vrf": "mgmt", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "exit02", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr":
+    "1e:35:b8:33:f3:1b", "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname":
+    "swp3.3", "ipAddressList": ["169.254.253.5/30"], "macaddr": "52:54:00:36:33:d9",
+    "ip6AddressList": ["fe80::5054:ff:fe36:33d9/64"], "state": "up", "vrf": "evpn-vrf",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname":
+    "evpn-vrf", "ipAddressList": [], "macaddr": "aa:17:ca:a7:57:fc", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace":
+    "panos", "hostname": "exit02", "ifname": "vni999", "ipAddressList": [], "macaddr":
+    "4a:7d:c4:74:ec:93", "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp":
+    1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname": "vlan999",
+    "ipAddressList": [], "macaddr": "44:39:39:ff:41:96", "ip6AddressList": ["fe80::4639:39ff:feff:4196/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "exit02", "ifname": "swp3", "ipAddressList": [], "macaddr": "52:54:00:36:33:d9",
+    "ip6AddressList": ["fe80::5054:ff:fe36:33d9/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname":
+    "swp2", "ipAddressList": ["10.0.0.32/32"], "macaddr": "52:54:00:3c:63:f0", "ip6AddressList":
+    ["fe80::5054:ff:fe3c:63f0/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.32/32"], "macaddr": "52:54:00:d2:4a:6a", "ip6AddressList":
+    ["fe80::5054:ff:fed2:4a6a/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname": "lo", "ipAddressList":
+    ["10.0.0.32/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "exit02", "ifname": "bridge", "ipAddressList": [], "macaddr": "4a:7d:c4:74:ec:93",
+    "ip6AddressList": ["fe80::487d:c4ff:fe74:ec93/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname":
+    "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr": "c2:29:96:08:4e:2e", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace":
+    "panos", "hostname": "exit02", "ifname": "swp3.2", "ipAddressList": ["169.254.253.1/30"],
+    "macaddr": "52:54:00:36:33:d9", "ip6AddressList": ["fe80::5054:ff:fe36:33d9/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "bridge", "ipAddressList": [], "macaddr": "52:54:00:12:5d:46",
+    "ip6AddressList": ["fe80::5054:ff:fe12:5d46/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
+    "swp4", "ipAddressList": [], "macaddr": "52:54:00:06:a0:c9", "ip6AddressList":
+    [], "state": "up", "vrf": "bond02", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf04", "ifname": "lo", "ipAddressList": ["10.0.0.14/32",
+    "10.0.0.134/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "peerlink", "ipAddressList": [], "macaddr": "48:47:00:20:27:cd",
+    "ip6AddressList": ["fe80::4a47:ff:fe20:27cd/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
+    "peerlink.4094", "ipAddressList": [], "macaddr": "48:47:00:20:27:cd", "ip6AddressList":
+    ["fe80::4a47:ff:fe20:27cd/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.14/32"], "macaddr": "52:54:00:d8:ee:83", "ip6AddressList":
+    ["fe80::5054:ff:fed8:ee83/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "swp2",
+    "ipAddressList": ["10.0.0.14/32"], "macaddr": "52:54:00:69:28:3b", "ip6AddressList":
+    ["fe80::5054:ff:fe69:283b/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "swp3",
+    "ipAddressList": [], "macaddr": "52:54:00:12:5d:46", "ip6AddressList": [], "state":
+    "up", "vrf": "bond01", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf04", "ifname": "swp5", "ipAddressList": [], "macaddr": "48:47:00:20:27:cd",
+    "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp": 1639476254836},
+    {"namespace": "panos", "hostname": "leaf04", "ifname": "vlan999", "ipAddressList":
+    [], "macaddr": "44:39:39:ff:40:96", "ip6AddressList": ["fe80::4639:39ff:feff:4096/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "vni20", "ipAddressList": [], "macaddr": "1e:b6:ff:b1:dd:bb",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1639476254836},
+    {"namespace": "panos", "hostname": "leaf04", "ifname": "vni30", "ipAddressList":
+    [], "macaddr": "ee:ed:b0:ba:3c:d7", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04",
+    "ifname": "vni999", "ipAddressList": [], "macaddr": "76:71:3c:2d:a8:12", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf04", "ifname": "Vlan20", "ipAddressList": ["172.16.2.254/24"],
+    "macaddr": "00:00:00:11:12:20", "ip6AddressList": ["fe80::200:ff:fe11:1220/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "Vlan30", "ipAddressList": ["172.16.3.254/24"],
+    "macaddr": "00:00:00:11:12:30", "ip6AddressList": ["fe80::200:ff:fe11:1230/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "evpn-vrf", "ipAddressList": [], "macaddr": "66:82:b4:33:e7:75",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254836},
+    {"namespace": "panos", "hostname": "leaf04", "ifname": "eth0", "ipAddressList":
+    ["10.255.2.187/24"], "macaddr": "44:38:39:01:02:04", "ip6AddressList": ["fe80::4638:39ff:fe01:204/64"],
+    "state": "up", "vrf": "mgmt", "timestamp": 1639476254836}, {"namespace": "panos",
     "hostname": "leaf04", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr":
-    "36:45:f6:59:f3:b6", "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp":
-    1616638471115}, {"namespace": "dual-bgp", "hostname": "internet", "ifname": "lo",
-    "ipAddressList": ["10.0.0.253/32", "172.16.253.1/32"], "macaddr": "00:00:00:00:00:00",
-    "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "internet", "ifname": "eth0", "ipAddressList":
-    ["192.168.121.141/24"], "macaddr": "52:54:00:46:fe:70", "ip6AddressList": ["fe80::5054:ff:fe46:fe70/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "swp1", "ipAddressList": [], "macaddr": "52:54:00:7e:5a:82",
-    "ip6AddressList": ["fe80::5054:ff:fe7e:5a82/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname":
-    "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr": "56:d5:34:84:93:0c", "ip6AddressList":
-    [], "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "ifname": "vlan24", "ipAddressList": ["172.16.4.1/24"],
-    "macaddr": "52:54:00:4e:04:fd", "ip6AddressList": ["2001:db8:0:4::1/64", "fe80::5054:ff:fe4e:4fd/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "peerlink.4094", "ipAddressList": ["169.254.1.2/30"],
-    "macaddr": "52:54:00:62:dc:88", "ip6AddressList": ["fe80::5054:ff:fe62:dc88/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "lo", "ipAddressList": ["10.0.0.14/32"], "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::12/128", "::1/128"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "ifname": "swp5.4", "ipAddressList": ["169.254.253.9/30"],
-    "macaddr": "52:54:00:17:a9:1a", "ip6AddressList": ["fe80::5054:ff:fe17:a91a/64"],
-    "state": "up", "vrf": "internet-vrf", "timestamp": 1616638471115}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "ifname": "bridge", "ipAddressList": [], "macaddr":
-    "52:54:00:4e:04:fd", "ip6AddressList": ["fe80::5054:ff:fe4e:4fd/64"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "bond02", "ipAddressList": [], "macaddr": "52:54:00:eb:18:a7",
-    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "ifname": "bond01", "ipAddressList":
-    [], "macaddr": "52:54:00:4e:04:fd", "ip6AddressList": [], "state": "up", "vrf":
-    "bridge", "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02",
-    "ifname": "internet-vrf", "ipAddressList": ["10.0.0.102/32"], "macaddr": "ae:ce:d3:71:a6:c9",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "exit02", "ifname": "swp5.2", "ipAddressList":
-    ["169.254.253.1/30"], "macaddr": "52:54:00:17:a9:1a", "ip6AddressList": ["fe80::5054:ff:fe17:a91a/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "ifname": "swp5", "ipAddressList": [], "macaddr": "52:54:00:17:a9:1a",
-    "ip6AddressList": ["fe80::5054:ff:fe17:a91a/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname":
-    "swp4", "ipAddressList": [], "macaddr": "52:54:00:32:ad:c1", "ip6AddressList":
-    ["fe80::5054:ff:fe32:adc1/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname": "swp3",
-    "ipAddressList": [], "macaddr": "52:54:00:d1:4f:4d", "ip6AddressList": ["fe80::5054:ff:fed1:4f4d/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "ifname": "swp2", "ipAddressList": [], "macaddr": "52:54:00:8d:05:90",
-    "ip6AddressList": ["fe80::5054:ff:fe8d:590/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname":
-    "swp1", "ipAddressList": [], "macaddr": "52:54:00:a1:d8:6a", "ip6AddressList":
-    ["fe80::5054:ff:fea1:d86a/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname": "lo",
-    "ipAddressList": ["10.0.0.102/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "ifname": "eth0", "ipAddressList": ["192.168.121.181/24"],
-    "macaddr": "52:54:00:cf:36:be", "ip6AddressList": ["fe80::5054:ff:fecf:36be/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "internet", "ifname": "swp2", "ipAddressList": ["169.254.127.2/31"],
-    "macaddr": "52:54:00:71:3e:55", "ip6AddressList": ["fe80::5054:ff:fe71:3e55/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "peerlink", "ipAddressList": [], "macaddr": "52:54:00:62:dc:88",
-    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "exit02", "ifname": "swp6", "ipAddressList":
-    ["169.254.127.3/31"], "macaddr": "52:54:00:01:1f:98", "ip6AddressList": ["fe80::5054:ff:fe01:1f98/64"],
-    "state": "up", "vrf": "internet-vrf", "timestamp": 1616638471115}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "ifname": "bond02", "ipAddressList": [], "macaddr":
-    "52:54:00:dc:c2:ff", "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp":
-    1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "mgmt",
-    "ipAddressList": ["127.0.0.1/8"], "macaddr": "02:a6:92:38:c3:a7", "ip6AddressList":
-    [], "state": "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "ifname": "bridge", "ipAddressList": [], "macaddr":
-    "52:54:00:76:91:c0", "ip6AddressList": ["fe80::5054:ff:fe76:91c0/64"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "lo", "ipAddressList": ["10.0.0.11/32"], "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::11/128", "::1/128"], "state":
-    "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "peerlink", "ipAddressList": [], "macaddr": "52:54:00:76:91:c0",
-    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1616638471143},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "peerlink.4094", "ipAddressList":
-    ["169.254.1.1/30"], "macaddr": "52:54:00:76:91:c0", "ip6AddressList": ["fe80::5054:ff:fe76:91c0/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "swp1", "ipAddressList": [], "macaddr": "52:54:00:a1:d2:0b",
-    "ip6AddressList": ["fe80::5054:ff:fea1:d20b/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname":
-    "swp2", "ipAddressList": [], "macaddr": "52:54:00:6b:79:41", "ip6AddressList":
-    ["fe80::5054:ff:fe6b:7941/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "swp3",
-    "ipAddressList": [], "macaddr": "52:54:00:76:91:c0", "ip6AddressList": [], "state":
-    "up", "vrf": "peerlink", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:76:91:c0",
-    "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp": 1616638471143},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "swp5", "ipAddressList":
-    [], "macaddr": "52:54:00:ff:0f:ce", "ip6AddressList": [], "state": "up", "vrf":
-    "bond01", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01",
-    "ifname": "swp6", "ipAddressList": [], "macaddr": "52:54:00:dc:c2:ff", "ip6AddressList":
-    [], "state": "up", "vrf": "bond02", "timestamp": 1616638471143}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "ifname": "vlan13", "ipAddressList": ["172.16.1.1/24"],
-    "macaddr": "52:54:00:76:91:c0", "ip6AddressList": ["2001:db8:0:1::1/64", "fe80::5054:ff:fe76:91c0/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "vlan24", "ipAddressList": ["172.16.2.1/24"],
-    "macaddr": "52:54:00:76:91:c0", "ip6AddressList": ["2001:db8:0:2::1/64", "fe80::5054:ff:fe76:91c0/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "eth0", "ipAddressList": ["192.168.121.119/24"],
-    "macaddr": "52:54:00:11:7d:b8", "ip6AddressList": ["fe80::5054:ff:fe11:7db8/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "bond01", "ipAddressList": [], "macaddr": "52:54:00:ff:0f:ce",
-    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1616638471143},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "ifname": "mgmt", "ipAddressList":
-    ["127.0.0.1/8"], "macaddr": "7e:70:dd:80:8f:8d", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "bridge", "ipAddressList": [], "macaddr": "52:54:00:37:45:2d",
-    "ip6AddressList": ["fe80::5054:ff:fe37:452d/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471859}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname":
-    "lo", "ipAddressList": ["10.0.0.13/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    ["2001:db8::12/128", "::1/128"], "state": "up", "vrf": "default", "timestamp":
-    1616638471859}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname": "peerlink",
-    "ipAddressList": [], "macaddr": "52:54:00:37:45:2d", "ip6AddressList": [], "state":
-    "up", "vrf": "bridge", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "peerlink.4094", "ipAddressList": ["169.254.1.1/30"],
-    "macaddr": "52:54:00:37:45:2d", "ip6AddressList": ["fe80::5054:ff:fe37:452d/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "swp1", "ipAddressList": [], "macaddr": "52:54:00:79:48:5e",
-    "ip6AddressList": ["fe80::5054:ff:fe79:485e/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471859}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname":
-    "swp2", "ipAddressList": [], "macaddr": "52:54:00:c6:7c:c6", "ip6AddressList":
-    ["fe80::5054:ff:fec6:7cc6/64"], "state": "up", "vrf": "default", "timestamp":
-    1616638471859}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname": "swp3",
-    "ipAddressList": [], "macaddr": "52:54:00:37:45:2d", "ip6AddressList": [], "state":
-    "up", "vrf": "peerlink", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:37:45:2d",
-    "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp": 1616638471859},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "ifname": "swp5", "ipAddressList":
-    [], "macaddr": "52:54:00:44:8d:bb", "ip6AddressList": [], "state": "up", "vrf":
-    "bond01", "timestamp": 1616638471859}, {"namespace": "dual-bgp", "hostname": "leaf03",
-    "ifname": "swp6", "ipAddressList": [], "macaddr": "52:54:00:dc:18:8c", "ip6AddressList":
-    [], "state": "up", "vrf": "bond02", "timestamp": 1616638471859}, {"namespace":
-    "dual-bgp", "hostname": "leaf03", "ifname": "vlan13", "ipAddressList": ["172.16.3.1/24"],
-    "macaddr": "52:54:00:37:45:2d", "ip6AddressList": ["2001:db8:0:3::1/64", "fe80::5054:ff:fe37:452d/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "vlan24", "ipAddressList": ["172.16.4.1/24"],
-    "macaddr": "52:54:00:37:45:2d", "ip6AddressList": ["2001:db8:0:4::1/64", "fe80::5054:ff:fe37:452d/64"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "eth0", "ipAddressList": ["192.168.121.33/24"],
-    "macaddr": "52:54:00:7c:35:15", "ip6AddressList": ["fe80::5054:ff:fe7c:3515/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471859}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "bond02", "ipAddressList": [], "macaddr": "52:54:00:dc:18:8c",
-    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1616638471859},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "ifname": "bond01", "ipAddressList":
-    [], "macaddr": "52:54:00:44:8d:bb", "ip6AddressList": [], "state": "up", "vrf":
-    "bridge", "timestamp": 1616638471859}]'
+    "4e:6d:8a:ad:95:c9", "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
+    "bond02", "ipAddressList": [], "macaddr": "52:54:00:06:a0:c9", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf04", "ifname": "swp6", "ipAddressList": [], "macaddr":
+    "48:47:00:20:27:cd", "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "bond01",
+    "ipAddressList": [], "macaddr": "52:54:00:12:5d:46", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf02", "ifname": "evpn-vrf", "ipAddressList": [], "macaddr": "8a:75:81:f5:04:8f",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254836},
+    {"namespace": "panos", "hostname": "leaf02", "ifname": "bond02", "ipAddressList":
+    [], "macaddr": "52:54:00:b0:50:70", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+    "ifname": "Vlan30", "ipAddressList": ["172.16.3.254/24"], "macaddr": "00:00:00:11:12:30",
+    "ip6AddressList": ["fe80::200:ff:fe11:1230/64"], "state": "up", "vrf": "evpn-vrf",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
+    "vni30", "ipAddressList": [], "macaddr": "5a:e5:40:c3:44:d4", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf02", "ifname": "vlan999", "ipAddressList": [], "macaddr":
+    "44:39:39:ff:40:95", "ip6AddressList": ["fe80::4639:39ff:feff:4095/64"], "state":
+    "up", "vrf": "evpn-vrf", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf02", "ifname": "eth0", "ipAddressList": ["10.255.2.185/24"], "macaddr": "44:38:39:01:02:02",
+    "ip6AddressList": ["fe80::4638:39ff:fe01:202/64"], "state": "up", "vrf": "mgmt",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
+    "vni10", "ipAddressList": [], "macaddr": "06:bf:86:d3:80:e1", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf02", "ifname": "swp6", "ipAddressList": [], "macaddr":
+    "48:47:00:98:3d:08", "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp5",
+    "ipAddressList": [], "macaddr": "48:47:00:98:3d:08", "ip6AddressList": [], "state":
+    "up", "vrf": "peerlink", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf02", "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:b0:50:70",
+    "ip6AddressList": [], "state": "up", "vrf": "bond02", "timestamp": 1639476254836},
+    {"namespace": "panos", "hostname": "leaf02", "ifname": "swp3", "ipAddressList":
+    [], "macaddr": "52:54:00:cb:a1:ea", "ip6AddressList": [], "state": "up", "vrf":
+    "bond01", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+    "ifname": "swp2", "ipAddressList": ["10.0.0.12/32"], "macaddr": "52:54:00:69:bc:26",
+    "ip6AddressList": ["fe80::5054:ff:fe69:bc26/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
+    "swp1", "ipAddressList": ["10.0.0.12/32"], "macaddr": "52:54:00:6f:d5:11", "ip6AddressList":
+    ["fe80::5054:ff:fe6f:d511/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "Vlan10",
+    "ipAddressList": ["172.16.1.254/24"], "macaddr": "00:00:00:11:12:10", "ip6AddressList":
+    ["fe80::200:ff:fe11:1210/64"], "state": "up", "vrf": "evpn-vrf", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "peerlink.4094",
+    "ipAddressList": [], "macaddr": "48:47:00:98:3d:08", "ip6AddressList": ["fe80::4a47:ff:fe98:3d08/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf02", "ifname": "lo", "ipAddressList": ["10.0.0.12/32", "10.0.0.112/32"],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"], "state": "up",
+    "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf02", "ifname": "bridge", "ipAddressList": [], "macaddr": "52:54:00:cb:a1:ea",
+    "ip6AddressList": ["fe80::5054:ff:fecb:a1ea/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
+    "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr": "66:f8:11:d3:1c:81", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf02", "ifname": "bond01", "ipAddressList": [], "macaddr":
+    "52:54:00:cb:a1:ea", "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "peerlink",
+    "ipAddressList": [], "macaddr": "48:47:00:98:3d:08", "ip6AddressList": ["fe80::4a47:ff:fe98:3d08/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf02", "ifname": "vni999", "ipAddressList": [], "macaddr": "a2:8f:8f:c7:a1:3c",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1639476254836},
+    {"namespace": "panos", "hostname": "spine02", "ifname": "lo", "ipAddressList":
+    ["10.0.0.22/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos",
+    "hostname": "spine02", "ifname": "swp1", "ipAddressList": ["10.0.0.22/32"], "macaddr":
+    "52:54:00:eb:56:a6", "ip6AddressList": ["fe80::5054:ff:feeb:56a6/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "spine02", "ifname": "swp2", "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:56:b7:ac",
+    "ip6AddressList": ["fe80::5054:ff:fe56:b7ac/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname":
+    "swp3", "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:88:70:ac", "ip6AddressList":
+    ["fe80::5054:ff:fe88:70ac/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp4",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:52:25:2e", "ip6AddressList":
+    ["fe80::5054:ff:fe52:252e/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp5",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:88:51:93", "ip6AddressList":
+    ["fe80::5054:ff:fe88:5193/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp6",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:3d:45:07", "ip6AddressList":
+    ["fe80::5054:ff:fe3d:4507/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "bond01",
+    "ipAddressList": [], "macaddr": "52:54:00:6c:e0:4a", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "leaf03", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr": "66:fb:4a:13:36:44",
+    "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254844},
+    {"namespace": "panos", "hostname": "leaf03", "ifname": "bond02", "ipAddressList":
+    [], "macaddr": "52:54:00:e3:c1:9e", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
+    "ifname": "bridge", "ipAddressList": [], "macaddr": "52:54:00:6c:e0:4a", "ip6AddressList":
+    ["fe80::5054:ff:fe6c:e04a/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "lo", "ipAddressList":
+    ["10.0.0.13/32", "10.0.0.134/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace":
+    "panos", "hostname": "leaf03", "ifname": "peerlink", "ipAddressList": [], "macaddr":
+    "48:47:00:36:b8:ff", "ip6AddressList": ["fe80::4a47:ff:fe36:b8ff/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "leaf03", "ifname": "peerlink.4094", "ipAddressList": [], "macaddr": "48:47:00:36:b8:ff",
+    "ip6AddressList": ["fe80::4a47:ff:fe36:b8ff/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname":
+    "swp1", "ipAddressList": ["10.0.0.13/32"], "macaddr": "52:54:00:dd:d1:18", "ip6AddressList":
+    ["fe80::5054:ff:fedd:d118/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp2",
+    "ipAddressList": ["10.0.0.13/32"], "macaddr": "52:54:00:7b:cc:c3", "ip6AddressList":
+    ["fe80::5054:ff:fe7b:ccc3/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "eth0",
+    "ipAddressList": ["10.255.2.118/24"], "macaddr": "44:38:39:01:01:02", "ip6AddressList":
+    ["fe80::4638:39ff:fe01:102/64"], "state": "up", "vrf": "mgmt", "timestamp": 1639476254844},
+    {"namespace": "panos", "hostname": "leaf03", "ifname": "swp3", "ipAddressList":
+    [], "macaddr": "52:54:00:6c:e0:4a", "ip6AddressList": [], "state": "up", "vrf":
+    "bond01", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
+    "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:e3:c1:9e", "ip6AddressList":
+    [], "state": "up", "vrf": "bond02", "timestamp": 1639476254844}, {"namespace":
+    "panos", "hostname": "spine02", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"],
+    "macaddr": "ee:7c:7a:6f:a6:01", "ip6AddressList": ["::1/128"], "state": "up",
+    "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "leaf03", "ifname": "swp6", "ipAddressList": [], "macaddr": "48:47:00:36:b8:ff",
+    "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp": 1639476254844},
+    {"namespace": "panos", "hostname": "leaf03", "ifname": "vni20", "ipAddressList":
+    [], "macaddr": "d2:8b:a6:04:35:98", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
+    "ifname": "vni30", "ipAddressList": [], "macaddr": "86:a8:63:04:4d:5b", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1639476254844}, {"namespace":
+    "panos", "hostname": "leaf03", "ifname": "vni999", "ipAddressList": [], "macaddr":
+    "5a:b6:19:2f:83:a5", "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "Vlan20",
+    "ipAddressList": ["172.16.2.254/24"], "macaddr": "00:00:00:11:12:20", "ip6AddressList":
+    ["fe80::200:ff:fe11:1220/64"], "state": "up", "vrf": "evpn-vrf", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp5",
+    "ipAddressList": [], "macaddr": "48:47:00:36:b8:ff", "ip6AddressList": [], "state":
+    "up", "vrf": "peerlink", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "leaf03", "ifname": "evpn-vrf", "ipAddressList": [], "macaddr": "96:7b:37:27:5a:d3",
+    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1639476254844},
+    {"namespace": "panos", "hostname": "leaf03", "ifname": "vlan999", "ipAddressList":
+    [], "macaddr": "44:39:39:ff:40:96", "ip6AddressList": ["fe80::4639:39ff:feff:4096/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254844}, {"namespace": "panos",
+    "hostname": "leaf03", "ifname": "eth0", "ipAddressList": ["10.255.2.186/24"],
+    "macaddr": "44:38:39:01:02:03", "ip6AddressList": ["fe80::4638:39ff:fe01:203/64"],
+    "state": "up", "vrf": "mgmt", "timestamp": 1639476254844}, {"namespace": "panos",
+    "hostname": "leaf03", "ifname": "Vlan30", "ipAddressList": ["172.16.3.254/24"],
+    "macaddr": "00:00:00:11:12:30", "ip6AddressList": ["fe80::200:ff:fe11:1230/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254844}, {"namespace": "panos",
+    "hostname": "spine01", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr":
+    "16:3c:be:94:91:b5", "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname":
+    "swp6", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:c4:54:00", "ip6AddressList":
+    ["fe80::5054:ff:fec4:5400/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp5",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:f5:f0:96", "ip6AddressList":
+    ["fe80::5054:ff:fef5:f096/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp4",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:a0:82:3d", "ip6AddressList":
+    ["fe80::5054:ff:fea0:823d/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp3",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:d3:be:93", "ip6AddressList":
+    ["fe80::5054:ff:fed3:be93/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp2",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:41:6f:13", "ip6AddressList":
+    ["fe80::5054:ff:fe41:6f13/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:83:d9:77", "ip6AddressList":
+    ["fe80::5054:ff:fe83:d977/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "lo",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254852}, {"namespace":
+    "panos", "hostname": "spine01", "ifname": "eth0", "ipAddressList": ["10.255.2.117/24"],
+    "macaddr": "44:38:39:01:01:01", "ip6AddressList": ["fe80::4638:39ff:fe01:101/64"],
+    "state": "up", "vrf": "mgmt", "timestamp": 1639476254852}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "bond01", "ipAddressList": [], "macaddr": "52:54:00:05:e0:cc",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1639476254854},
+    {"namespace": "panos", "hostname": "leaf01", "ifname": "bridge", "ipAddressList":
+    [], "macaddr": "52:54:00:05:e0:cc", "ip6AddressList": ["fe80::5054:ff:fe05:e0cc/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "lo", "ipAddressList": ["10.0.0.11/32", "10.0.0.112/32"],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"], "state": "up",
+    "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+    "leaf01", "ifname": "mgmt", "ipAddressList": ["127.0.0.1/8"], "macaddr": "36:91:1d:d2:94:21",
+    "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254854},
+    {"namespace": "panos", "hostname": "leaf01", "ifname": "eth0", "ipAddressList":
+    ["10.255.2.184/24"], "macaddr": "44:38:39:01:02:01", "ip6AddressList": ["fe80::4638:39ff:fe01:201/64"],
+    "state": "up", "vrf": "mgmt", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "vlan999", "ipAddressList": [], "macaddr": "44:39:39:ff:40:95",
+    "ip6AddressList": ["fe80::4639:39ff:feff:4095/64"], "state": "up", "vrf": "evpn-vrf",
+    "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname":
+    "evpn-vrf", "ipAddressList": [], "macaddr": "22:46:96:72:ea:46", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace":
+    "panos", "hostname": "leaf01", "ifname": "Vlan30", "ipAddressList": ["172.16.3.254/24"],
+    "macaddr": "00:00:00:11:12:30", "ip6AddressList": ["fe80::200:ff:fe11:1230/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "Vlan10", "ipAddressList": ["172.16.1.254/24"],
+    "macaddr": "00:00:00:11:12:10", "ip6AddressList": ["fe80::200:ff:fe11:1210/64"],
+    "state": "up", "vrf": "evpn-vrf", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "vni999", "ipAddressList": [], "macaddr": "e2:bb:bd:0e:f5:47",
+    "ip6AddressList": [], "state": "up", "vrf": "bridge", "timestamp": 1639476254854},
+    {"namespace": "panos", "hostname": "leaf01", "ifname": "bond02", "ipAddressList":
+    [], "macaddr": "52:54:00:74:07:99", "ip6AddressList": [], "state": "up", "vrf":
+    "bridge", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01",
+    "ifname": "vni30", "ipAddressList": [], "macaddr": "ba:a6:68:89:94:68", "ip6AddressList":
+    [], "state": "up", "vrf": "bridge", "timestamp": 1639476254854}, {"namespace":
+    "panos", "hostname": "leaf01", "ifname": "swp6", "ipAddressList": [], "macaddr":
+    "48:47:00:a1:2a:cc", "ip6AddressList": [], "state": "up", "vrf": "peerlink", "timestamp":
+    1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp5",
+    "ipAddressList": [], "macaddr": "48:47:00:a1:2a:cc", "ip6AddressList": [], "state":
+    "up", "vrf": "peerlink", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+    "leaf01", "ifname": "swp4", "ipAddressList": [], "macaddr": "52:54:00:74:07:99",
+    "ip6AddressList": [], "state": "up", "vrf": "bond02", "timestamp": 1639476254854},
+    {"namespace": "panos", "hostname": "leaf01", "ifname": "swp2", "ipAddressList":
+    ["10.0.0.11/32"], "macaddr": "52:54:00:89:13:56", "ip6AddressList": ["fe80::5054:ff:fe89:1356/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "swp1", "ipAddressList": ["10.0.0.11/32"], "macaddr":
+    "52:54:00:c4:19:83", "ip6AddressList": ["fe80::5054:ff:fec4:1983/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+    "leaf01", "ifname": "peerlink.4094", "ipAddressList": [], "macaddr": "48:47:00:a1:2a:cc",
+    "ip6AddressList": ["fe80::4a47:ff:fea1:2acc/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname":
+    "peerlink", "ipAddressList": [], "macaddr": "48:47:00:a1:2a:cc", "ip6AddressList":
+    ["fe80::4a47:ff:fea1:2acc/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname": "vni10",
+    "ipAddressList": [], "macaddr": "5e:1a:f8:45:bc:61", "ip6AddressList": [], "state":
+    "up", "vrf": "bridge", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+    "leaf01", "ifname": "swp3", "ipAddressList": [], "macaddr": "52:54:00:05:e0:cc",
+    "ip6AddressList": [], "state": "up", "vrf": "bond01", "timestamp": 1639476254854}]'
 - command: address show --address="44:38:39:00:00:34 44:39:39:ff:00:13"  --format=json
   data-directory: tests/data/panos/parquet-out
   marks: address show panos filter
@@ -1064,398 +1178,273 @@ tests:
   marks: address show panos filter
   output: '[]'
 - command: address show --address="2001:db8::21/128"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "spine01", "ifname": "lo", "ipAddressList":
-    ["10.0.0.21/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": "2001:db8::21/128",
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}]'
+  output: '[]'
 - command: address show --address="2001:db9::21/128"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
   output: '[]'
 - command: address show --address="2001:db8:0:1::101 2001:db8::12"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0",
-    "ipAddressList": ["172.16.1.101/24"], "macaddr": "52:54:00:d6:66:41", "ip6AddressList":
-    "2001:db8:0:1::101/64", "state": "up", "vrf": "default", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "lo", "ipAddressList":
-    ["10.0.0.12/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": "2001:db8::12/128",
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "lo", "ipAddressList": ["10.0.0.14/32"], "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": "2001:db8::12/128", "state": "up", "vrf":
-    "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname":
-    "leaf03", "ifname": "lo", "ipAddressList": ["10.0.0.13/32"], "macaddr": "00:00:00:00:00:00",
-    "ip6AddressList": "2001:db8::12/128", "state": "up", "vrf": "default", "timestamp":
-    1616638471859}]'
+  output: '[]'
 - command: address show --address="2001:db8::12  2001:db8:0:1::101 10.0.0.101"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0",
-    "ipAddressList": "172.16.1.101/24", "macaddr": "52:54:00:d6:66:41", "ip6AddressList":
-    "2001:db8:0:1::101/64", "state": "up", "vrf": "default", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "exit01", "ifname": "internet-vrf", "ipAddressList":
-    "10.0.0.101/32", "macaddr": "d6:f4:51:5f:6b:77", "ip6AddressList": "", "state":
-    "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "lo", "ipAddressList": "10.0.0.101/32", "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": "::1/128", "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname":
-    "lo", "ipAddressList": "10.0.0.12/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    "2001:db8::12/128", "state": "up", "vrf": "default", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "ifname": "lo", "ipAddressList":
-    "10.0.0.14/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": "2001:db8::12/128",
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "lo", "ipAddressList": "10.0.0.13/32", "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": "2001:db8::12/128", "state": "up", "vrf":
-    "default", "timestamp": 1616638471859}]'
+  output: '[]'
 - command: address show --address="2001:db8::12  2001:db8:0:1::101 10.0.0.101 52:54:00:76:91:c0
     10.0.0.14"  --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0",
-    "ipAddressList": "172.16.1.101/24", "macaddr": "52:54:00:d6:66:41", "ip6AddressList":
-    "2001:db8:0:1::101/64", "state": "up", "vrf": "default", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "exit01", "ifname": "internet-vrf", "ipAddressList":
-    "10.0.0.101/32", "macaddr": "d6:f4:51:5f:6b:77", "ip6AddressList": "", "state":
-    "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "lo", "ipAddressList": "10.0.0.101/32", "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": "::1/128", "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname":
-    "lo", "ipAddressList": "10.0.0.12/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    "2001:db8::12/128", "state": "up", "vrf": "default", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "ifname": "lo", "ipAddressList":
-    "10.0.0.14/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": "2001:db8::12/128",
-    "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "lo", "ipAddressList": "10.0.0.14/32", "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": "::1/128", "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname":
-    "bridge", "ipAddressList": "", "macaddr": "52:54:00:76:91:c0", "ip6AddressList":
-    "fe80::5054:ff:fe76:91c0/64", "state": "up", "vrf": "default", "timestamp": 1616638471143},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "peerlink", "ipAddressList":
-    "", "macaddr": "52:54:00:76:91:c0", "ip6AddressList": "", "state": "up", "vrf":
-    "bridge", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01",
-    "ifname": "peerlink.4094", "ipAddressList": "169.254.1.1/30", "macaddr": "52:54:00:76:91:c0",
-    "ip6AddressList": "fe80::5054:ff:fe76:91c0/64", "state": "up", "vrf": "default",
-    "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname":
-    "swp3", "ipAddressList": "", "macaddr": "52:54:00:76:91:c0", "ip6AddressList":
-    "", "state": "up", "vrf": "peerlink", "timestamp": 1616638471143}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "ifname": "swp4", "ipAddressList": "", "macaddr":
-    "52:54:00:76:91:c0", "ip6AddressList": "", "state": "up", "vrf": "peerlink", "timestamp":
-    1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "vlan13",
-    "ipAddressList": "172.16.1.1/24", "macaddr": "52:54:00:76:91:c0", "ip6AddressList":
-    "2001:db8:0:1::1/64", "state": "up", "vrf": "default", "timestamp": 1616638471143},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "ifname": "vlan13", "ipAddressList":
-    "172.16.1.1/24", "macaddr": "52:54:00:76:91:c0", "ip6AddressList": "fe80::5054:ff:fe76:91c0/64",
-    "state": "up", "vrf": "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "vlan24", "ipAddressList": "172.16.2.1/24", "macaddr":
-    "52:54:00:76:91:c0", "ip6AddressList": "2001:db8:0:2::1/64", "state": "up", "vrf":
-    "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname":
-    "leaf01", "ifname": "vlan24", "ipAddressList": "172.16.2.1/24", "macaddr": "52:54:00:76:91:c0",
-    "ip6AddressList": "fe80::5054:ff:fe76:91c0/64", "state": "up", "vrf": "default",
-    "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname":
-    "lo", "ipAddressList": "10.0.0.13/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    "2001:db8::12/128", "state": "up", "vrf": "default", "timestamp": 1616638471859}]'
+  output: '[{"namespace": "panos", "hostname": "leaf04", "ifname": "lo", "ipAddressList":
+    ["10.0.0.14/32", "10.0.0.134/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf04", "ifname": "swp1", "ipAddressList": ["10.0.0.14/32"],
+    "macaddr": "52:54:00:d8:ee:83", "ip6AddressList": ["fe80::5054:ff:fed8:ee83/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "swp2", "ipAddressList": ["10.0.0.14/32"], "macaddr":
+    "52:54:00:69:28:3b", "ip6AddressList": ["fe80::5054:ff:fe69:283b/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254836}]'
 - command: address show --address="172.16.1.1/32 172.16.4.104 52:54:00:4e:04:fd" --columns='ifname
     ip6AddressList' --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"ifname": "bond0", "ip6AddressList": ["2001:db8:0:4::104/64"]}, {"ifname":
-    "swp5", "ip6AddressList": []}, {"ifname": "vlan13", "ip6AddressList": ["2001:db8:0:3::1/64",
-    "fe80::5054:ff:fe4e:4fd/64"]}, {"ifname": "vlan24", "ip6AddressList": ["2001:db8:0:4::1/64",
-    "fe80::5054:ff:fe4e:4fd/64"]}, {"ifname": "bridge", "ip6AddressList": ["fe80::5054:ff:fe4e:4fd/64"]},
-    {"ifname": "bond01", "ip6AddressList": []}]'
+  output: '[]'
 - command: address show --ipvers=v4 --address="2001:db8:0:1::101" --columns="ifname
     macaddr" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"ifname": "bond0", "macaddr": "52:54:00:d6:66:41"}]'
+  output: '[]'
 - command: address show --address="invalidaddress" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid address specified"}]'
   marks: address show panos filter
 - command: address show --prefix="192.168.121.0/24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server103", "ifname": "eth0", "ipAddressList":
-    "192.168.121.222/24", "macaddr": "52:54:00:d0:d4:9f", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server104", "ifname": "eth0", "ipAddressList": "192.168.121.180/24",
-    "macaddr": "52:54:00:8f:82:c0", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "edge01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.103/24", "macaddr": "52:54:00:96:94:6e",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "server101", "ifname": "eth0", "ipAddressList":
-    "192.168.121.233/24", "macaddr": "52:54:00:5a:70:0e", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470198}, {"namespace": "dual-bgp",
-    "hostname": "server102", "ifname": "eth0", "ipAddressList": "192.168.121.254/24",
-    "macaddr": "52:54:00:f8:25:80", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470218}, {"namespace": "dual-bgp", "hostname": "spine02",
-    "ifname": "eth0", "ipAddressList": "192.168.121.186/24", "macaddr": "52:54:00:5e:ec:b7",
-    "ip6AddressList": ["fe80::5054:ff:fe5e:ecb7/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638470639}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname":
-    "eth0", "ipAddressList": "192.168.121.94/24", "macaddr": "52:54:00:a5:d3:9f",
-    "ip6AddressList": ["fe80::5054:ff:fea5:d39f/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.164/24", "macaddr": "52:54:00:7f:7a:90",
-    "ip6AddressList": ["fe80::5054:ff:fe7f:7a90/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "ifname": "eth0", "ipAddressList": "192.168.121.51/24", "macaddr": "52:54:00:83:72:c9",
-    "ip6AddressList": ["fe80::5054:ff:fe83:72c9/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf04", "ifname":
-    "eth0", "ipAddressList": "192.168.121.132/24", "macaddr": "52:54:00:1c:0e:57",
-    "ip6AddressList": ["fe80::5054:ff:fe1c:e57/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "internet",
-    "ifname": "eth0", "ipAddressList": "192.168.121.141/24", "macaddr": "52:54:00:46:fe:70",
-    "ip6AddressList": ["fe80::5054:ff:fe46:fe70/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname":
-    "eth0", "ipAddressList": "192.168.121.181/24", "macaddr": "52:54:00:cf:36:be",
-    "ip6AddressList": ["fe80::5054:ff:fecf:36be/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.119/24", "macaddr": "52:54:00:11:7d:b8",
-    "ip6AddressList": ["fe80::5054:ff:fe11:7db8/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname":
-    "eth0", "ipAddressList": "192.168.121.33/24", "macaddr": "52:54:00:7c:35:15",
-    "ip6AddressList": ["fe80::5054:ff:fe7c:3515/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471859}]'
+  output: '[]'
 - command: address show --prefix="2001:db8:0:1::/64" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0",
-    "ipAddressList": ["172.16.1.101/24"], "macaddr": "52:54:00:d6:66:41", "ip6AddressList":
-    "2001:db8:0:1::101/64", "state": "up", "vrf": "default", "timestamp": 1616638470198},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "ifname": "vlan13", "ipAddressList":
-    ["172.16.1.1/24"], "macaddr": "52:54:00:61:91:8e", "ip6AddressList": "2001:db8:0:1::1/64",
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "vlan13", "ipAddressList": ["172.16.1.1/24"],
-    "macaddr": "52:54:00:76:91:c0", "ip6AddressList": "2001:db8:0:1::1/64", "state":
-    "up", "vrf": "default", "timestamp": 1616638471143}]'
+  output: '[]'
 - command: address show --prefix="2001:db8:0:1::/64 192.168.121.0/24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "server103", "ifname": "eth0", "ipAddressList":
-    "192.168.121.222/24", "macaddr": "52:54:00:d0:d4:9f", "ip6AddressList": "", "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server104", "ifname": "eth0", "ipAddressList": "192.168.121.180/24",
-    "macaddr": "52:54:00:8f:82:c0", "ip6AddressList": "", "state": "up", "vrf": "default",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "edge01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.103/24", "macaddr": "52:54:00:96:94:6e",
-    "ip6AddressList": "", "state": "up", "vrf": "default", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "server101", "ifname": "bond0", "ipAddressList":
-    "172.16.1.101/24", "macaddr": "52:54:00:d6:66:41", "ip6AddressList": "2001:db8:0:1::101/64",
-    "state": "up", "vrf": "default", "timestamp": 1616638470198}, {"namespace": "dual-bgp",
-    "hostname": "server101", "ifname": "eth0", "ipAddressList": "192.168.121.233/24",
-    "macaddr": "52:54:00:5a:70:0e", "ip6AddressList": "", "state": "up", "vrf": "default",
-    "timestamp": 1616638470198}, {"namespace": "dual-bgp", "hostname": "server102",
-    "ifname": "eth0", "ipAddressList": "192.168.121.254/24", "macaddr": "52:54:00:f8:25:80",
-    "ip6AddressList": "", "state": "up", "vrf": "default", "timestamp": 1616638470218},
-    {"namespace": "dual-bgp", "hostname": "spine02", "ifname": "eth0", "ipAddressList":
-    "192.168.121.186/24", "macaddr": "52:54:00:5e:ec:b7", "ip6AddressList": "fe80::5054:ff:fe5e:ecb7/64",
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638470639}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "ifname": "vlan13", "ipAddressList": "172.16.1.1/24", "macaddr":
-    "52:54:00:61:91:8e", "ip6AddressList": "2001:db8:0:1::1/64", "state": "up", "vrf":
-    "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname":
-    "leaf02", "ifname": "eth0", "ipAddressList": "192.168.121.94/24", "macaddr": "52:54:00:a5:d3:9f",
-    "ip6AddressList": "fe80::5054:ff:fea5:d39f/64", "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.164/24", "macaddr": "52:54:00:7f:7a:90",
-    "ip6AddressList": "fe80::5054:ff:fe7f:7a90/64", "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "ifname": "eth0", "ipAddressList": "192.168.121.51/24", "macaddr": "52:54:00:83:72:c9",
-    "ip6AddressList": "fe80::5054:ff:fe83:72c9/64", "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf04", "ifname":
-    "eth0", "ipAddressList": "192.168.121.132/24", "macaddr": "52:54:00:1c:0e:57",
-    "ip6AddressList": "fe80::5054:ff:fe1c:e57/64", "state": "up", "vrf": "mgmt", "timestamp":
-    1616638471115}, {"namespace": "dual-bgp", "hostname": "internet", "ifname": "eth0",
-    "ipAddressList": "192.168.121.141/24", "macaddr": "52:54:00:46:fe:70", "ip6AddressList":
-    "fe80::5054:ff:fe46:fe70/64", "state": "up", "vrf": "default", "timestamp": 1616638471115},
-    {"namespace": "dual-bgp", "hostname": "exit02", "ifname": "eth0", "ipAddressList":
-    "192.168.121.181/24", "macaddr": "52:54:00:cf:36:be", "ip6AddressList": "fe80::5054:ff:fecf:36be/64",
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "ifname": "vlan13", "ipAddressList": "172.16.1.1/24", "macaddr":
-    "52:54:00:76:91:c0", "ip6AddressList": "2001:db8:0:1::1/64", "state": "up", "vrf":
-    "default", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname":
-    "leaf01", "ifname": "eth0", "ipAddressList": "192.168.121.119/24", "macaddr":
-    "52:54:00:11:7d:b8", "ip6AddressList": "fe80::5054:ff:fe11:7db8/64", "state":
-    "up", "vrf": "mgmt", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname":
-    "leaf03", "ifname": "eth0", "ipAddressList": "192.168.121.33/24", "macaddr": "52:54:00:7c:35:15",
-    "ip6AddressList": "fe80::5054:ff:fe7c:3515/64", "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471859}]'
+  output: '[]'
 - command: address show --prefix="192.168.121.0/24 10.0.0.0/24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address show panos filter
-  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "ifname": "lo", "ipAddressList":
-    "10.0.0.100/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server103", "ifname": "eth0", "ipAddressList": "192.168.121.222/24",
-    "macaddr": "52:54:00:d0:d4:9f", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "server104",
-    "ifname": "eth0", "ipAddressList": "192.168.121.180/24", "macaddr": "52:54:00:8f:82:c0",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "edge01", "ifname": "eth0", "ipAddressList":
-    "192.168.121.103/24", "macaddr": "52:54:00:96:94:6e", "ip6AddressList": [], "state":
-    "up", "vrf": "default", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "server101", "ifname": "eth0", "ipAddressList": "192.168.121.233/24",
-    "macaddr": "52:54:00:5a:70:0e", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638470198}, {"namespace": "dual-bgp", "hostname": "server102",
-    "ifname": "eth0", "ipAddressList": "192.168.121.254/24", "macaddr": "52:54:00:f8:25:80",
-    "ip6AddressList": [], "state": "up", "vrf": "default", "timestamp": 1616638470218},
-    {"namespace": "dual-bgp", "hostname": "spine02", "ifname": "lo", "ipAddressList":
-    "10.0.0.22/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::22/128",
-    "::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638470639}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "ifname": "eth0", "ipAddressList": "192.168.121.186/24",
-    "macaddr": "52:54:00:5e:ec:b7", "ip6AddressList": ["fe80::5054:ff:fe5e:ecb7/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638470639}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "ifname": "internet-vrf", "ipAddressList": "10.0.0.101/32",
-    "macaddr": "d6:f4:51:5f:6b:77", "ip6AddressList": [], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "ifname":
-    "eth0", "ipAddressList": "192.168.121.94/24", "macaddr": "52:54:00:a5:d3:9f",
-    "ip6AddressList": ["fe80::5054:ff:fea5:d39f/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "ifname": "lo", "ipAddressList": "10.0.0.21/32", "macaddr": "00:00:00:00:00:00",
-    "ip6AddressList": ["2001:db8::21/128", "::1/128"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.164/24", "macaddr": "52:54:00:7f:7a:90",
-    "ip6AddressList": ["fe80::5054:ff:fe7f:7a90/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname":
-    "lo", "ipAddressList": "10.0.0.101/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace":
-    "dual-bgp", "hostname": "leaf02", "ifname": "lo", "ipAddressList": "10.0.0.12/32",
-    "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["2001:db8::12/128", "::1/128"],
-    "state": "up", "vrf": "default", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "ifname": "eth0", "ipAddressList": "192.168.121.51/24",
-    "macaddr": "52:54:00:83:72:c9", "ip6AddressList": ["fe80::5054:ff:fe83:72c9/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "ifname": "eth0", "ipAddressList": "192.168.121.132/24",
-    "macaddr": "52:54:00:1c:0e:57", "ip6AddressList": ["fe80::5054:ff:fe1c:e57/64"],
-    "state": "up", "vrf": "mgmt", "timestamp": 1616638471115}, {"namespace": "dual-bgp",
-    "hostname": "internet", "ifname": "lo", "ipAddressList": "10.0.0.253/32", "macaddr":
-    "00:00:00:00:00:00", "ip6AddressList": ["::1/128"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "internet",
-    "ifname": "eth0", "ipAddressList": "192.168.121.141/24", "macaddr": "52:54:00:46:fe:70",
-    "ip6AddressList": ["fe80::5054:ff:fe46:fe70/64"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname": "leaf04", "ifname":
-    "lo", "ipAddressList": "10.0.0.14/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    ["2001:db8::12/128", "::1/128"], "state": "up", "vrf": "default", "timestamp":
-    1616638471115}, {"namespace": "dual-bgp", "hostname": "exit02", "ifname": "internet-vrf",
-    "ipAddressList": "10.0.0.102/32", "macaddr": "ae:ce:d3:71:a6:c9", "ip6AddressList":
-    [], "state": "up", "vrf": "default", "timestamp": 1616638471115}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "ifname": "lo", "ipAddressList": "10.0.0.102/32",
+  output: '[{"namespace": "panos", "hostname": "firewall01", "ifname": "loopback",
+    "ipAddressList": ["10.0.0.200/32"], "macaddr": "ba:db:ee:fb:ad:03", "ip6AddressList":
+    [], "state": "up", "vrf": "default", "timestamp": 1639476254171}, {"namespace":
+    "panos", "hostname": "dcedge01", "ifname": "lo", "ipAddressList": ["10.0.0.41/32"],
     "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"], "state": "up",
-    "vrf": "default", "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "ifname": "eth0", "ipAddressList": "192.168.121.181/24", "macaddr":
-    "52:54:00:cf:36:be", "ip6AddressList": ["fe80::5054:ff:fecf:36be/64"], "state":
-    "up", "vrf": "mgmt", "timestamp": 1616638471115}, {"namespace": "dual-bgp", "hostname":
-    "leaf01", "ifname": "lo", "ipAddressList": "10.0.0.11/32", "macaddr": "00:00:00:00:00:00",
-    "ip6AddressList": ["2001:db8::11/128", "::1/128"], "state": "up", "vrf": "default",
-    "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname":
-    "eth0", "ipAddressList": "192.168.121.119/24", "macaddr": "52:54:00:11:7d:b8",
-    "ip6AddressList": ["fe80::5054:ff:fe11:7db8/64"], "state": "up", "vrf": "mgmt",
-    "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname":
-    "lo", "ipAddressList": "10.0.0.13/32", "macaddr": "00:00:00:00:00:00", "ip6AddressList":
-    ["2001:db8::12/128", "::1/128"], "state": "up", "vrf": "default", "timestamp":
-    1616638471859}, {"namespace": "dual-bgp", "hostname": "leaf03", "ifname": "eth0",
-    "ipAddressList": "192.168.121.33/24", "macaddr": "52:54:00:7c:35:15", "ip6AddressList":
-    ["fe80::5054:ff:fe7c:3515/64"], "state": "up", "vrf": "mgmt", "timestamp": 1616638471859}]'
+    "vrf": "default", "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
+    "exit01", "ifname": "swp2", "ipAddressList": ["10.0.0.31/32"], "macaddr": "52:54:00:24:8c:0b",
+    "ip6AddressList": ["fe80::5054:ff:fe24:8c0b/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname":
+    "lo", "ipAddressList": ["10.0.0.31/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace":
+    "panos", "hostname": "exit01", "ifname": "swp1", "ipAddressList": ["10.0.0.31/32"],
+    "macaddr": "52:54:00:53:4c:f5", "ip6AddressList": ["fe80::5054:ff:fe53:4cf5/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos",
+    "hostname": "exit02", "ifname": "swp2", "ipAddressList": ["10.0.0.32/32"], "macaddr":
+    "52:54:00:3c:63:f0", "ip6AddressList": ["fe80::5054:ff:fe3c:63f0/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+    "exit02", "ifname": "swp1", "ipAddressList": ["10.0.0.32/32"], "macaddr": "52:54:00:d2:4a:6a",
+    "ip6AddressList": ["fe80::5054:ff:fed2:4a6a/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname":
+    "lo", "ipAddressList": ["10.0.0.32/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254817}, {"namespace":
+    "panos", "hostname": "leaf04", "ifname": "lo", "ipAddressList": ["10.0.0.14/32",
+    "10.0.0.134/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos",
+    "hostname": "leaf04", "ifname": "swp1", "ipAddressList": ["10.0.0.14/32"], "macaddr":
+    "52:54:00:d8:ee:83", "ip6AddressList": ["fe80::5054:ff:fed8:ee83/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf04", "ifname": "swp2", "ipAddressList": ["10.0.0.14/32"], "macaddr": "52:54:00:69:28:3b",
+    "ip6AddressList": ["fe80::5054:ff:fe69:283b/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
+    "swp2", "ipAddressList": ["10.0.0.12/32"], "macaddr": "52:54:00:69:bc:26", "ip6AddressList":
+    ["fe80::5054:ff:fe69:bc26/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.12/32"], "macaddr": "52:54:00:6f:d5:11", "ip6AddressList":
+    ["fe80::5054:ff:fe6f:d511/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "lo", "ipAddressList":
+    ["10.0.0.12/32", "10.0.0.112/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "spine02", "ifname": "lo", "ipAddressList": ["10.0.0.22/32"],
+    "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"], "state": "up",
+    "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "spine02", "ifname": "swp1", "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:eb:56:a6",
+    "ip6AddressList": ["fe80::5054:ff:feeb:56a6/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname":
+    "swp2", "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:56:b7:ac", "ip6AddressList":
+    ["fe80::5054:ff:fe56:b7ac/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp3",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:88:70:ac", "ip6AddressList":
+    ["fe80::5054:ff:fe88:70ac/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp4",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:52:25:2e", "ip6AddressList":
+    ["fe80::5054:ff:fe52:252e/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp5",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:88:51:93", "ip6AddressList":
+    ["fe80::5054:ff:fe88:5193/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp6",
+    "ipAddressList": ["10.0.0.22/32"], "macaddr": "52:54:00:3d:45:07", "ip6AddressList":
+    ["fe80::5054:ff:fe3d:4507/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "lo", "ipAddressList":
+    ["10.0.0.13/32", "10.0.0.134/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace":
+    "panos", "hostname": "leaf03", "ifname": "swp1", "ipAddressList": ["10.0.0.13/32"],
+    "macaddr": "52:54:00:dd:d1:18", "ip6AddressList": ["fe80::5054:ff:fedd:d118/64"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos",
+    "hostname": "leaf03", "ifname": "swp2", "ipAddressList": ["10.0.0.13/32"], "macaddr":
+    "52:54:00:7b:cc:c3", "ip6AddressList": ["fe80::5054:ff:fe7b:ccc3/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "spine01", "ifname": "swp6", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:c4:54:00",
+    "ip6AddressList": ["fe80::5054:ff:fec4:5400/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname":
+    "swp5", "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:f5:f0:96", "ip6AddressList":
+    ["fe80::5054:ff:fef5:f096/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp4",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:a0:82:3d", "ip6AddressList":
+    ["fe80::5054:ff:fea0:823d/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp3",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:d3:be:93", "ip6AddressList":
+    ["fe80::5054:ff:fed3:be93/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp2",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:41:6f:13", "ip6AddressList":
+    ["fe80::5054:ff:fe41:6f13/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp1",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "52:54:00:83:d9:77", "ip6AddressList":
+    ["fe80::5054:ff:fe83:d977/64"], "state": "up", "vrf": "default", "timestamp":
+    1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "lo",
+    "ipAddressList": ["10.0.0.21/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList":
+    ["::1/128"], "state": "up", "vrf": "default", "timestamp": 1639476254852}, {"namespace":
+    "panos", "hostname": "leaf01", "ifname": "lo", "ipAddressList": ["10.0.0.11/32",
+    "10.0.0.112/32"], "macaddr": "00:00:00:00:00:00", "ip6AddressList": ["::1/128"],
+    "state": "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos",
+    "hostname": "leaf01", "ifname": "swp2", "ipAddressList": ["10.0.0.11/32"], "macaddr":
+    "52:54:00:89:13:56", "ip6AddressList": ["fe80::5054:ff:fe89:1356/64"], "state":
+    "up", "vrf": "default", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+    "leaf01", "ifname": "swp1", "ipAddressList": ["10.0.0.11/32"], "macaddr": "52:54:00:c4:19:83",
+    "ip6AddressList": ["fe80::5054:ff:fec4:1983/64"], "state": "up", "vrf": "default",
+    "timestamp": 1639476254854}]'
 - command: address show --prefix="192.168.1.0" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid prefix specified"}]'
-  marks: address show panos filter
 - command: address show --prefix="44:38:39:00:00:23" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid prefix specified"}]'
   marks: address show panos filter
 - command: address show --prefix="10.0.0.0/24" --address="192.168.1.2" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Cannot specify address and prefix together"}]'
   marks: address show panos filter
 - command: address show --prefix="10.0.0.1/24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid prefix specified"}]'
   marks: address show panos filter
 - command: address unique --columns="macaddr" --count=True --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address unique panos filter
-  output: '[{"macaddr": "02:a6:92:38:c3:a7", "numRows": 1}, {"macaddr": "1e:39:2f:19:6b:80",
-    "numRows": 1}, {"macaddr": "2a:89:e4:ac:3a:ca", "numRows": 1}, {"macaddr": "36:45:f6:59:f3:b6",
-    "numRows": 1}, {"macaddr": "52:54:00:01:1f:98", "numRows": 1}, {"macaddr": "52:54:00:11:7d:b8",
-    "numRows": 1}, {"macaddr": "52:54:00:14:09:81", "numRows": 1}, {"macaddr": "52:54:00:1c:0e:57",
-    "numRows": 1}, {"macaddr": "52:54:00:31:e6:f2", "numRows": 1}, {"macaddr": "52:54:00:32:ad:c1",
-    "numRows": 1}, {"macaddr": "52:54:00:32:c3:37", "numRows": 1}, {"macaddr": "52:54:00:33:c7:3d",
-    "numRows": 1}, {"macaddr": "52:54:00:38:a3:29", "numRows": 1}, {"macaddr": "52:54:00:40:03:86",
-    "numRows": 1}, {"macaddr": "52:54:00:46:fe:70", "numRows": 1}, {"macaddr": "52:54:00:5a:70:0e",
-    "numRows": 1}, {"macaddr": "52:54:00:5e:ec:b7", "numRows": 1}, {"macaddr": "52:54:00:5f:e8:d4",
-    "numRows": 1}, {"macaddr": "52:54:00:6b:79:41", "numRows": 1}, {"macaddr": "52:54:00:6c:9d:f3",
-    "numRows": 1}, {"macaddr": "52:54:00:71:3e:55", "numRows": 1}, {"macaddr": "52:54:00:79:48:5e",
-    "numRows": 1}, {"macaddr": "52:54:00:7c:35:15", "numRows": 1}, {"macaddr": "52:54:00:7c:b7:33",
-    "numRows": 1}, {"macaddr": "52:54:00:7e:5a:82", "numRows": 1}, {"macaddr": "52:54:00:7f:7a:90",
-    "numRows": 1}, {"macaddr": "52:54:00:83:72:c9", "numRows": 1}, {"macaddr": "52:54:00:8c:5b:4d",
-    "numRows": 1}, {"macaddr": "52:54:00:8d:05:90", "numRows": 1}, {"macaddr": "52:54:00:8d:ff:ce",
-    "numRows": 1}, {"macaddr": "52:54:00:8f:82:c0", "numRows": 1}, {"macaddr": "52:54:00:96:94:6e",
-    "numRows": 1}, {"macaddr": "52:54:00:a1:30:72", "numRows": 1}, {"macaddr": "52:54:00:a1:d2:0b",
-    "numRows": 1}, {"macaddr": "52:54:00:a1:d8:6a", "numRows": 1}, {"macaddr": "52:54:00:a5:d3:9f",
-    "numRows": 1}, {"macaddr": "52:54:00:c6:7c:c6", "numRows": 1}, {"macaddr": "52:54:00:cf:36:be",
-    "numRows": 1}, {"macaddr": "52:54:00:d0:d4:9f", "numRows": 1}, {"macaddr": "52:54:00:d1:4f:4d",
-    "numRows": 1}, {"macaddr": "52:54:00:d3:cd:00", "numRows": 1}, {"macaddr": "52:54:00:d6:12:38",
-    "numRows": 1}, {"macaddr": "52:54:00:d6:94:80", "numRows": 1}, {"macaddr": "52:54:00:d7:13:17",
-    "numRows": 1}, {"macaddr": "52:54:00:da:45:f9", "numRows": 1}, {"macaddr": "52:54:00:db:b0:8e",
-    "numRows": 1}, {"macaddr": "52:54:00:dc:80:3b", "numRows": 1}, {"macaddr": "52:54:00:f1:8d:28",
-    "numRows": 1}, {"macaddr": "52:54:00:f6:f0:5d", "numRows": 1}, {"macaddr": "52:54:00:f8:25:80",
-    "numRows": 1}, {"macaddr": "56:d5:34:84:93:0c", "numRows": 1}, {"macaddr": "7e:70:dd:80:8f:8d",
-    "numRows": 1}, {"macaddr": "96:82:91:f8:fb:c3", "numRows": 1}, {"macaddr": "ae:ce:d3:71:a6:c9",
-    "numRows": 1}, {"macaddr": "ba:4a:8d:58:32:dc", "numRows": 1}, {"macaddr": "d6:f4:51:5f:6b:77",
-    "numRows": 1}, {"macaddr": "52:54:00:44:8d:bb", "numRows": 2}, {"macaddr": "52:54:00:d8:a2:27",
-    "numRows": 2}, {"macaddr": "52:54:00:dc:18:8c", "numRows": 2}, {"macaddr": "52:54:00:dc:c2:ff",
-    "numRows": 2}, {"macaddr": "52:54:00:dd:97:00", "numRows": 2}, {"macaddr": "52:54:00:eb:18:a7",
-    "numRows": 2}, {"macaddr": "52:54:00:ff:0f:ce", "numRows": 2}, {"macaddr": "52:54:00:0c:bf:b3",
-    "numRows": 3}, {"macaddr": "52:54:00:17:a9:1a", "numRows": 3}, {"macaddr": "52:54:00:41:f9:4d",
-    "numRows": 3}, {"macaddr": "52:54:00:52:13:14", "numRows": 3}, {"macaddr": "52:54:00:a8:38:3d",
-    "numRows": 3}, {"macaddr": "52:54:00:d6:66:41", "numRows": 3}, {"macaddr": "52:54:00:d7:58:57",
-    "numRows": 3}, {"macaddr": "52:54:00:f9:0d:6e", "numRows": 3}, {"macaddr": "52:54:00:62:dc:88",
-    "numRows": 4}, {"macaddr": "52:54:00:4e:04:fd", "numRows": 5}, {"macaddr": "52:54:00:37:45:2d",
-    "numRows": 7}, {"macaddr": "52:54:00:61:91:8e", "numRows": 7}, {"macaddr": "52:54:00:76:91:c0",
-    "numRows": 7}, {"macaddr": "00:00:00:00:00:00", "numRows": 14}]'
+  output: '[{"macaddr": "06:bf:86:d3:80:e1", "numRows": 1}, {"macaddr": "12:1e:84:c1:0e:83",
+    "numRows": 1}, {"macaddr": "16:3c:be:94:91:b5", "numRows": 1}, {"macaddr": "1e:35:b8:33:f3:1b",
+    "numRows": 1}, {"macaddr": "1e:b6:ff:b1:dd:bb", "numRows": 1}, {"macaddr": "22:46:96:72:ea:46",
+    "numRows": 1}, {"macaddr": "36:91:1d:d2:94:21", "numRows": 1}, {"macaddr": "44:38:39:01:01:01",
+    "numRows": 1}, {"macaddr": "44:38:39:01:01:02", "numRows": 1}, {"macaddr": "44:38:39:01:02:01",
+    "numRows": 1}, {"macaddr": "44:38:39:01:02:02", "numRows": 1}, {"macaddr": "44:38:39:01:02:03",
+    "numRows": 1}, {"macaddr": "44:38:39:01:02:04", "numRows": 1}, {"macaddr": "44:38:39:01:03:01",
+    "numRows": 1}, {"macaddr": "44:38:39:01:03:02", "numRows": 1}, {"macaddr": "44:38:39:01:03:fe",
+    "numRows": 1}, {"macaddr": "44:39:39:ff:41:95", "numRows": 1}, {"macaddr": "44:39:39:ff:41:96",
+    "numRows": 1}, {"macaddr": "4e:6d:8a:ad:95:c9", "numRows": 1}, {"macaddr": "52:54:00:0d:c8:77",
+    "numRows": 1}, {"macaddr": "52:54:00:0f:01:38", "numRows": 1}, {"macaddr": "52:54:00:11:a4:14",
+    "numRows": 1}, {"macaddr": "52:54:00:24:8c:0b", "numRows": 1}, {"macaddr": "52:54:00:2e:b2:fa",
+    "numRows": 1}, {"macaddr": "52:54:00:3c:63:f0", "numRows": 1}, {"macaddr": "52:54:00:3d:45:07",
+    "numRows": 1}, {"macaddr": "52:54:00:41:6f:13", "numRows": 1}, {"macaddr": "52:54:00:52:25:2e",
+    "numRows": 1}, {"macaddr": "52:54:00:53:4c:f5", "numRows": 1}, {"macaddr": "52:54:00:56:b7:ac",
+    "numRows": 1}, {"macaddr": "52:54:00:69:28:3b", "numRows": 1}, {"macaddr": "52:54:00:69:bc:26",
+    "numRows": 1}, {"macaddr": "52:54:00:6f:d5:11", "numRows": 1}, {"macaddr": "52:54:00:74:49:da",
+    "numRows": 1}, {"macaddr": "52:54:00:7b:cc:c3", "numRows": 1}, {"macaddr": "52:54:00:83:d9:77",
+    "numRows": 1}, {"macaddr": "52:54:00:88:51:93", "numRows": 1}, {"macaddr": "52:54:00:88:70:ac",
+    "numRows": 1}, {"macaddr": "52:54:00:89:13:56", "numRows": 1}, {"macaddr": "52:54:00:89:e4:e1",
+    "numRows": 1}, {"macaddr": "52:54:00:8e:ea:75", "numRows": 1}, {"macaddr": "52:54:00:9a:f9:e3",
+    "numRows": 1}, {"macaddr": "52:54:00:a0:82:3d", "numRows": 1}, {"macaddr": "52:54:00:ba:b7:e0",
+    "numRows": 1}, {"macaddr": "52:54:00:c4:19:83", "numRows": 1}, {"macaddr": "52:54:00:c4:54:00",
+    "numRows": 1}, {"macaddr": "52:54:00:d2:4a:6a", "numRows": 1}, {"macaddr": "52:54:00:d3:be:93",
+    "numRows": 1}, {"macaddr": "52:54:00:d8:ee:83", "numRows": 1}, {"macaddr": "52:54:00:dd:d1:18",
+    "numRows": 1}, {"macaddr": "52:54:00:de:df:7d", "numRows": 1}, {"macaddr": "52:54:00:e4:4d:a4",
+    "numRows": 1}, {"macaddr": "52:54:00:eb:56:a6", "numRows": 1}, {"macaddr": "52:54:00:f5:f0:96",
+    "numRows": 1}, {"macaddr": "5a:b6:19:2f:83:a5", "numRows": 1}, {"macaddr": "5a:e5:40:c3:44:d4",
+    "numRows": 1}, {"macaddr": "5e:1a:f8:45:bc:61", "numRows": 1}, {"macaddr": "66:82:b4:33:e7:75",
+    "numRows": 1}, {"macaddr": "66:9e:f3:a8:13:42", "numRows": 1}, {"macaddr": "66:f8:11:d3:1c:81",
+    "numRows": 1}, {"macaddr": "66:fb:4a:13:36:44", "numRows": 1}, {"macaddr": "76:10:45:cf:55:05",
+    "numRows": 1}, {"macaddr": "76:71:3c:2d:a8:12", "numRows": 1}, {"macaddr": "86:a8:63:04:4d:5b",
+    "numRows": 1}, {"macaddr": "8a:75:81:f5:04:8f", "numRows": 1}, {"macaddr": "96:7b:37:27:5a:d3",
+    "numRows": 1}, {"macaddr": "9e:d8:75:87:06:00", "numRows": 1}, {"macaddr": "a2:8f:8f:c7:a1:3c",
+    "numRows": 1}, {"macaddr": "aa:17:ca:a7:57:fc", "numRows": 1}, {"macaddr": "ba:a6:68:89:94:68",
+    "numRows": 1}, {"macaddr": "ba:db:ee:fb:ad:03", "numRows": 1}, {"macaddr": "c2:29:96:08:4e:2e",
+    "numRows": 1}, {"macaddr": "d2:8b:a6:04:35:98", "numRows": 1}, {"macaddr": "e2:bb:bd:0e:f5:47",
+    "numRows": 1}, {"macaddr": "ee:7c:7a:6f:a6:01", "numRows": 1}, {"macaddr": "ee:ed:b0:ba:3c:d7",
+    "numRows": 1}, {"macaddr": "00:00:00:11:12:10", "numRows": 2}, {"macaddr": "00:00:00:11:12:20",
+    "numRows": 2}, {"macaddr": "44:39:39:ff:40:95", "numRows": 2}, {"macaddr": "44:39:39:ff:40:96",
+    "numRows": 2}, {"macaddr": "4a:7d:c4:74:ec:93", "numRows": 2}, {"macaddr": "52:54:00:06:a0:c9",
+    "numRows": 2}, {"macaddr": "52:54:00:74:07:99", "numRows": 2}, {"macaddr": "52:54:00:b0:50:70",
+    "numRows": 2}, {"macaddr": "52:54:00:e3:c1:9e", "numRows": 2}, {"macaddr": "da:02:77:48:60:af",
+    "numRows": 2}, {"macaddr": "26:76:20:42:e2:c6", "numRows": 3}, {"macaddr": "2a:b4:fa:73:2a:0d",
+    "numRows": 3}, {"macaddr": "4e:01:f3:25:8c:7a", "numRows": 3}, {"macaddr": "52:54:00:05:e0:cc",
+    "numRows": 3}, {"macaddr": "52:54:00:12:5d:46", "numRows": 3}, {"macaddr": "52:54:00:6c:e0:4a",
+    "numRows": 3}, {"macaddr": "52:54:00:cb:a1:ea", "numRows": 3}, {"macaddr": "9e:f7:6f:94:05:0c",
+    "numRows": 3}, {"macaddr": "00:00:00:11:12:30", "numRows": 4}, {"macaddr": "48:47:00:20:27:cd",
+    "numRows": 4}, {"macaddr": "48:47:00:36:b8:ff", "numRows": 4}, {"macaddr": "48:47:00:98:3d:08",
+    "numRows": 4}, {"macaddr": "48:47:00:a1:2a:cc", "numRows": 4}, {"macaddr": "52:54:00:36:33:d9",
+    "numRows": 4}, {"macaddr": "52:54:00:de:82:68", "numRows": 4}, {"macaddr": "",
+    "numRows": 6}, {"macaddr": "00:00:00:00:00:00", "numRows": 13}]'
 - command: address unique --columns="ipAddressList" --count=True --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address unique panos filter
-  output: '[{"ipAddressList": "10.0.0.100/32", "numRows": 1}, {"ipAddressList": "10.0.0.11/32",
-    "numRows": 1}, {"ipAddressList": "10.0.0.12/32", "numRows": 1}, {"ipAddressList":
-    "10.0.0.13/32", "numRows": 1}, {"ipAddressList": "10.0.0.14/32", "numRows": 1},
-    {"ipAddressList": "10.0.0.21/32", "numRows": 1}, {"ipAddressList": "10.0.0.22/32",
-    "numRows": 1}, {"ipAddressList": "10.0.0.253/32", "numRows": 1}, {"ipAddressList":
-    "169.254.127.0/31", "numRows": 1}, {"ipAddressList": "169.254.127.1/31", "numRows":
-    1}, {"ipAddressList": "169.254.127.2/31", "numRows": 1}, {"ipAddressList": "169.254.127.3/31",
-    "numRows": 1}, {"ipAddressList": "169.254.253.1/30", "numRows": 1}, {"ipAddressList":
-    "169.254.253.10/30", "numRows": 1}, {"ipAddressList": "169.254.253.2/30", "numRows":
+  output: '[{"ipAddressList": "10.0.0.200/32", "numRows": 1}, {"ipAddressList": "10.0.0.41/32",
+    "numRows": 1}, {"ipAddressList": "10.255.2.103/24", "numRows": 1}, {"ipAddressList":
+    "10.255.2.117/24", "numRows": 1}, {"ipAddressList": "10.255.2.118/24", "numRows":
+    1}, {"ipAddressList": "10.255.2.141", "numRows": 1}, {"ipAddressList": "10.255.2.184/24",
+    "numRows": 1}, {"ipAddressList": "10.255.2.185/24", "numRows": 1}, {"ipAddressList":
+    "10.255.2.186/24", "numRows": 1}, {"ipAddressList": "10.255.2.187/24", "numRows":
+    1}, {"ipAddressList": "10.255.2.241/24", "numRows": 1}, {"ipAddressList": "10.255.2.250/24",
+    "numRows": 1}, {"ipAddressList": "10.255.2.251/24", "numRows": 1}, {"ipAddressList":
+    "10.255.2.252/24", "numRows": 1}, {"ipAddressList": "10.255.2.76/24", "numRows":
+    1}, {"ipAddressList": "10.255.2.9/24", "numRows": 1}, {"ipAddressList": "169.254.127.0/31",
+    "numRows": 1}, {"ipAddressList": "169.254.127.1/31", "numRows": 1}, {"ipAddressList":
+    "169.254.127.2/31", "numRows": 1}, {"ipAddressList": "169.254.127.3/31", "numRows":
+    1}, {"ipAddressList": "169.254.253.1/30", "numRows": 1}, {"ipAddressList": "169.254.253.10/30",
+    "numRows": 1}, {"ipAddressList": "169.254.253.2/30", "numRows": 1}, {"ipAddressList":
+    "169.254.253.5/30", "numRows": 1}, {"ipAddressList": "169.254.253.6/30", "numRows":
     1}, {"ipAddressList": "169.254.253.9/30", "numRows": 1}, {"ipAddressList": "169.254.254.1/30",
     "numRows": 1}, {"ipAddressList": "169.254.254.10/30", "numRows": 1}, {"ipAddressList":
-    "169.254.254.2/30", "numRows": 1}, {"ipAddressList": "169.254.254.9/30", "numRows":
-    1}, {"ipAddressList": "172.16.1.101/24", "numRows": 1}, {"ipAddressList": "172.16.2.102/24",
-    "numRows": 1}, {"ipAddressList": "172.16.253.1/32", "numRows": 1}, {"ipAddressList":
-    "172.16.3.103/24", "numRows": 1}, {"ipAddressList": "172.16.4.104/24", "numRows":
-    1}, {"ipAddressList": "192.168.121.103/24", "numRows": 1}, {"ipAddressList": "192.168.121.119/24",
-    "numRows": 1}, {"ipAddressList": "192.168.121.132/24", "numRows": 1}, {"ipAddressList":
-    "192.168.121.141/24", "numRows": 1}, {"ipAddressList": "192.168.121.164/24", "numRows":
-    1}, {"ipAddressList": "192.168.121.180/24", "numRows": 1}, {"ipAddressList": "192.168.121.181/24",
-    "numRows": 1}, {"ipAddressList": "192.168.121.186/24", "numRows": 1}, {"ipAddressList":
-    "192.168.121.222/24", "numRows": 1}, {"ipAddressList": "192.168.121.233/24", "numRows":
-    1}, {"ipAddressList": "192.168.121.254/24", "numRows": 1}, {"ipAddressList": "192.168.121.33/24",
-    "numRows": 1}, {"ipAddressList": "192.168.121.51/24", "numRows": 1}, {"ipAddressList":
-    "192.168.121.94/24", "numRows": 1}, {"ipAddressList": "10.0.0.101/32", "numRows":
-    2}, {"ipAddressList": "10.0.0.102/32", "numRows": 2}, {"ipAddressList": "169.254.1.1/30",
-    "numRows": 2}, {"ipAddressList": "169.254.1.2/30", "numRows": 2}, {"ipAddressList":
-    "172.16.1.1/24", "numRows": 2}, {"ipAddressList": "172.16.2.1/24", "numRows":
-    2}, {"ipAddressList": "172.16.3.1/24", "numRows": 2}, {"ipAddressList": "172.16.4.1/24",
-    "numRows": 2}, {"ipAddressList": "127.0.0.1/8", "numRows": 8}]'
+    "169.254.254.2/30", "numRows": 1}, {"ipAddressList": "169.254.254.5/30", "numRows":
+    1}, {"ipAddressList": "169.254.254.6/30", "numRows": 1}, {"ipAddressList": "169.254.254.9/30",
+    "numRows": 1}, {"ipAddressList": "172.16.1.101/24", "numRows": 1}, {"ipAddressList":
+    "172.16.2.201/24", "numRows": 1}, {"ipAddressList": "172.16.3.102/24", "numRows":
+    1}, {"ipAddressList": "172.16.3.202/24", "numRows": 1}, {"ipAddressList": "10.0.0.112/32",
+    "numRows": 2}, {"ipAddressList": "10.0.0.134/32", "numRows": 2}, {"ipAddressList":
+    "172.16.1.254/24", "numRows": 2}, {"ipAddressList": "172.16.2.254/24", "numRows":
+    2}, {"ipAddressList": "10.0.0.11/32", "numRows": 3}, {"ipAddressList": "10.0.0.12/32",
+    "numRows": 3}, {"ipAddressList": "10.0.0.13/32", "numRows": 3}, {"ipAddressList":
+    "10.0.0.14/32", "numRows": 3}, {"ipAddressList": "10.0.0.31/32", "numRows": 3},
+    {"ipAddressList": "10.0.0.32/32", "numRows": 3}, {"ipAddressList": "172.16.3.254/24",
+    "numRows": 4}, {"ipAddressList": "10.0.0.21/32", "numRows": 7}, {"ipAddressList":
+    "10.0.0.22/32", "numRows": 7}, {"ipAddressList": "127.0.0.1/8", "numRows": 9}]'
 - command: address unique --columns="vrf" --count=True --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: address unique panos filter
-  output: '[{"vrf": "internet-vrf", "numRows": 4}, {"vrf": "mgmt", "numRows": 8},
-    {"vrf": "default", "numRows": 84}]'
+  output: '[{"vrf": "internet-vrf", "numRows": 4}, {"vrf": "mgmt", "numRows": 9},
+    {"vrf": "evpn-vrf", "numRows": 16}, {"vrf": "default", "numRows": 78}]'
 - command: address unique --columns="vrf" --format=json
   data-directory: tests/data/panos/parquet-out
   marks: address unique panos filter
@@ -1463,5 +1452,6 @@ tests:
     "mgmt"}]'
 - command: address unique --columns="vrf" --query-str='hostname == "leaf01" ' --format=json
   data-directory: tests/data/panos/parquet-out
+  error:
+    error: '[{"error": "ERROR: UserQueryError: name ''hostname'' is not defined"}]'
   marks: address unique panos filter
-  output: '[{"vrf": "default"}, {"vrf": "evpn-vrf"}, {"vrf": "mgmt"}]'

--- a/tests/integration/sqcmds/panos-samples/arpnd.yml
+++ b/tests/integration/sqcmds/panos-samples/arpnd.yml
@@ -584,11 +584,14 @@ tests:
     79, "v6NDLLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 6,
     "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 6, "failedEntriesCnt": 0, "failedV4EntriesCnt":
     0, "failedV6EntriesCnt": 0}}'
-- command: arpnd summarize --namespace=dual-evpn --format=json
+- command: arpnd summarize --namespace=panos --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: arpnd summarize
-  output: '{"namespace": {}, "hostname": {}, "ipAddress": {}, "oif": {}, "macaddr":
-    {}, "state": {}, "remote": {}, "timestamp": {}, "active": {}}'
+  output: '{"panos": {"deviceCnt": 14, "arpNdEntriesCnt": 154, "uniqueArpEntriesCnt":
+    65, "uniqueOifCnt": 22, "arpEntriesCnt": 75, "v6NDEntriesCnt": 79, "v6NDGlobalEntriesCnt":
+    79, "v6NDLLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 6,
+    "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 6, "failedEntriesCnt": 0, "failedV4EntriesCnt":
+    0, "failedV6EntriesCnt": 0}}'
 - command: arpnd unique --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: arpnd unique
@@ -617,10 +620,10 @@ tests:
     {"hostname": "server301"}, {"hostname": "server302"}, {"hostname": "spine01"},
     {"hostname": "spine02"}]'
 - command: arpnd summarize --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: arpnd summarize
-  output: '{"dual-bgp": {"deviceCnt": 14, "arpNdEntriesCnt": 138, "uniqueArpEntriesCnt":
-    64, "uniqueOifCnt": 17, "arpEntriesCnt": 78, "v6NDEntriesCnt": 60, "v6NDGlobalEntriesCnt":
-    52, "v6NDLLAEntriesCnt": 8, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 36,
-    "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 16, "failedEntriesCnt": 0, "failedV4EntriesCnt":
+  output: '{"panos": {"deviceCnt": 14, "arpNdEntriesCnt": 154, "uniqueArpEntriesCnt":
+    65, "uniqueOifCnt": 22, "arpEntriesCnt": 75, "v6NDEntriesCnt": 79, "v6NDGlobalEntriesCnt":
+    79, "v6NDLLAEntriesCnt": 0, "remoteV4EntriesCnt": 0, "staticV4EntriesCnt": 6,
+    "remoteV6EntriesCnt": 0, "staticV6EntriesCnt": 6, "failedEntriesCnt": 0, "failedV4EntriesCnt":
     0, "failedV6EntriesCnt": 0}}'

--- a/tests/integration/sqcmds/panos-samples/bgp.yml
+++ b/tests/integration/sqcmds/panos-samples/bgp.yml
@@ -834,333 +834,396 @@ tests:
       1639476253949}]'
   marks: bgp assert panos
 - command: bgp assert --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
-    error: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
-      "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616638469998},
-      {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4",
-      "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
-      "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn":
-      65530, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp",
-      "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "spine02",
-      "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-      "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
-      1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-      "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-      "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470426},
-      {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
-      "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
-      "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "asn":
-      65000, "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-      "hostname": "spine02", "vrf": "default", "peer": "swp5", "asn": 65000, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "fail", "assertReason":
-      "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-      "hostname": "spine02", "vrf": "default", "peer": "swp6", "asn": 65000, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "fail", "assertReason":
-      "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-      "hostname": "internet", "vrf": "default", "peer": "swp1", "asn": 25253, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-      "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
-      "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-      "vrf": "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state":
-      "Established", "peerHostname": "internet", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-      "vrf": "default", "peer": "swp2", "asn": 65202, "peerAsn": 65000, "state": "Established",
+    error: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
+      "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
+      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+      {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
+      "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
+      "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
+      "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
+      "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
+      "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+      "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
+      "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
+      "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
+      {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+      "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
+      "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
+      "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
+      {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2",
+      "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
+      "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+      "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
       "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
-      enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname":
-      "exit02", "vrf": "default", "peer": "swp1", "asn": 65202, "peerAsn": 65000,
+      enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+      "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state":
+      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+      "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
+      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+      "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
+      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
+      "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
+      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01",
+      "vrf": "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state":
+      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf":
+      "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
+      "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
+      {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+      "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
+      "vrf": "default", "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "asn": 65534,
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522,
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "exit02", "vrf": "default", "peer": "swp3.2", "asn": 65520, "peerAsn":
+      65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+      "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname":
+      "exit02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
       "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
-      "Not all Afi/Safis enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp",
-      "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "asn": 65202, "peerAsn":
-      65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "internet",
-      "vrf": "default", "peer": "swp2", "asn": 25253, "peerAsn": 65202, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
-      1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-      "peer": "swp6", "asn": 65201, "peerAsn": 25253, "state": "Established", "peerHostname":
-      "internet", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
-      {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
-      "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace":
-      "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "asn": 65201,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "assert":
-      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1616638470555},
-      {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp1",
-      "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
+      "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace":
+      "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
+      "panos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
       "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-      "peer": "swp5.4", "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname":
-      "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
-      {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp6",
-      "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
+      1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+      "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf01",
+      "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
+      "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
+      "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
       "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-      "peer": "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-      "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established", "peerHostname":
-      "leaf04", "assert": "pass", "assertReason": "-", "timestamp": 1616638470647},
-      {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp3",
-      "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname": "leaf03",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
-      "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2", "asn":
-      65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp",
-      "hostname": "spine01", "vrf": "default", "peer": "swp1", "asn": 65000, "peerAsn":
-      65101, "state": "Established", "peerHostname": "leaf01", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp", "hostname": "leaf04",
-      "vrf": "default", "peer": "swp2", "asn": 65104, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
-      1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-      "peer": "swp1", "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616638471112},
-      {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "peer": "swp2",
-      "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
-      "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1", "asn": 65104,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine01", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-      "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-      "hostname": "leaf01", "vrf": "default", "peer": "swp1", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-      "hostname": "leaf03", "vrf": "default", "peer": "swp1", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471475}, {"namespace": "dual-bgp",
-      "hostname": "leaf03", "vrf": "default", "peer": "swp2", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471475}]'
+      1639476253949}]'
   marks: bgp assert panos
 - command: bgp assert --status=pass --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   marks: bgp assert panos
-  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
-    "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-    "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616638469998},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4",
-    "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
-    "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn": 65530,
-    "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp",
-    "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn":
-    65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "spine02",
-    "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-    "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-    "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
-    "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "asn": 65000,
-    "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "peer": "swp1", "asn": 25253, "peerAsn":
-    65201, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-    "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-    "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
-    "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state": "Established",
-    "peerHostname": "internet", "assert": "pass", "assertReason": "-", "timestamp":
-    1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "peer": "swp5.2", "asn": 65202, "peerAsn": 65530, "state": "Established", "peerHostname":
-    "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616638470550},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "peer": "swp2",
-    "asn": 25253, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638470550}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "asn":
-    65201, "peerAsn": 25253, "state": "Established", "peerHostname": "internet", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "peer": "swp5.2", "asn": 65201, "peerAsn":
-    65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01",
-    "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65201, "peerAsn": 65530, "state":
-    "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
-    "timestamp": 1616638470555}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-    "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
-    1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-    "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470647},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2",
-    "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp1", "asn": 65000,
-    "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "peer": "swp2", "asn": 65104, "peerAsn":
-    65000, "state": "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02",
-    "vrf": "default", "peer": "swp1", "asn": 65102, "peerAsn": 65000, "state": "Established",
-    "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
-    1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "peer": "swp2", "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname":
-    "spine02", "assert": "pass", "assertReason": "-", "timestamp": 1616638471112},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1",
-    "asn": 65104, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn": 65101,
-    "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "peer": "swp1", "asn": 65101, "peerAsn":
-    65000, "state": "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf03",
-    "vrf": "default", "peer": "swp1", "asn": 65103, "peerAsn": 65000, "state": "Established",
-    "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
-    1616638471475}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "peer": "swp2", "asn": 65103, "peerAsn": 65000, "state": "Established", "peerHostname":
-    "spine02", "assert": "pass", "assertReason": "-", "timestamp": 1616638471475}]'
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
+    "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
+    "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
+    "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
+    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
+    "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
+    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
+    "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
+    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
+    "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
+    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
+    "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
+    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2", "asn": 65520,
+    "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+    "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn":
+    65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+    "assertReason": "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534,
+    "state": "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+    "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
+    "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+    "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
+    "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason": "-",
+    "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01", "vrf":
+    "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state": "Established",
+    "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+    1639476253948}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "default",
+    "peer": "169.254.127.1", "asn": 65534, "peerAsn": 65522, "state": "Established",
+    "peerHostname": "exit01", "assert": "pass", "assertReason": "-", "timestamp":
+    1639476253948}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state": "Established", "peerHostname":
+    "firewall01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253948},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "peer": "swp3.2",
+    "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
+    "assert": "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
+    "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+    "pass", "assertReason": "-", "timestamp": 1639476253948}]'
 - command: bgp assert --status=fail --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
-    error: '[{"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer":
-      "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-      "peer": "swp6", "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470426}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-      "peer": "swp2", "asn": 65202, "peerAsn": 65000, "state": "Established", "peerHostname":
+    error: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "peer":
+      "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname":
       "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-      "peer": "swp1", "asn": 65202, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-      "peer": "swp2", "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-      "peer": "swp1", "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470555}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-      "peer": "swp6", "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-      "peer": "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470647}]'
+      1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+      "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
+      "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
+      "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
+      {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+      "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
+      "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
+      "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
+      {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+      "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine01",
+      "vrf": "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "exit02", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
+      {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+      "peer": "10.0.0.13", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "leaf03", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
+      "vrf": "default", "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
+      {"namespace": "panos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253948}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
+      "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "leaf02",
+      "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "spine02", "assert": "fail", "assertReason":
+      "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
+      "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine01", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
+      "panos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+      "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf04",
+      "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "spine02", "assert": "fail", "assertReason":
+      "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
+      "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine01", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}]'
   marks: bgp assert panos
 - command: bgp assert --status=all --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out
+  data-directory: tests/data/panos/parquet-out/
   error:
-    error: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
-      "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616638469998},
-      {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4",
-      "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
-      "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn":
-      65530, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp",
-      "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "spine02",
-      "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-      "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
-      1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-      "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-      "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470426},
-      {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
-      "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
-      "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "asn":
-      65000, "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-      "hostname": "spine02", "vrf": "default", "peer": "swp5", "asn": 65000, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "fail", "assertReason":
-      "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-      "hostname": "spine02", "vrf": "default", "peer": "swp6", "asn": 65000, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "fail", "assertReason":
-      "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-      "hostname": "internet", "vrf": "default", "peer": "swp1", "asn": 25253, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-      "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
-      "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-      "vrf": "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state":
-      "Established", "peerHostname": "internet", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
-      "vrf": "default", "peer": "swp2", "asn": 65202, "peerAsn": 65000, "state": "Established",
+    error: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
+      "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
+      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+      {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
+      "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
+      "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
+      "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
+      "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
+      "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+      "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
+      "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
+      "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
+      {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+      "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
+      "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
+      "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
+      {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2",
+      "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
+      "assert": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
+      "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+      "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
       "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
-      enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname":
-      "exit02", "vrf": "default", "peer": "swp1", "asn": 65202, "peerAsn": 65000,
+      enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+      "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state":
+      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+      "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
+      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
+      "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
+      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
+      "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
+      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01",
+      "vrf": "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state":
+      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf":
+      "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
+      "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
+      {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
+      "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03",
+      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+      "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
+      "vrf": "default", "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not
+      all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "asn": 65534,
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522,
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "exit02", "vrf": "default", "peer": "swp3.2", "asn": 65520, "peerAsn":
+      65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+      "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname":
+      "exit02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
       "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
-      "Not all Afi/Safis enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp",
-      "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "asn": 65202, "peerAsn":
-      65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "internet",
-      "vrf": "default", "peer": "swp2", "asn": 25253, "peerAsn": 65202, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
-      1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-      "peer": "swp6", "asn": 65201, "peerAsn": 25253, "state": "Established", "peerHostname":
-      "internet", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
-      {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
-      "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace":
-      "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "asn": 65201,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "assert":
-      "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1616638470555},
-      {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp1",
-      "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
+      "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace":
+      "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
+      "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
+      "panos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
       "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-      "peer": "swp5.4", "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname":
-      "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
-      {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp6",
-      "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
+      1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+      "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf01",
+      "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
+      "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
+      "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
+      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
+      "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
       "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-      "peer": "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
-      1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-      "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established", "peerHostname":
-      "leaf04", "assert": "pass", "assertReason": "-", "timestamp": 1616638470647},
-      {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp3",
-      "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname": "leaf03",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
-      "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2", "asn":
-      65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp",
-      "hostname": "spine01", "vrf": "default", "peer": "swp1", "asn": 65000, "peerAsn":
-      65101, "state": "Established", "peerHostname": "leaf01", "assert": "pass", "assertReason":
-      "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp", "hostname": "leaf04",
-      "vrf": "default", "peer": "swp2", "asn": 65104, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
-      1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-      "peer": "swp1", "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616638471112},
-      {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "peer": "swp2",
-      "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
-      "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1", "asn": 65104,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine01", "assert":
-      "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
-      "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-      "hostname": "leaf01", "vrf": "default", "peer": "swp1", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
-      "hostname": "leaf03", "vrf": "default", "peer": "swp1", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471475}, {"namespace": "dual-bgp",
-      "hostname": "leaf03", "vrf": "default", "peer": "swp2", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
-      "assertReason": "-", "timestamp": 1616638471475}]'
+      1639476253949}]'
   marks: bgp assert panos
 - command: bgp assert --status=whatever --format=json
   data-directory: tests/data/panos/parquet-out/
@@ -1177,10 +1240,17 @@ tests:
       "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}]'
   marks: bgp assert panos
-- command: bgp assert --hostname=leaf01 --namespace=ospf-ibgp --format=json
+- command: bgp assert --hostname=leaf01 --namespace=panos --format=json
   data-directory: tests/data/panos/parquet-out/
+  error:
+    error: '[{"namespace": "panos", "hostname": "leaf01", "vrf": "default", "peer":
+      "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname":
+      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+      "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
+      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      enabled", "timestamp": 1639476253949}]'
   marks: bgp assert panos
-  output: '[]'
 - command: bgp unique --columns=hostname --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: bgp unique panos

--- a/tests/integration/sqcmds/panos-samples/device.yml
+++ b/tests/integration/sqcmds/panos-samples/device.yml
@@ -59,12 +59,14 @@ tests:
     "vm": 4, "PA-VM": 1}, "archCnt": {"x86_64": 9, "x86-64": 4, "": 1}, "versionCnt":
     {"4.1.1": 9, "18.04.6 LTS": 4, "8.0.0": 1}, "upTimeStat": [6018621, 91984946,
     6020852]}}'
-- command: device summarize --namespace=dual-evpn --format=json
+- command: device summarize --namespace=panos --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: device summarize panos
-  output: '{"namespace": {}, "hostname": {}, "model": {}, "version": {}, "vendor":
-    {}, "architecture": {}, "status": {}, "address": {}, "bootupTimestamp": {}, "timestamp":
-    {}, "uptime": {}, "os": {}, "serialNumber": {}, "active": {}}'
+  output: '{"panos": {"deviceCnt": 14, "downDeviceCnt": 0, "unpolledDeviceCnt": 0,
+    "vendorCnt": {"Cumulus": 9, "Ubuntu": 4, "Palo Alto": 1}, "modelCnt": {"VX": 9,
+    "vm": 4, "PA-VM": 1}, "archCnt": {"x86_64": 9, "x86-64": 4, "": 1}, "versionCnt":
+    {"4.1.1": 9, "18.04.6 LTS": 4, "8.0.0": 1}, "upTimeStat": [6018621, 91984946,
+    6020852]}}'
 - command: device summarize --columns="namespace hostname" --format=json
   data-directory: tests/data/panos/parquet-out/
   error:

--- a/tests/integration/sqcmds/panos-samples/interface.yml
+++ b/tests/integration/sqcmds/panos-samples/interface.yml
@@ -876,23 +876,23 @@ tests:
 - command: interface top --what='statusChangeTimestamp' --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: interface top panos
-  output: '[{"namespace": "panos", "hostname": "server102", "ifname": "eth0", "state":
-    "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master":
-    "", "ipAddressList": ["10.255.2.76/24"], "ip6AddressList": [], "statusChangeTimestamp":
-    0, "timestamp": 1639476253769}, {"namespace": "panos", "hostname": "server301",
-    "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
-    1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.241/24"], "ip6AddressList":
-    [], "statusChangeTimestamp": 0, "timestamp": 1639476253889}, {"namespace": "panos",
-    "hostname": "server302", "ifname": "eth0", "state": "up", "adminState": "up",
-    "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.103/24"],
-    "ip6AddressList": [], "statusChangeTimestamp": 0, "timestamp": 1639476253942},
-    {"namespace": "panos", "hostname": "server101", "ifname": "eth0", "state": "up",
-    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
-    "ipAddressList": ["10.255.2.9/24"], "ip6AddressList": [], "statusChangeTimestamp":
-    0, "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "firewall01",
-    "ifname": "ethernet1/1", "state": "up", "adminState": "up", "type": "ethernet",
-    "mtu": 1500, "vlan": 0, "master": "default", "ipAddressList": [], "ip6AddressList":
-    [], "statusChangeTimestamp": 0, "timestamp": 1639476254171}]'
+  output: '[{"namespace": "panos", "hostname": "leaf04", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1639466737400,
+    "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
+    "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1639466737400, "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "leaf02", "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1639466737200, "timestamp": 1639476254836}, {"namespace":
+    "panos", "hostname": "leaf02", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "statusChangeTimestamp": 1639466737190, "timestamp":
+    1639476254836}, {"namespace": "panos", "hostname": "leaf01", "ifname": "bond01",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1639466736510, "timestamp": 1639476254854}]'
 - command: interface assert --status=pass --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: interface assert panos

--- a/tests/integration/sqcmds/panos-samples/lldp.yml
+++ b/tests/integration/sqcmds/panos-samples/lldp.yml
@@ -173,27 +173,27 @@ tests:
     "leaf03", "numRows": 4}, {"hostname": "leaf04", "numRows": 4}, {"hostname": "spine01",
     "numRows": 6}, {"hostname": "spine02", "numRows": 6}]'
 - command: lldp show --peerHostname=spine01 --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   marks: lldp show panos
-  output: '[{"namespace": "dual-bgp", "hostname": "exit02", "ifname": "swp1", "peerHostname":
-    "spine01", "peerIfname": "swp5", "description": "Cumulus Linux version 4.3.0 running
+  output: '[{"namespace": "panos", "hostname": "exit01", "ifname": "swp1", "peerHostname":
+    "spine01", "peerIfname": "swp5", "description": "Cumulus Linux version 4.1.1 running
     on QEMU Standard PC (i440FX + PIIX, 1996)", "mgmtIP": "10.0.0.21", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "exit01", "ifname": "swp1",
+    1639476254478}, {"namespace": "panos", "hostname": "exit02", "ifname": "swp1",
     "peerHostname": "spine01", "peerIfname": "swp6", "description": "Cumulus Linux
-    version 4.3.0 running on QEMU Standard PC (i440FX + PIIX, 1996)", "mgmtIP": "10.0.0.21",
-    "timestamp": 1616638470009}, {"namespace": "dual-bgp", "hostname": "leaf01", "ifname":
-    "swp1", "peerHostname": "spine01", "peerIfname": "swp1", "description": "Cumulus
-    Linux version 4.3.0 running on QEMU Standard PC (i440FX + PIIX, 1996)", "mgmtIP":
-    "10.0.0.21", "timestamp": 1616638470218}, {"namespace": "dual-bgp", "hostname":
-    "leaf02", "ifname": "swp1", "peerHostname": "spine01", "peerIfname": "swp2", "description":
-    "Cumulus Linux version 4.3.0 running on QEMU Standard PC (i440FX + PIIX, 1996)",
-    "mgmtIP": "10.0.0.21", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "ifname": "swp1", "peerHostname": "spine01", "peerIfname":
-    "swp3", "description": "Cumulus Linux version 4.3.0 running on QEMU Standard PC
-    (i440FX + PIIX, 1996)", "mgmtIP": "10.0.0.21", "timestamp": 1616638471112}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "ifname": "swp1", "peerHostname": "spine01",
-    "peerIfname": "swp4", "description": "Cumulus Linux version 4.3.0 running on QEMU
-    Standard PC (i440FX + PIIX, 1996)", "mgmtIP": "10.0.0.21", "timestamp": 1616638471112}]'
+    version 4.1.1 running on QEMU Standard PC (i440FX + PIIX, 1996)", "mgmtIP": "10.0.0.21",
+    "timestamp": 1639476254488}, {"namespace": "panos", "hostname": "leaf04", "ifname":
+    "swp1", "peerHostname": "spine01", "peerIfname": "swp4", "description": "Cumulus
+    Linux version 4.1.1 running on QEMU Standard PC (i440FX + PIIX, 1996)", "mgmtIP":
+    "10.0.0.21", "timestamp": 1639476254543}, {"namespace": "panos", "hostname": "leaf02",
+    "ifname": "swp1", "peerHostname": "spine01", "peerIfname": "swp2", "description":
+    "Cumulus Linux version 4.1.1 running on QEMU Standard PC (i440FX + PIIX, 1996)",
+    "mgmtIP": "10.0.0.21", "timestamp": 1639476254548}, {"namespace": "panos", "hostname":
+    "leaf03", "ifname": "swp1", "peerHostname": "spine01", "peerIfname": "swp3", "description":
+    "Cumulus Linux version 4.1.1 running on QEMU Standard PC (i440FX + PIIX, 1996)",
+    "mgmtIP": "10.0.0.21", "timestamp": 1639476254559}, {"namespace": "panos", "hostname":
+    "leaf01", "ifname": "swp1", "peerHostname": "spine01", "peerIfname": "swp1", "description":
+    "Cumulus Linux version 4.1.1 running on QEMU Standard PC (i440FX + PIIX, 1996)",
+    "mgmtIP": "10.0.0.21", "timestamp": 1639476254658}]'
 - command: lldp show --peerHostname='leaf01 exit01' --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: lldp show panos

--- a/tests/integration/sqcmds/panos-samples/network.yml
+++ b/tests/integration/sqcmds/panos-samples/network.yml
@@ -30,15 +30,15 @@ tests:
   data-directory: tests/data/panos/parquet-out
   marks: network find panos
   output: '[]'
-- command: network find --namespace=dual-evpn --address="172.16.1.101" --format=json
+- command: network find --namespace=panos --address="172.16.1.101" --format=json
   data-directory: tests/data/panos/parquet-out
   marks: network find panos
   output: '[]'
-- command: network find --address="52:54:00:c5:1d:06" --namespace=ospf-ibgp --format=json
+- command: network find --address="52:54:00:c5:1d:06" --namespace=panos --format=json
   data-directory: tests/data/panos/parquet-out
   marks: network find panos
   output: '[]'
-- command: network find --address="72:f0:17:6d:80:3f" --namespace=ospf-ibgp --format=json
+- command: network find --address="72:f0:17:6d:80:3f" --namespace=panos --format=json
   data-directory: tests/data/panos/parquet-out
   marks: network find  panos
   output: '[]'

--- a/tests/integration/sqcmds/panos-samples/route.yml
+++ b/tests/integration/sqcmds/panos-samples/route.yml
@@ -1542,2998 +1542,1825 @@ tests:
     "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
     "timestamp": 1639476253357}]'
 - command: route show --prefix='2001:db8:0:1::/64' --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   marks: route show
-  output: '[{"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix":
-    "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
-    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}]'
+  output: '[]'
 - command: route show --prefixlen=64 --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   marks: route show filter prefixlen panos
-  output: '[{"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix":
-    "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02",
-    "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fec6:7cc6"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64",
-    "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs": ["swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs":
-    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe79:485e"],
-    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe40:386"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe8d:ffce",
-    "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
-    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3",
-    "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:4::/64",
-    "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
-    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480",
-    "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426}]'
+  output: '[]'
 - command: route show --prefixlen=">24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   marks: route show filter prefixlen panos
-  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
-    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.8/30",
-    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
-    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
-    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
-    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
-    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d", "fe80::5054:ff:fe8c:5b4d",
-    "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2", "swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"], "oifs":
-    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs":
-    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"],
-    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
-    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "169.254.127.0/31",
-    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
-    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.127.1",
-    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.102/32", "nexthopIps": ["169.254.127.3"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs":
-    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
-    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
-    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
+    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
+    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
+    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
+    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
+    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
+    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
     "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
-    ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs":
-    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
-    ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e", "fe80::5054:ff:fe7e:5a82"],
-    "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
-    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
-    "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"],
-    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps":
-    [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.254.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp5.2"], "protocol":
-    "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
-    "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
-    "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs":
-    ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"],
-    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fedc:803b"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "169.254.1.0/30", "nexthopIps": [""], "oifs": ["peerlink.4094"],
-    "protocol": "kernel", "source": "169.254.1.2", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
-    "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe8d:ffce",
-    "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
-    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
-    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe6c:9df3"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
-    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
-    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
-- command: route show --prefixlen="<=24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
-  marks: route show filter prefixlen panos
-  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix":
-    "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol": "",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
-    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
-    "kernel", "source": "192.168.121.254", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server102", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": [""],
-    "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.102", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16",
-    "nexthopIps": ["172.16.2.1"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
-    "10.0.0.0/8", "nexthopIps": ["172.16.2.1"], "oifs": ["bond0"], "protocol": "",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs":
-    ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""],
-    "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.103", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "server104", "vrf": "default", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.180",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433},
-    {"namespace": "dual-bgp", "hostname": "server104", "vrf": "default", "prefix":
-    "172.16.4.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel",
-    "source": "172.16.4.104", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname": "server104",
-    "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.4.1"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.4.1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"],
-    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.3.1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""],
-    "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.222", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433}, {"namespace":
-    "dual-bgp", "hostname": "server103", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.103",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433},
-    {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default", "prefix":
-    "172.16.0.0/16", "nexthopIps": ["172.16.3.1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469433}, {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469433}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp4", "swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp4", "swp3"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.186",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517}, {"namespace":
-    "dual-bgp", "hostname": "server101", "vrf": "default", "prefix": "10.0.0.0/8",
-    "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517},
-    {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default", "prefix":
-    "172.16.0.0/16", "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469517}, {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
-    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469517}, {"namespace": "dual-bgp", "hostname": "server101",
-    "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"],
-    "protocol": "kernel", "source": "192.168.121.233", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469517}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.141", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.4.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp3", "swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "mgmt",
-    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
-    "kernel", "source": "192.168.121.51", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp3", "swp4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "172.16.2.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.181",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.4.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "mgmt",
-    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
-    "kernel", "source": "192.168.121.164", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "leaf04", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["vlan13"], "protocol":
-    "kernel", "source": "172.16.3.1", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "172.16.4.0/24", "nexthopIps": [""], "oifs": ["vlan24"],
-    "protocol": "kernel", "source": "172.16.4.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
-    "leaf04", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs":
-    ["eth0"], "protocol": "kernel", "source": "192.168.121.132", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.119",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps":
-    [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.2.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002}, {"namespace":
-    "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.1.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "0.0.0.0/0",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.2.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.1.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "0.0.0.0/0",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "mgmt",
-    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
-    "kernel", "source": "192.168.121.94", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname":
-    "leaf03", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps": [""], "oifs":
-    ["vlan24"], "protocol": "kernel", "source": "172.16.4.1", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.3.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}, {"namespace":
-    "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}, {"namespace":
-    "dual-bgp", "hostname": "leaf03", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.33",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
-- command: route show --prefixlen=">24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
-  marks: route show filter prefixlen panos
-  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
-    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.8/30",
-    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
-    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
-    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
-    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
-    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d", "fe80::5054:ff:fe8c:5b4d",
-    "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2", "swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"], "oifs":
-    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs":
-    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"],
-    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
-    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "169.254.127.0/31",
-    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
-    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.127.1",
-    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.102/32", "nexthopIps": ["169.254.127.3"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs":
-    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
-    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
-    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
-    ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs":
-    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
-    ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e", "fe80::5054:ff:fe7e:5a82"],
-    "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
-    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
-    "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"],
-    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps":
-    [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.254.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp5.2"], "protocol":
-    "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp3.2"],
+    "protocol": "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"], "oifs": ["swp3.3"],
     "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
-    "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
-    "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs":
-    ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"],
-    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fedc:803b"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "169.254.1.0/30", "nexthopIps": [""], "oifs": ["peerlink.4094"],
-    "protocol": "kernel", "source": "169.254.1.2", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
-    "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe8d:ffce",
-    "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
-    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
-    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe6c:9df3"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
-    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
-    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
-- command: route show --prefixlen=">=24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
-  marks: route show filter prefixlen panos
-  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
-    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
-    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
-    "kernel", "source": "192.168.121.254", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server102", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": [""],
-    "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.102", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.253.1/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": [""],
-    "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368}, {"namespace":
-    "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.103",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
-    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
-    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
-    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
-    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""],
-    "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.180", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433}, {"namespace":
-    "dual-bgp", "hostname": "server104", "vrf": "default", "prefix": "172.16.4.0/24",
-    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.4.104",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469433},
-    {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default", "prefix":
-    "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
-    "source": "192.168.121.222", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname": "server103",
-    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"],
-    "protocol": "kernel", "source": "172.16.3.103", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d", "fe80::5054:ff:fe8c:5b4d",
-    "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2", "swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"], "oifs":
-    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp4", "swp3"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp4", "swp3"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "mgmt",
-    "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
-    "kernel", "source": "192.168.121.186", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fec6:7cc6"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64",
-    "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs": ["swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
-    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469517}, {"namespace": "dual-bgp", "hostname": "server101",
-    "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps": [""], "oifs": ["eth0"],
-    "protocol": "kernel", "source": "192.168.121.233", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469517}, {"namespace": "dual-bgp",
-    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
-    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "169.254.127.0/31",
-    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
-    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.127.1",
-    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.102/32", "nexthopIps": ["169.254.127.3"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs":
-    ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
-    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "192.168.121.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.141", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
-    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs":
-    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fe79:485e"],
-    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps":
-    ["fe80::5054:ff:fe40:386"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e",
-    "fe80::5054:ff:fe7e:5a82"], "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp3", "swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.51", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp3", "swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "10.0.0.253/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol":
-    "kernel", "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "172.16.4.0/24", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["swp5.4"],
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["swp3.4"],
     "protocol": "kernel", "source": "169.254.254.9", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp3.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["swp3.3"], "protocol": "kernel", "source": "169.254.254.5", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["swp3.3"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [""], "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.2"], "oifs": ["swp5.2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps":
-    [""], "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.254.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "10.0.0.21/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.181", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "10.0.0.12/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps":
-    [""], "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.4.0/24",
-    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "172.16.3.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30", "nexthopIps": [""],
-    "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31",
-    "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel", "source": "169.254.127.3",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"], "oifs": ["swp6"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "mgmt", "prefix": "192.168.121.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.164", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["vlan13"], "protocol":
-    "kernel", "source": "172.16.3.1", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "172.16.4.0/24", "nexthopIps": [""], "oifs": ["vlan24"],
-    "protocol": "kernel", "source": "172.16.4.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname":
-    "leaf04", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::22/128", "nexthopIps":
-    ["fe80::5054:ff:fedc:803b"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
-    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe8d:ffce"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.132",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp4"], "protocol":
+    "kernel", "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [""], "oifs": ["swp3.3"],
+    "protocol": "kernel", "source": "169.254.253.5", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.253.2"], "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["swp3.2"], "protocol": "kernel", "source": "169.254.253.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999",
+    "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
-    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.119",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.2.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.1.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
-    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe6c:9df3"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "172.16.4.0/24", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["vlan24"], "protocol":
-    "kernel", "source": "172.16.2.1", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf":
-    "default", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["vlan13"],
-    "protocol": "kernel", "source": "172.16.1.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname":
-    "leaf02", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps": [""], "oifs":
-    ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
-    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.94",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
-    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.4.0/24",
-    "nexthopIps": [""], "oifs": ["vlan24"], "protocol": "kernel", "source": "172.16.4.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": [""], "oifs": ["vlan13"], "protocol": "kernel", "source": "172.16.3.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
-    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.1",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "mgmt", "prefix": "192.168.121.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "192.168.121.33",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:2::/64",
-    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426}]'
-- command: route show --prefixlen="!24" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["swp3.4"], "protocol":
+    "kernel", "source": "169.254.253.9", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp3.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp4"], "protocol": "kernel", "source": "169.254.127.3", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.76",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.241",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}]'
+- command: route show --prefixlen="<=24" --format=json
+  data-directory: tests/data/panos/parquet-out/
   marks: route show filter prefixlen panos
-  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix":
-    "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol": "",
+  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix":
+    "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"], "protocol": "kernel",
+    "source": "172.16.2.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
+    "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
+    ["eth0"], "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
+    ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
+    ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.187",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "10.0.0.0/24",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.103",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.185",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.252",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs": ["swp4"], "protocol": "bgp",
     "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"], "oifs": ["eth0"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.112", "10.0.0.134"], "oifs":
+    ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
+    ["eth0"], "protocol": "kernel", "source": "10.255.2.251", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
+    ["eth0"], "protocol": "kernel", "source": "10.255.2.184", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
+    ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    ["10.0.0.112", "10.0.0.134"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs": ["swp4"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server101", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol":
     "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "server102", "vrf": "default",
-    "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"],
-    "protocol": "", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname": "server102",
-    "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.2.1"], "oifs":
+    1639476253490}, {"namespace": "panos", "hostname": "server101", "vrf": "default",
+    "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253490}, {"namespace": "panos", "hostname": "server101", "vrf": "default",
+    "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
+    "source": "10.255.2.9", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253490}, {"namespace": "panos", "hostname": "server101", "vrf": "default",
+    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server101", "vrf":
+    "default", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.1.101", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102", "vrf":
+    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102", "vrf":
+    "default", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.76", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102", "vrf":
+    "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs":
     ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server102", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.2.1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.253.9",
-    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.8/30",
-    "nexthopIps": [""], "oifs": ["eth1.4"], "protocol": "kernel", "source": "169.254.254.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["eth2.4"], "protocol": "kernel", "source": "169.254.253.10",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.254.0/30",
-    "nexthopIps": [""], "oifs": ["eth1.2"], "protocol": "kernel", "source": "169.254.254.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.1",
-    "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.254.1",
-    "169.254.254.9"], "oifs": ["eth1.2", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.253.1", "169.254.253.9"], "oifs": ["eth2.2", "eth2.4"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "edge01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.253.9",
-    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "186", "source": "10.0.0.100",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "169.254.253.0/30",
-    "nexthopIps": [""], "oifs": ["eth2.2"], "protocol": "kernel", "source": "169.254.253.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469368},
-    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.253.1", "169.254.254.1"], "oifs": ["eth2.2", "eth1.2"],
-    "protocol": "186", "source": "10.0.0.100", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469368}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.4.1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.4.1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"],
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"],
+    "protocol": "kernel", "source": "172.16.3.102", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server301", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
     "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "10.0.0.0/8", "nexthopIps": ["172.16.3.1"],
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server301", "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"],
     "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["192.168.121.1"],
-    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server104", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "server103", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "2001:db8:0:2::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe8c:5b4d"], "oifs":
-    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe33:c73d",
-    "fe80::5054:ff:fe8c:5b4d", "fe80::5054:ff:fec6:7cc6"], "oifs": ["swp4", "swp2",
-    "swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "spine02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514}, {"namespace":
-    "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469514},
-    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp3"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469514}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
-    "prefix": "2001:db8:0:3::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"], "oifs":
-    ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fec6:7cc6"],
-    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517}, {"namespace":
-    "dual-bgp", "hostname": "server101", "vrf": "default", "prefix": "10.0.0.0/8",
-    "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469517},
-    {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default", "prefix":
-    "172.16.0.0/16", "nexthopIps": ["172.16.1.1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469517}, {"namespace": "dual-bgp", "hostname": "server101", "vrf": "default",
-    "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:1::1"], "oifs": ["bond0"],
-    "protocol": "", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469517}, {"namespace": "dual-bgp", "hostname": "internet",
-    "vrf": "default", "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp1"],
-    "protocol": "kernel", "source": "169.254.127.0", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "internet", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.127.1",
-    "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.1"], "oifs": ["swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "internet",
-    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.3"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fea1:d20b"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp2"], "protocol": "kernel",
-    "source": "169.254.127.2", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1"], "oifs":
-    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp5", "swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp6"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp5"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1"], "oifs":
-    ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol": "bgp",
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server301", "vrf": "default", "prefix": "10.255.2.0/24", "nexthopIps": [""],
+    "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.241", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}, {"namespace":
+    "panos", "hostname": "server301", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.201",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}]'
+- command: route show --prefixlen=">24" --format=json
+  data-directory: tests/data/panos/parquet-out/
+  marks: route show filter prefixlen panos
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
+    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
+    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
+    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
+    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
+    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
+    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
     "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "internet", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["192.168.121.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "internet", "vrf": "default", "prefix": "10.0.0.12/32",
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp3.2"],
+    "protocol": "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"], "oifs": ["swp3.3"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [""], "oifs": ["swp3.4"],
+    "protocol": "kernel", "source": "169.254.254.9", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["swp3.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["swp3.3"], "protocol": "kernel", "source": "169.254.254.5", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["swp3.3"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [""], "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32",
     "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
-    ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe79:485e"], "oifs": ["swp3"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
-    "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"], "oifs":
-    ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "spine01", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe40:386"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp",
-    "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::12/128", "nexthopIps":
-    ["fe80::5054:ff:fe40:386", "fe80::5054:ff:fe79:485e", "fe80::5054:ff:fe7e:5a82"],
-    "oifs": ["swp2", "swp3", "swp4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp5"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469538},
-    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "prefix":
-    "10.0.0.11/32", "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1",
-    "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469538}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
-    "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps": ["169.254.127.0"],
-    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps":
-    [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.254.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.102/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
-    "prefix": "169.254.254.0/30", "nexthopIps": [""], "oifs": ["swp5.2"], "protocol":
-    "kernel", "source": "169.254.254.1", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.253.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "10.0.0.12/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
-    "10.0.0.21/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp6"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.254.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": [""],
-    "oifs": ["swp5.2"], "protocol": "kernel", "source": "169.254.253.1", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "default", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.2"],
-    "oifs": ["swp5.2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.127.2"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "169.254.253.8/30",
-    "nexthopIps": [""], "oifs": ["swp5.4"], "protocol": "kernel", "source": "169.254.253.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
-    "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp6"], "protocol": "kernel",
-    "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.127.2"], "oifs":
-    ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.127.2"],
-    "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.253.10"], "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "exit02", "vrf": "default", "prefix": "172.16.253.1/32",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["swp5.2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690},
-    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469690}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.254.10"], "oifs": ["swp5.4"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
-    "internet-vrf", "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.253.10"], "oifs":
-    ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.254.10"],
-    "oifs": ["swp5.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469690}, {"namespace": "dual-bgp",
-    "hostname": "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["169.254.127.0"], "oifs": ["swp6"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638469690}, {"namespace":
-    "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:2::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8::22/128", "nexthopIps":
-    ["fe80::5054:ff:fedc:803b"], "oifs": ["swp2"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:1::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "169.254.1.0/30", "nexthopIps":
-    [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source": "169.254.1.2",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "2001:db8:0:4::/64", "nexthopIps":
-    ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf":
-    "default", "prefix": "2001:db8::21/128", "nexthopIps": ["fe80::5054:ff:fe8d:ffce"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.253/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.101/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "0.0.0.0/0",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638469730},
-    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638469730}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:1::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp4"], "protocol":
+    "kernel", "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [""], "oifs": ["swp3.3"],
+    "protocol": "kernel", "source": "169.254.253.5", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.253.2"], "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["swp3.2"], "protocol": "kernel", "source": "169.254.253.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999",
+    "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8:0:3::/64", "nexthopIps":
-    ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
-    "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fe38:a329",
-    "fe80::5054:ff:fef1:8d28"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fe38:a329"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "2001:db8::12/128", "nexthopIps": ["fe80::5054:ff:fe38:a329", "fe80::5054:ff:fef1:8d28"],
-    "oifs": ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.100/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp",
-    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470002},
-    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "prefix": "2001:db8::21/128",
-    "nexthopIps": ["fe80::5054:ff:fef1:8d28"], "oifs": ["swp1"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470002}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2",
-    "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638470002}, {"namespace": "dual-bgp", "hostname":
-    "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
-    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8:0:3::/64",
-    "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.2", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.253/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.102/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.100/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["swp3.4"], "protocol":
+    "kernel", "source": "169.254.253.9", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp3.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp4"], "protocol": "kernel", "source": "169.254.127.3", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.76",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.241",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}]'
+- command: route show --prefixlen=">=24" --format=json
+  data-directory: tests/data/panos/parquet-out/
+  marks: route show filter prefixlen panos
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
+    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
+    "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31",
+    "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
-    ["169.254.0.1"], "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
-    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284},
-    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol":
+    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
+    "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
+    "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs":
+    ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "mgmt", "prefix":
+    "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source":
+    "10.255.2.118", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "mgmt", "prefix":
+    "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source":
+    "10.255.2.117", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.3.202", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf04", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.187", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"],
+    "protocol": "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
+    ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
+    "source": "10.255.2.103", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.103", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "mgmt", "prefix":
+    "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source":
+    "10.255.2.185", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "10.255.2.252", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": [""],
+    "oifs": ["swp3.2"], "protocol": "kernel", "source": "169.254.254.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"],
+    "oifs": ["swp3.3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [""],
+    "oifs": ["swp3.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp3.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp4"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1",
-    "169.254.0.1"], "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1616638470284}, {"namespace":
-    "dual-bgp", "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::22/128",
-    "nexthopIps": ["fe80::5054:ff:fea1:3072"], "oifs": ["swp2"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
-    "prefix": "2001:db8:0:4::/64", "nexthopIps": ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470284}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8:0:1::/64", "nexthopIps":
-    ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
-    "default", "prefix": "2001:db8::22/128", "nexthopIps": ["fe80::5054:ff:fed6:9480"],
-    "oifs": ["swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::21/128", "nexthopIps":
-    ["fe80::5054:ff:fedb:b08e"], "oifs": ["swp1"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fed6:9480", "fe80::5054:ff:fedb:b08e"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "172.16.253.1/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "169.254.1.0/30",
-    "nexthopIps": [""], "oifs": ["peerlink.4094"], "protocol": "kernel", "source":
-    "169.254.1.1", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.102/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.100/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.112", "10.0.0.134"], "oifs":
+    ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "169.254.254.4/30", "nexthopIps": [""],
+    "oifs": ["swp3.3"], "protocol": "kernel", "source": "169.254.254.5", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.6"], "oifs": ["swp3.3"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.251", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31",
+    "nexthopIps": [""], "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp2"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp4"], "protocol":
+    "kernel", "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [""], "oifs": ["swp3.3"],
+    "protocol": "kernel", "source": "169.254.253.5", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.253.2"], "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["swp3.2"], "protocol": "kernel", "source": "169.254.253.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.184",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999",
+    "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs":
+    ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
+    "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["swp3.4"], "protocol":
+    "kernel", "source": "169.254.253.9", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": ["10.0.0.112", "10.0.0.134"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.127.2"], "oifs": ["swp4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "10.0.0.200/32", "nexthopIps": ["169.254.253.10"], "oifs": ["swp3.4"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["169.254.0.1"], "oifs": ["swp1"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.127.2/31", "nexthopIps": [""], "oifs": ["swp4"], "protocol":
+    "kernel", "source": "169.254.127.3", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "server101", "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps":
+    ["172.16.1.254"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}, {"namespace":
+    "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.1.101",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.76",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.76",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.102",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "10.0.0.0/24",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.241",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.241",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.2.201",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs": [], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "2001:2::1/128", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
+    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.6/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+- command: route show --prefixlen="!24" --format=json
+  data-directory: tests/data/panos/parquet-out/
+  marks: route show filter prefixlen panos
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
+    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
+    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
+    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
+    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
+    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
+    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
+    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
+    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "server302", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "server302", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999",
+    "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps":
+    [""], "oifs": ["swp3.2"], "protocol": "kernel", "source": "169.254.254.1", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.254.2"], "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.6"],
+    "oifs": ["swp3.3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "internet-vrf", "prefix": "169.254.254.8/30", "nexthopIps": [""],
+    "oifs": ["swp3.4"], "protocol": "kernel", "source": "169.254.254.9", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["swp3.4"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf", "prefix":
+    "10.0.0.41/32", "nexthopIps": ["169.254.127.0"], "oifs": ["swp4"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs":
-    ["swp2", "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs": ["swp4"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2",
-    "swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname":
-    "leaf03", "vrf": "default", "prefix": "2001:db8:0:2::/64", "nexthopIps": ["fe80::5054:ff:fed6:9480",
-    "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426},
-    {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.253/32",
-    "nexthopIps": ["169.254.0.1", "169.254.0.1"], "oifs": ["swp2", "swp1"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "169.254.254.4/30", "nexthopIps": [""], "oifs": ["swp3.3"], "protocol":
+    "kernel", "source": "169.254.254.5", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["swp3.3"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "dcedge01", "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp2"], "protocol": "kernel", "source": "169.254.127.2", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "169.254.127.0/31",
+    "nexthopIps": [""], "oifs": ["swp1"], "protocol": "kernel", "source": "169.254.127.0",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["169.254.127.1", "169.254.127.3"], "oifs": ["swp1", "swp2"], "protocol":
     "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1616638470426}]'
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf",
+    "prefix": "169.254.127.0/31", "nexthopIps": [""], "oifs": ["swp4"], "protocol":
+    "kernel", "source": "169.254.127.1", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "169.254.253.4/30", "nexthopIps": [""], "oifs": ["swp3.3"],
+    "protocol": "kernel", "source": "169.254.253.5", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13",
+    "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["169.254.253.2"], "oifs": ["swp3.2"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": [""], "oifs": ["swp3.2"], "protocol": "kernel", "source": "169.254.253.1",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999",
+    "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
+    "prefix": "169.254.253.8/30", "nexthopIps": [""], "oifs": ["swp3.4"], "protocol":
+    "kernel", "source": "169.254.253.9", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["169.254.253.10"],
+    "oifs": ["swp3.4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "169.254.127.2/31", "nexthopIps": [""],
+    "oifs": ["swp4"], "protocol": "kernel", "source": "169.254.127.3", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.76",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.241",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server301", "vrf": "default", "prefix": "172.16.0.0/16",
+    "nexthopIps": ["172.16.2.254"], "oifs": ["bond0"], "protocol": "", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.6/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
 - command: route show --prefixlen=">128" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen panos
 - command: route show --prefixlen="<0" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid prefixlen: value should be between 0 and 128"}]'
   marks: route show filter prefixlen panos
 - command: route show --prefixlen=">24 and !32" --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "Invalid prefixlen query: it must be of the form ''[<|<=|>=|>|!]
       length'' (i.e. ''>= 24'')"}]'
   marks: route show filter prefixlen panos
 - command: route summarize --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   marks: route summarize
-  output: '{"dual-bgp": {"deviceCnt": 14, "uniquePrefixCnt": 35, "uniqueVrfsCnt":
-    3, "ifRoutesCnt": 16, "hostRoutesCnt": 119, "totalV4RoutesinNs": 228, "totalV6RoutesinNs":
-    40, "routingProtocolCnt": 4, "nexthopCnt": {"1": 153, "2": 113, "3": 2}, "routesPerHostStat":
-    [6, 35, 22.0], "routesperVrfStat": [16, 218, 34.0], "deviceWithNoDefRoute": true}}'
+  output: '{"panos": {"deviceCnt": 14, "uniquePrefixCnt": 38, "uniqueVrfsCnt": 4,
+    "ifRoutesCnt": 16, "hostRoutesCnt": 93, "totalV4RoutesinNs": 177, "totalV6RoutesinNs":
+    4, "routingProtocolCnt": 7, "nexthopCnt": 4, "routesPerHostStat": [5, 24, 13.0],
+    "routesperVrfStat": [10, 121, 25.0], "deviceWithNoDefRoute": true}}'
 - command: route lpm --address 2001:db8::11 --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
+  error:
+    error: '[{"error": "ERROR: \"None of [Index([''namespace'', ''hostname'', ''vrf'',
+      ''prefix'', ''nexthopIps'', ''oifs'',\\n       ''protocol'', ''source'', ''preference'',
+      ''ipvers'', ''action'', ''timestamp''],\\n      dtype=''object'')] are in the
+      [columns]\""}]'
   marks: route lpm
-  output: '[{"namespace": "dual-bgp", "hostname": "server102", "vrf": "default", "prefix":
-    "2001:db8::/32", "nexthopIps": ["2001:db8:0:2::1"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469368}, {"namespace": "dual-bgp", "hostname": "server103", "vrf": "default",
-    "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:3::1"], "oifs": ["bond0"],
-    "protocol": "", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname": "server104",
-    "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps": ["2001:db8:0:4::1"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 6,
-    "action": "forward", "timestamp": 1616638469433}, {"namespace": "dual-bgp", "hostname":
-    "spine02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe6b:7941"],
-    "oifs": ["swp1"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469514}, {"namespace": "dual-bgp",
-    "hostname": "server101", "vrf": "default", "prefix": "2001:db8::/32", "nexthopIps":
-    ["2001:db8:0:1::1"], "oifs": ["bond0"], "protocol": "", "source": "", "preference":
-    20, "ipvers": 6, "action": "forward", "timestamp": 1616638469517}, {"namespace":
-    "dual-bgp", "hostname": "spine01", "vrf": "default", "prefix": "2001:db8::11/128",
-    "nexthopIps": ["fe80::5054:ff:fea1:d20b"], "oifs": ["swp1"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp":
-    1616638469538}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
-    "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fe8d:ffce", "fe80::5054:ff:fedc:803b"],
-    "oifs": ["swp1", "swp2"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    6, "action": "forward", "timestamp": 1616638469730}, {"namespace": "dual-bgp",
-    "hostname": "leaf02", "vrf": "default", "prefix": "2001:db8::11/128", "nexthopIps":
-    ["fe80::5054:ff:fe6c:9df3", "fe80::5054:ff:fea1:3072"], "oifs": ["swp1", "swp2"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 6, "action": "forward",
-    "timestamp": 1616638470284}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf":
-    "default", "prefix": "2001:db8::11/128", "nexthopIps": ["fe80::5054:ff:fed6:9480",
-    "fe80::5054:ff:fedb:b08e"], "oifs": ["swp2", "swp1"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 6, "action": "forward", "timestamp": 1616638470426}]'
 - command: route lpm --address 2001:db:0:2::102 --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   error:
     error: '[{"error": "ERROR: \"None of [Index([''namespace'', ''hostname'', ''vrf'',
       ''prefix'', ''nexthopIps'', ''oifs'',\\n       ''protocol'', ''source'', ''preference'',
@@ -4541,11 +3368,10 @@ tests:
       [columns]\""}]'
   marks: route lpm panos
 - command: route unique --columns=prefixlen --format=json
-  data-directory: tests/data/basic_dual_bgp/parquet-out/
+  data-directory: tests/data/panos/parquet-out/
   marks: route unique panos
-  output: '[{"prefixlen": 0}, {"prefixlen": 8}, {"prefixlen": 16}, {"prefixlen": 24},
-    {"prefixlen": 30}, {"prefixlen": 31}, {"prefixlen": 32}, {"prefixlen": 64}, {"prefixlen":
-    128}]'
+  output: '[{"prefixlen": 0}, {"prefixlen": 16}, {"prefixlen": 24}, {"prefixlen":
+    30}, {"prefixlen": 31}, {"prefixlen": 32}, {"prefixlen": 127}, {"prefixlen": 128}]'
 - command: route lpm --address='172.16.1.101' --columns='hostname nexthopIps' --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: route lpm panos

--- a/tests/integration/sqcmds/panos-samples/sqpoller.yml
+++ b/tests/integration/sqcmds/panos-samples/sqpoller.yml
@@ -949,13 +949,11 @@ tests:
   marks: sqpoller summarize panos
   output: '{"panos": {"deviceCnt": 14, "entriesCnt": 217, "service": 18, "status":
     {"0": 210, "200": 7}, "pollExcdPeriodStat": [0, 0, 0.0]}}'
-- command: sqpoller summarize --namespace=dual-evpn --format=json
+- command: sqpoller summarize --namespace=panos --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: sqpoller summarize panos
-  output: '{"namespace": {}, "hostname": {}, "service": {}, "status": {}, "gatherTime":
-    {}, "totalTime": {}, "svcQsize": {}, "wrQsize": {}, "nodeQsize": {}, "rxBytes":
-    {}, "pollExcdPeriodCount": {}, "timestamp": {}, "version": {}, "nodesPolledCnt":
-    {}, "nodesFailedCnt": {}, "active": {}}'
+  output: '{"panos": {"deviceCnt": 14, "entriesCnt": 217, "service": 18, "status":
+    {"0": 210, "200": 7}, "pollExcdPeriodStat": [0, 0, 0.0]}}'
 - command: sqpoller unique --format=json
   data-directory: tests/data/panos/parquet-out/
   marks: sqpoller unique

--- a/tests/integration/test_sqcmds.py
+++ b/tests/integration/test_sqcmds.py
@@ -485,6 +485,16 @@ def test_junos_sqcmds(testvar, create_context_config):
 @ pytest.mark.parametrize(
     "testvar",
     load_up_the_tests(os.scandir(os.path.abspath(os.curdir) +
+                                 '/tests/integration/sqcmds/panos-samples')))
+def test_panos_sqcmds(testvar, create_context_config):
+    _test_sqcmds(testvar, create_context_config)
+
+
+@ pytest.mark.smoke
+@ pytest.mark.sqcmds
+@ pytest.mark.parametrize(
+    "testvar",
+    load_up_the_tests(os.scandir(os.path.abspath(os.curdir) +
                                  '/tests/integration/sqcmds/eos-samples')))
 def test_eos_sqcmds(testvar, create_context_config):
     _test_sqcmds(testvar, create_context_config)


### PR DESCRIPTION
This PR enable the discovery of sqcmds for panos as they were not included earlier. It also patches some cmd outputs due to fixes applied to the codebase after those output were checked in.