### PR TITLE
sq-poller: gracefully terminate with -i mode

### DIFF
--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -50,14 +50,8 @@ class StaticManager(Manager, InventoryAsyncPlugin):
 
         # Get the running mode
         self._input_dir = config_data.get('input-dir', None)
-        self._run_once = config_data.get('run-once', None)
+        self._single_run_mode = config_data.get('single-run-mode', None)
         self._no_coalescer = config_data.get('no-coalescer', False)
-
-        # If the debug mode is active we need to set run_once
-        if config_data.get('debug'):
-            self._run_once = 'debug'
-        elif self._input_dir:
-            self._run_once = 'input-dir'
 
         if not self._no_coalescer:
             self._coalescer_launcher = CoalescerLauncher(
@@ -142,7 +136,7 @@ class StaticManager(Manager, InventoryAsyncPlugin):
 
             # Launch all the pollers we need to launch
             # If the mode is debug we do not need to launch the pollers
-            if self._run_once != 'debug':
+            if self._single_run_mode != 'debug':
                 launch_tasks = [self._launch_poller(i)
                                 for i in pollers_to_launch]
                 res = await asyncio.gather(
@@ -233,7 +227,7 @@ class StaticManager(Manager, InventoryAsyncPlugin):
                         # Probably unexpected poller died
                         process = self._running_workers[poller_id]
 
-                        if self._run_once and process.returncode == 0:
+                        if self._single_run_mode and process.returncode == 0:
                             # Worker natural death
                             del self._running_workers[poller_id]
                         else:

--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -56,6 +56,8 @@ class StaticManager(Manager, InventoryAsyncPlugin):
         # If the debug mode is active we need to set run_once
         if config_data.get('debug'):
             self._run_once = 'debug'
+        elif self._input_dir:
+            self._run_once = 'input-dir'
 
         if not self._no_coalescer:
             self._coalescer_launcher = CoalescerLauncher(

--- a/suzieq/poller/controller/source/base_source.py
+++ b/suzieq/poller/controller/source/base_source.py
@@ -165,7 +165,7 @@ class Source(ControllerPlugin):
             raise InventorySourceError('A source plugin cannot be initialized'
                                        'without the inventory file path')
         src_confs = _load_inventory(plugin_conf.get('path'))
-        run_once = plugin_conf.get('run-once', False)
+        run_once = plugin_conf.get('single-run-mode', None)
         for src_conf in src_confs:
             ptype = src_conf.get('type') or 'native'
 

--- a/suzieq/poller/worker/writers/output_worker_manager.py
+++ b/suzieq/poller/worker/writers/output_worker_manager.py
@@ -54,7 +54,7 @@ class OutputWorkerManager:
             try:
                 data = await self._output_queue.get()
             except asyncio.CancelledError:
-                logger.error(
+                logger.warning(
                     'OutputWorkerManager: received signal to terminate'
                 )
                 return

--- a/tests/unit/poller/controller/manager/test_static_manager.py
+++ b/tests/unit/poller/controller/manager/test_static_manager.py
@@ -30,6 +30,7 @@ MANAGER_ARGS = {
     'output-dir': '/tmp/out-dir',
     'outputs': ['parquet', 'gather'],
     'run-once': None,
+    'single-run-mode': None,
     'service-only': None,
     'ssh-config-file': None,
     'workers': 1
@@ -309,7 +310,7 @@ async def test_launch_debug_mode(monkeypatch, manager_cfg, capsys):
     monkeypatch.setattr(os, 'environ', fake_environ)
 
     manager_args = MANAGER_ARGS.copy()
-    manager_args['debug'] = True
+    manager_args['single-run-mode'] = 'debug'
     manager_args['workers'] = 2
     manager = init_static_manager(manager_cfg, manager_args)
 
@@ -610,6 +611,7 @@ async def test_execute_run_once(monkeypatch, manager_cfg):
     monkeypatch.setattr(os, 'environ', fake_environ)
     manager_args = MANAGER_ARGS.copy()
     manager_args['run-once'] = 'gather'
+    manager_args['single-run-mode'] = manager_args['run-once']
     manager_args['no-coalescer'] = True
 
     manager = init_static_manager(manager_cfg, manager_args)
@@ -634,6 +636,8 @@ async def test_execute_run_once(monkeypatch, manager_cfg):
 
             # Check if the execute task properly terminated
             assert execute_task.done()
+            assert not execute_task.exception(), \
+                f'Manager terminated with exception {execute_task.exception()}'
         finally:
             # Cancel the execute task
             if not execute_task.done():

--- a/tests/unit/poller/controller/test_controller.py
+++ b/tests/unit/poller/controller/test_controller.py
@@ -289,11 +289,11 @@ def test_controller_valid_args(config_file: str, inv_file: str, args: Dict):
     assert c._input_dir == args['input_dir']
 
     if args['debug']:
-        assert c.run_once == 'debug'
+        assert c.single_run_mode == 'debug'
     elif args['input_dir']:
-        assert c.run_once == 'input-dir'
+        assert c.single_run_mode == 'input-dir'
     else:
-        assert c.run_once == args['run_once']
+        assert c.single_run_mode == args['run_once']
 
     if not args['input_dir']:
         assert c._config['source']['path'] == args['inventory']
@@ -367,7 +367,7 @@ def test_default_controller_config(default_args):
         assert c._config['manager']['config'] == sq_get_config_file(None)
         assert c._config['manager']['workers'] == 1
         assert c.period == 3600
-        assert c.run_once is None
+        assert c.single_run_mode is None
         manager_args = ['debug', 'exclude-services', 'outputs',
                         'output-dir', 'service-only', 'ssh-config-file']
         for ma in manager_args:


### PR DESCRIPTION
Currently when the poller is launched with the `-i` flag, it raises an exception when the worker terminates. This PR solves this problem.