### PR TITLE
Reduce warning in pytest

### DIFF
--- a/suzieq/engines/pandas/routes.py
+++ b/suzieq/engines/pandas/routes.py
@@ -43,7 +43,7 @@ class RoutesObj(SqPandasEngine):
         '''Some NOS do not return an ifname, we need to fix it'''
 
         def add_oifs(row, ifdict):
-            if row.nexthopIps == []:
+            if row.nexthopIps.size == 0:
                 return row.oifs
 
             oifs = []

--- a/tests/integration/test_coalescer.py
+++ b/tests/integration/test_coalescer.py
@@ -274,7 +274,7 @@ def _write_verify_transform(mod_df, table, dbeng, schema, config_file,
 
     """
     mod_df = mod_df.reset_index(drop=True)
-    mod_df.timestamp = mod_df.timestamp.astype(np.int64)
+    mod_df.timestamp = mod_df.timestamp.view(np.int64)
     mod_df.timestamp = mod_df.timestamp//1000000
     mod_df.sqvers = mod_df.sqvers.astype(str)
     dbeng.write(table, 'pandas', mod_df, False, schema.get_arrow_schema(),

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -507,6 +507,8 @@ def app_initialize():
 # which screws things up. So, we run server with & without https sequentially
 # For some reason, putting the no_https in a for loop didn't work either
 @ pytest.mark.rest
+@ pytest.mark.filterwarnings(
+    'ignore::urllib3.exceptions.InsecureRequestWarning')
 def test_rest_server():
     '''Try starting the REST server, actually'''
     # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
This PR fixes some deprecation warnings that appeared during pytest runs. The only warnings that now are still present are related to pandas and numpy internals and will probably be fixed in a new release of them.