### PR TITLE
Remove warning on path gui page

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,6 +1,6 @@
 # GUI
 
-Starting with version 0.8, Suzieq has a GUI. The GUI is included in the same docker container, netenglabs/suzieq, as the rest of the suzieq pieces such as the REST server, the poller and the CLI. However, its recommended to launch a separate instance of the docker container that just runs the GUI. 
+Starting with version 0.8, Suzieq has a GUI. The GUI is included in the same docker container, netenglabs/suzieq, as the rest of the suzieq pieces such as the REST server, the poller and the CLI. However, its recommended to launch a separate instance of the docker container that just runs the GUI.
 
 To launch the docker container running the GUI, you can do:
 ```docker run -itd -v <host parquet dir>:/suzieq/parquet -p 8501:8501 --name suzieq netenglabs/suzieq:latest```
@@ -10,7 +10,7 @@ Now attach to the docker container via:
 
 And at the prompt you can type ```suzieq-gui &``` and detach from the container via the usual escape sequence CTRL-P CTRL-Q
 
-Now you can connect to localhost:8501 or to the host's IP address and port 8501 (for example, http://192.168.12.23:8501) and enjoy the GUI (ignore the external URL thats displayed when you launch the GUI). 
+Now you can connect to localhost:8501 or to the host's IP address and port 8501 (for example, http://192.168.12.23:8501) and enjoy the GUI (ignore the external URL thats displayed when you launch the GUI).
 
 ## Experimental Feature on Xplore Page
 
@@ -18,7 +18,6 @@ With the new table display, you can filter both simple and complex queries witho
 
 The caveats with this are:
 
-* In the Xplore page, after changing the shown table, applying a filter might cause a page refresh. After this reload, filters work as expected. The page may randomly refresh at times causing you to lose the filters. 
+* In the Xplore page, after changing the shown table, applying a filter might cause a page refresh. After this reload, filters work as expected. The page may randomly refresh at times causing you to lose the filters.
 * Keeping the page idle for more than 20 seconds, applying a filter or changing the column of the distribution graph might cause the page to be reloaded. After the reloading, filters should work as expected.
 * Changing the column of the distribution graph might may cause a page refresh, so filters are lost.
-

--- a/suzieq/gui/stlit/path.py
+++ b/suzieq/gui/stlit/path.py
@@ -119,20 +119,19 @@ class PathPage(SqGuiPage):
 
     def _sync_state(self) -> None:
         wsstate = st.session_state
+        state = self._state
 
-        if wsstate.path_swap:
-            self._state.source, self._state.dest = \
-                self._state.dest, self._state.source
-            wsstate.path_source = self._state.source
-            wsstate.path_dest = self._state.dest
+        if wsstate.get('path_swap', False):
+            state.source, state.dest = \
+                state.dest, state.source
         else:
-            self._state.source = wsstate.path_source
-            self._state.dest = wsstate.path_dest
-        self._state.namespace = wsstate.path_namespace
-        self._state.vrf = wsstate.path_vrf
-        self._state.start_time = wsstate.path_start_time
-        self._state.end_time = wsstate.path_end_time
-        self._state.show_ifnames = wsstate.path_show_ifnames
+            state.source = wsstate.path_source
+            state.dest = wsstate.path_dest
+        state.namespace = wsstate.path_namespace
+        state.vrf = wsstate.path_vrf
+        state.start_time = wsstate.path_start_time
+        state.end_time = wsstate.path_end_time
+        state.show_ifnames = wsstate.path_show_ifnames
         self._save_page_url()
 
     def _render(self, layout: dict) -> None:

--- a/suzieq/gui/stlit/path.py
+++ b/suzieq/gui/stlit/path.py
@@ -115,15 +115,18 @@ class PathPage(SqGuiPage):
                                              key='path_show_ifnames',
                                              on_change=self._sync_state)
             _ = st.button(
-                'Source <-> Dest', key='path_swap', on_click=self._sync_state)
+                'Source <-> Dest', key='path_swap',
+                on_click=self._swap_src_dest)
+
+    def _swap_src_dest(self):
+        state = self._state
+        state.source, state.dest = state.dest, state.source
+        self._sync_state()
 
     def _sync_state(self) -> None:
         wsstate = st.session_state
         state = self._state
 
-        if wsstate.get('path_swap', False):
-            state.source, state.dest = \
-                state.dest, state.source
         state.namespace = wsstate.path_namespace
         state.vrf = wsstate.path_vrf
         state.start_time = wsstate.path_start_time

--- a/suzieq/gui/stlit/path.py
+++ b/suzieq/gui/stlit/path.py
@@ -124,9 +124,6 @@ class PathPage(SqGuiPage):
         if wsstate.get('path_swap', False):
             state.source, state.dest = \
                 state.dest, state.source
-        else:
-            state.source = wsstate.path_source
-            state.dest = wsstate.path_dest
         state.namespace = wsstate.path_namespace
         state.vrf = wsstate.path_vrf
         state.start_time = wsstate.path_start_time


### PR DESCRIPTION
This PR removes warning from the gui path page and fixes a bug on the same page: performing a valid trace, going to another page and coming back to the path page results into a page fail