### PR TITLE
sq-poller: Show input-dir and run-once in debug mode help message

### DIFF
--- a/suzieq/poller/sq_poller.py
+++ b/suzieq/poller/sq_poller.py
@@ -5,7 +5,6 @@ This module contains the logic needed to start the poller
 
 import argparse
 import asyncio
-import os
 import sys
 import traceback
 from typing import Dict
@@ -116,7 +115,6 @@ def controller_main():
     parser.add_argument(
         "--output-dir",
         type=str,
-        default=f'{os.path.abspath(os.curdir)}/sqpoller-output',
         help=argparse.SUPPRESS,
     )
 


### PR DESCRIPTION
Currently when we launch the poller with the `--debug` flag along with `--run-once` or `--input-dir` options, we do not obtain the expected result, since:
- with `run-once` no flag is shown in the help message
```
$ sq-poller --run-once update --debug 
1 inventory chunks generated, you can now manually start the workers with the following commands:
...
python /path/to/suzieq/poller/worker/sq_worker.py --worker-id 0
```
- with `input-dir` the poller starts ignoring the `--debug` flag

The aim of this PR is solving this problem always providing the commands to be executed to manually launch the workers