### PR TITLE
Netbox env token + inventory validation

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -71,7 +71,7 @@ namespaces:
   auth: credentials-from-file-0
 ```
 
-## <a name='sensitive-data'></a>Sensible data
+## <a name='sensitive-data'></a>Sensitive data
 A sensitive data is an information that the user doesn't want to store in plain-text inside the inventory.
 For this reason, SuzieQ inventory now supports three different options to store these kind of informations
 

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -71,6 +71,15 @@ namespaces:
   auth: credentials-from-file-0
 ```
 
+## <a name='sensitive-data'></a>Sensible data
+A sensitive data is an information that the user doesn't want to store in plain-text inside the inventory.
+For this reason, SuzieQ inventory now supports three different options to store these kind of informations
+
+- `plain:<password-in-plaintext>` or `<password-in-plaintext>`: the sensitive information is stored as is in the inventory
+- `env:<ENV_VARIABLE>`: the sensitive information is stored in an environment variable
+- `ask`: the user can write the sensitive information on the stdin
+
+Currently this method is used to specify passwords, passphrases and tokens.
 ## <a name='inventory-sources'></a>Sources
 
 The device sources currently supported are:
@@ -132,7 +141,11 @@ Now you can set the path of the ansible inventory in the source:
 
 ### <a name='source-netbox'></a>Netbox
 
-[Netbox](https://netbox.readthedocs.io/en/stable/) is often used to store devices type, management address and other useful information to be used in network automation. Suzieq can pull device data from Netbox selecting them by tag (currently only one per each source). To do so a token to access the netbox API is required as well as the netbox instance url.
+[Netbox](https://netbox.readthedocs.io/en/stable/) is often used to store devices type, management address and other useful information to be used in network automation. Suzieq can pull device data from Netbox selecting them by tag (currently only one per each source).
+To do so a token to access the netbox API is required as well as the netbox instance url.
+
+The token is considered a [sensitive data](#sensitive-data), so it can be specified via an environment variable using the format `env:ENV_TOKEN`.
+
 Since Netbox is a _dynamic source_, the data are periodically pulled, the period can be set to any desired number in seconds (default is 3600).
 
 !!!Info
@@ -172,7 +185,7 @@ sources:
 auths:
 - name: auth-st
   username: user
-  passowrd: my-password
+  password: my-password
 
 namespaces:
 - name: netbox-sitename # devices namespaces equal to their site names
@@ -232,12 +245,6 @@ The simplest method is defining either username and password/private key.
   password: plain:pass
 ```
 
-where `password` can be specified in plaintext, as an environment variable or to be asked to the user:
-
-- `plain:<password-in-plaintext>`
-- `env:<ENV_VARIABLE>`
-- `ask`
-
 In case a private key is used to authenticate:
 ```yaml
 - name: suzieq-user
@@ -245,7 +252,10 @@ In case a private key is used to authenticate:
   key-passphrase: ask
 ```
 
-Where `key-passphrase` is the passphrase of the private key. As the `password` field, it can be set as plaintext, env variable or to be asked to the user.
+Where `key-passphrase` is the passphrase of the private key.
+
+Both `passoword` and `key-passphrase` are considered [sensitive data](#sensitive-data).
+For this reason they can be set as plaintext, env variable or asked to the user via stdin.
 
 ### <a name='cred-file'></a>Credential file
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -76,6 +76,7 @@ markers =
     controller_device
     controller_manager
     controller_manager_static
+    controller_inventory
     recursive
 
 xfail_strict = True

--- a/suzieq/poller/controller/base_controller_plugin.py
+++ b/suzieq/poller/controller/base_controller_plugin.py
@@ -51,7 +51,7 @@ class ControllerPlugin(SqPlugin):
         Args:
             plugin_conf (dict): plugin configuration
             validate (bool): validate the plugin during initialization
-                             Defalult: False
+                             Default: False
 
         Returns:
             List[Dict]: list of generated plugins

--- a/suzieq/poller/controller/base_controller_plugin.py
+++ b/suzieq/poller/controller/base_controller_plugin.py
@@ -1,6 +1,33 @@
-from typing import Dict, List
+# pylint: disable=no-name-in-module
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
 from suzieq.shared.exceptions import SqPollerConfError
 from suzieq.shared.sq_plugin import SqPlugin
+
+
+def _underscore_to_dash(field_name: str) -> str:
+    """Replaces the undescore in the name of the field to a dash
+    """
+    return field_name.replace('_', '-')
+
+
+class BasePluginModel(BaseModel):
+    """Base model for plugins validation
+    """
+    name: str
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+        alias_generator = _underscore_to_dash
+
+
+class InventoryPluginModel(BasePluginModel):
+    """Model for inventory validation
+    """
+    type: Optional[str]
 
 
 class ControllerPlugin(SqPlugin):
@@ -9,14 +36,22 @@ class ControllerPlugin(SqPlugin):
     Args:
         SqPlugin ([type]): [description]
     """
+    # pylint: disable=unused-argument
+    def __init__(self, plugin_conf: Dict, validate: bool = True) -> None:
+        self._validate = validate
 
     @classmethod
-    def init_plugins(cls, plugin_conf: Dict) -> List[Dict]:
+    def init_plugins(cls, plugin_conf: Dict, validate: bool = False) \
+            -> List[Dict]:
         """Instantiate one or more instances of the current class according
-        to the given configuration
+        to the given configuration.
+        The validation is set to False by default because when the init_plugins
+        function is called, the configuration has already been validated.
 
         Args:
             plugin_conf (dict): plugin configuration
+            validate (bool): validate the plugin during initialization
+                             Defalult: False
 
         Returns:
             List[Dict]: list of generated plugins
@@ -34,4 +69,16 @@ class ControllerPlugin(SqPlugin):
         if not controller_class:
             raise SqPollerConfError(f"Unknown plugin called {ptype}")
 
-        return [controller_class[ptype](plugin_conf)]
+        return [controller_class[ptype](plugin_conf, validate)]
+
+    @classmethod
+    def default_type(cls) -> str:
+        """Return the default type for a plugin
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_data_model(cls) -> BasePluginModel:
+        """Return the model used for the data
+        """
+        raise NotImplementedError

--- a/suzieq/poller/controller/chunker/base_chunker.py
+++ b/suzieq/poller/controller/chunker/base_chunker.py
@@ -11,6 +11,7 @@ from suzieq.poller.controller.base_controller_plugin import ControllerPlugin
 class Chunker(ControllerPlugin):
     """Abstract class for a Chunker
     """
+
     @abstractmethod
     def chunk(self, glob_inv, n_chunks, **addl_params):
         """Split the global inventory in <n_chunks> chunks
@@ -21,3 +22,14 @@ class Chunker(ControllerPlugin):
             addl_parameters ([type]): custom parameters that each Chunker
                                       plugin can define
         """
+
+    @classmethod
+    def default_type(cls) -> str:
+        return 'static'
+
+    @classmethod
+    def get_data_model(cls):
+        """This is only temporary. In future release I will add chunker
+        validation via pydantic
+        """
+        raise NotImplementedError

--- a/suzieq/poller/controller/chunker/static.py
+++ b/suzieq/poller/controller/chunker/static.py
@@ -22,7 +22,8 @@ class StaticChunker(Chunker):
     - namespace: splits the global inventory without splitting namespaces
     """
 
-    def __init__(self, config_data: dict = None):
+    def __init__(self, config_data: dict = None, validate: bool = True):
+        super().__init__(config_data, validate)
 
         self.policies_list = ['sequential', 'namespace']
         self.policies_fn = {}
@@ -40,6 +41,13 @@ class StaticChunker(Chunker):
             self.policy = policy
         else:
             self.policy = self.policies_list[0]
+
+    @classmethod
+    def get_data_model(cls):
+        """This is only temporary. In future release I will add chunker
+        validation via pydantic
+        """
+        raise NotImplementedError
 
     def chunk(self, glob_inv: dict, n_chunks: int, **kwargs) -> List[Dict]:
 

--- a/suzieq/poller/controller/controller.py
+++ b/suzieq/poller/controller/controller.py
@@ -75,7 +75,8 @@ class Controller:
         self._period = args.update_period or \
             self._config.get('update-period', 3600)
         self._inventory_timeout = self._config.get('inventory-timeout', 10)
-        self._n_workers = args.workers or self._config.get('workers', 1)
+        self._n_workers = args.workers or self._config.get(
+            'manager', {}).get('workers', 1)
 
         # Validate the arguments
         self._validate_controller_args(args, config_data)

--- a/suzieq/poller/controller/credential_loader/base_credential_loader.py
+++ b/suzieq/poller/controller/credential_loader/base_credential_loader.py
@@ -3,12 +3,36 @@ devices credentials
 """
 import logging
 from abc import abstractmethod
-from typing import Dict, List, Type
+from typing import Dict, List
 
-from suzieq.poller.controller.base_controller_plugin import ControllerPlugin
+from suzieq.poller.controller.base_controller_plugin import \
+    InventoryPluginModel, ControllerPlugin
 from suzieq.shared.exceptions import InventorySourceError
 
 logger = logging.getLogger(__name__)
+
+
+def check_credentials(inventory: Dict):
+    """Checks if all the credentials are set
+    """
+
+    # check if all devices has credentials
+    no_cred_nodes = [
+        f"{d.get('namespace')}.{d.get('address')}"
+        for d in inventory.values()
+        if not d.get('username', None) or
+        not (d.get('password') or d.get('ssh_keyfile'))
+    ]
+    if no_cred_nodes:
+        raise InventorySourceError(
+            'No credentials to log into the following nodes: '
+            f'{no_cred_nodes}'
+        )
+
+
+class CredentialLoaderModel(InventoryPluginModel):
+    """Model for credential loader validation
+    """
 
 
 class CredentialLoader(ControllerPlugin):
@@ -16,8 +40,8 @@ class CredentialLoader(ControllerPlugin):
     sources
     """
 
-    def __init__(self, init_data: Dict) -> None:
-        super().__init__()
+    def __init__(self, init_data: Dict, validate: bool = True) -> None:
+        super().__init__(init_data, validate)
 
         self._cred_format = [
             'username',
@@ -26,23 +50,39 @@ class CredentialLoader(ControllerPlugin):
             'passphrase'
         ]
 
-        # load auth parameters
-
-        self._name = init_data.get('name')
-
-        self._valid_fields = ['name', 'type']
-
-        self._validate_config(init_data)
-
+        self._data: CredentialLoaderModel = None
         self.init(init_data)
 
-    @abstractmethod
-    def init(self, init_data: Type):
+    @property
+    def name(self) -> str:
+        """Name of the source set in the inventory file
+
+        Returns:
+            str: name of the source
+        """
+        return self._data.name
+
+    @classmethod
+    def default_type(cls) -> str:
+        return 'static'
+
+    @classmethod
+    def get_data_model(cls):
+        return CredentialLoaderModel
+
+    def init(self, init_data: Dict):
         """Initialize the object
 
         Args:
-            init_data (Type): data used to initialize the object
+            init_data (Dict): data used to initialize the object
         """
+        if self._validate:
+            self._data = self.get_data_model()(**init_data)
+        else:
+            self._data = self.get_data_model().construct(**init_data)
+        if not self._data:
+            raise InventorySourceError(
+                'input_data was not loaded correctly')
 
     @abstractmethod
     def load(self, inventory: Dict[str, Dict]):
@@ -51,19 +91,6 @@ class CredentialLoader(ControllerPlugin):
         Args:
             inventory (Dict[str, Dict]): inventory to update
         """
-
-    def _validate_config(self, config: Dict):
-        """Validate configuration
-
-        Reads the valid fields from
-
-        Args:
-            config (Dict): configuration dictionary
-        """
-        inv_fields = [x for x in config if x not in self._valid_fields]
-        if inv_fields:
-            raise InventorySourceError(
-                f'{self._name}: unknown fields {inv_fields}')
 
     def write_credentials(self, device: Dict, credentials: Dict[str, Dict]):
         """write and validate input credentials for a device

--- a/suzieq/poller/controller/credential_loader/base_credential_loader.py
+++ b/suzieq/poller/controller/credential_loader/base_credential_loader.py
@@ -47,7 +47,8 @@ class CredentialLoader(ControllerPlugin):
             'username',
             'password',
             'ssh_keyfile',
-            'passphrase'
+            'passphrase',
+            'enable_password'
         ]
 
         self._data: CredentialLoaderModel = None

--- a/suzieq/poller/controller/credential_loader/cred_file.py
+++ b/suzieq/poller/controller/credential_loader/cred_file.py
@@ -24,6 +24,7 @@ class CredFileEntryModel(BaseModel):
     password: Optional[str]
     keyfile: Optional[str]
     key_passphrase: Optional[str] = Field(alias='key-passphrase')
+    enable_password: Optional[str] = Field(alias='enable-password')
 
     class Config:
         """pydantic configuration
@@ -154,6 +155,10 @@ class CredFile(CredentialLoader):
                 # rename 'key-passphrase' into 'passphrase'
                 node_info['passphrase'] = node_info.pop(
                         'key-passphrase', None)
+
+                # rename 'enable-password' into 'enable_password'
+                node_info['enable_password'] = node_info.pop(
+                    'enable-password', None)
 
                 node_cred = node_info.copy()
 

--- a/suzieq/poller/controller/credential_loader/cred_file.py
+++ b/suzieq/poller/controller/credential_loader/cred_file.py
@@ -1,75 +1,129 @@
 """This module contains the class to import device credentials using files
 """
+# pylint: disable=no-name-in-module
+# pylint: disable=no-self-argument
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional, Union
+from pydantic import BaseModel, Field, validator
 
 import yaml
 from suzieq.poller.controller.credential_loader.base_credential_loader import \
-    CredentialLoader
+    CredentialLoader, CredentialLoaderModel, check_credentials
 from suzieq.shared.exceptions import InventorySourceError
 
 logger = logging.getLogger(__name__)
+
+
+class CredFileEntryModel(BaseModel):
+    """Model to validate entries in credential file
+    """
+    hostname: Optional[str]
+    address: Optional[str]
+    username: Optional[str]
+    password: Optional[str]
+    keyfile: Optional[str]
+    key_passphrase: Optional[str] = Field(alias='key-passphrase')
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class CredFileNamespaceModel(BaseModel):
+    """Model to validate the content of the credential file
+    """
+    namespace: str
+    devices: List[CredFileEntryModel]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class CredFileModel(CredentialLoaderModel):
+    """Model for credential file validation
+    """
+    credentials: Union[str, List[CredFileNamespaceModel]] = Field(alias='path')
+
+    @validator('credentials')
+    def validate_credentials(cls, cred):
+        """validate the credentials
+        """
+        if isinstance(cred, str):
+            dev_cred_file = Path(cred)
+            if not dev_cred_file.is_file():
+                raise ValueError(
+                    f'The credential file {cred} does not exists')
+
+            try:
+                with open(dev_cred_file, 'r') as f:
+                    credentials = yaml.safe_load(f.read())
+            except yaml.YAMLError:
+                raise ValueError(
+                    'The credential file is not a valid yaml file'
+                )
+
+            if not credentials:
+                raise ValueError(
+                    'The credential file is empty'
+                )
+
+            if not isinstance(credentials, list):
+                raise ValueError(
+                    'The credentials file must contain all device '
+                    'credential divided in namespaces'
+                )
+        elif isinstance(cred, list):
+            credentials = cred
+        valid_creds = []
+        for c in credentials:
+            if not isinstance(c, dict):
+                raise ValueError(
+                    'Namespaces credentials must be a dictionary')
+            valid_creds.append(CredFileNamespaceModel(**c))
+        return valid_creds
 
 
 class CredFile(CredentialLoader):
     """Reads devices credentials from a file and write them on the inventory
     """
 
-    def _validate_config(self, config: Dict):
-        self._valid_fields.append('path')
-        return super()._validate_config(config)
+    @classmethod
+    def get_data_model(cls):
+        return CredFileModel
 
     def init(self, init_data: dict):
+        if not self._validate:
+            # fix pydantic aliases
+            init_data['credentials'] = []
+            for ns_cred in init_data.pop('path', []):
+                init_data['credentials'].append(
+                    CredFileNamespaceModel(**ns_cred)
+                )
 
-        if not init_data.get('path'):
-            raise InventorySourceError(
-                f'{self._name} No field <path> '
-                'for device credential provided'
-            )
-
-        dev_cred_file = Path(init_data['path'])
-        if not dev_cred_file.is_file():
-            raise InventorySourceError(
-                f'{self._name} The credential file {init_data["path"]} '
-                'does not exists')
-        try:
-            with open(dev_cred_file, 'r') as f:
-                self._raw_credentials = yaml.safe_load(f.read())
-        except yaml.YAMLError:
-            raise InventorySourceError(
-                f'{self._name} The credential file is not a valid yaml file'
-            )
-
-        if not self._raw_credentials:
-            raise InventorySourceError(
-                f'{self._name} The credential file is empty'
-            )
-
-        if not isinstance(self._raw_credentials, list):
-            raise InventorySourceError(
-                f'{self._name} The credentials file must contain all device '
-                'credential divided in namespaces'
-            )
+        super().init(init_data)
+        if not self._data.credentials:
+            raise InventorySourceError(f'{self.name} empty credentials')
 
     def load(self, inventory: Dict):
-        if not inventory:
-            logger.info('Not loading credentials due to empty inventory')
-            return
 
-        for ns_credentials in self._raw_credentials:
-            namespace = ns_credentials.get('namespace', '')
+        for ns_credentials in self._data.credentials:
+            namespace = ns_credentials.namespace
             if not namespace:
                 raise InventorySourceError(
-                    f'{self._name} All namespaces must have a name')
+                    f'{self.name} All namespaces must have a name')
 
-            ns_nodes = ns_credentials.get('devices', [])
+            ns_nodes = ns_credentials.devices
             if not ns_nodes:
                 logger.warning(
-                    f'{self._name} No devices in {namespace} namespace')
+                    f'{self.name} No devices in {namespace} namespace')
                 continue
 
-            for node_info in ns_nodes:
+            for ns_node in ns_nodes:
+                node_info = ns_node.dict(by_alias=True)
                 if node_info.get('hostname'):
                     node_id = node_info['hostname']
                     node_key = 'hostname'
@@ -78,14 +132,14 @@ class CredFile(CredentialLoader):
                     node_key = 'address'
                 else:
                     raise InventorySourceError(
-                        f'{self._name} Nodes must have a hostname or '
+                        f'{self.name} Nodes must have a hostname or '
                         'address')
 
                 node = [x for x in inventory.values()
                         if x.get(node_key) == node_id]
                 if not node:
                     logger.warning(
-                        f'{self._name} Unknown node called {node_id}')
+                        f'{self.name} Unknown node called {node_id}')
                     continue
 
                 node = node[0]
@@ -94,22 +148,17 @@ class CredFile(CredentialLoader):
                         f'The device {node_id} does not belong the namespace '
                         f'{namespace}'
                     )
-                if node_info.get('keyfile'):
-                    # rename 'keyfile' into 'ssh_keyfile'
-                    node_info['ssh_keyfile'] = node_info.pop('keyfile')
+                # rename 'keyfile' into 'ssh_keyfile'
+                node_info['ssh_keyfile'] = node_info.pop('keyfile', None)
 
-                if 'passphrase' not in node_info:
-                    if node_info.get('key-passphrase'):
-                        # rename 'key-passphrase' into 'passphrase'
-                        node_info['passphrase'] = node_info.pop(
-                            'key-passphrase')
-                    else:
-                        # set it to None
-                        node_info['passphrase'] = None
+                # rename 'key-passphrase' into 'passphrase'
+                node_info['passphrase'] = node_info.pop(
+                        'key-passphrase', None)
 
                 node_cred = node_info.copy()
 
-                node_cred.pop(node_key)
+                node_cred.pop('address')
+                node_cred.pop('hostname')
 
                 fields = ['username', 'passphrase', 'ssh_keyfile', 'password']
                 multi_defined = []
@@ -121,21 +170,10 @@ class CredFile(CredentialLoader):
 
                 if multi_defined:
                     raise InventorySourceError(
-                        f"{self._name} the node {node.get('address')} has the "
+                        f"{self.name} the node {node.get('address')} has the "
                         "following strings defined in multiple places "
                         f"{multi_defined}")
 
                 self.write_credentials(node, node_cred)
 
-        # check if all devices has credentials
-        no_cred_nodes = [
-            f"{d.get('namespace')}.{d.get('address')}"
-            for d in inventory.values()
-            if not d.get('username', None) or
-            not (d.get('password') or d.get('ssh_keyfile'))
-        ]
-        if no_cred_nodes:
-            raise InventorySourceError(
-                'No credentials to log into the following nodes: '
-                f'{no_cred_nodes}'
-            )
+        check_credentials(inventory)

--- a/suzieq/poller/controller/manager/base_manager.py
+++ b/suzieq/poller/controller/manager/base_manager.py
@@ -40,3 +40,13 @@ class Manager(ControllerPlugin):
         Returns:
             int: number of desired workers
         """
+    @classmethod
+    def default_type(cls) -> str:
+        return 'static'
+
+    @classmethod
+    def get_data_model(cls):
+        """This is only temporary. In future release I will add manager
+        validation via pydantic
+        """
+        raise NotImplementedError

--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -262,7 +262,8 @@ class StaticManager(Manager, InventoryAsyncPlugin):
             chunk (Dict): chunk of the inventory containing the dictionary
         """
         confidential_data = ['password', 'passphrase',
-                             'ssh_keyfile', 'jump_host_key_file']
+                             'ssh_keyfile', 'jump_host_key_file',
+                             'enable_password']
         out_name = {}
         out_name['inv'] = (f'{str(self._inventory_path)}/'
                            f'{self._inventory_file_name}_{poller_id}.yml')

--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -35,7 +35,9 @@ class StaticManager(Manager, InventoryAsyncPlugin):
     the path for inventory files
     """
 
-    def __init__(self, config_data: Dict = None):
+    def __init__(self, config_data: Dict = None, validate: bool = True):
+
+        super().__init__(config_data, validate)
 
         self._workers_count = config_data.get("workers", 1)
 
@@ -96,6 +98,13 @@ class StaticManager(Manager, InventoryAsyncPlugin):
                 self._args_to_pass.append(f'--{arg}', )
                 # All the arguments should be string
                 self._args_to_pass += [str(v) for v in val_list]
+
+    @classmethod
+    def get_data_model(cls):
+        """This is only temporary. In future release I will add mananger
+        validation via pydantic
+        """
+        raise NotImplementedError
 
     async def apply(self, inventory_chunks: List[Dict]):
         """Apply the inventory chyunks to the pollers
@@ -205,8 +214,8 @@ class StaticManager(Manager, InventoryAsyncPlugin):
 
                 self._running_workers.update(self._waiting_workers)
                 new_ptasks = {i: asyncio.create_task(
-                                    monitor_process(p, f'WORKER {i}'))
-                              for i, p in self._waiting_workers.items()}
+                    monitor_process(p, f'WORKER {i}'))
+                    for i, p in self._waiting_workers.items()}
                 poller_wait_tasks.update(new_ptasks)
                 tasks += list(new_ptasks.values())
                 self._waiting_workers = {}

--- a/suzieq/poller/controller/source/native.py
+++ b/suzieq/poller/controller/source/native.py
@@ -1,44 +1,122 @@
+# pylint: disable=no-name-in-module
+# pylint: disable=no-self-argument
 import logging
-import re
-from typing import Dict
-from urllib.parse import urlparse
-from ipaddress import ip_address
 from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
 
+from pydantic import Field, validator, BaseModel
+
+from suzieq.poller.controller.source.base_source import Source, SourceModel
+from suzieq.poller.controller.utils.inventory_utils import validate_hostname
 from suzieq.shared.utils import SUPPORTED_POLLER_TRANSPORTS
-from suzieq.poller.controller.source.base_source import Source
-from suzieq.shared.exceptions import InventorySourceError
-
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORTS = {'http': 80, 'https': 443, 'ssh': 22}
 
 
+class HostModel(BaseModel):
+    """Model used to validate the hosts of a native inventory
+    """
+    username: str = Field(default=None)
+    password: Optional[str] = Field(default=None)
+    keyfile: Optional[str] = Field(default=None)
+    devtype: Optional[str] = Field(default=None)
+    port: str = Field(default=None)
+    address: str = Field(default=None)
+    transport: str = Field(default=None)
+    url: str
+
+    @validator('url')
+    def validate_and_set(cls, url: str, values):
+        """Validate the 'url' parameter and set the other parameters
+        """
+        words = url.split()
+        decoded_url = urlparse(words[0])
+
+        username = decoded_url.username
+        password = (decoded_url.password or
+                    # self.user_password or #I can't get this info here
+                    None)
+        address = decoded_url.hostname
+        if not validate_hostname(address):
+            raise ValueError(f'Invalid hostname or address {address}')
+        transport = decoded_url.scheme or "http"
+        if transport not in SUPPORTED_POLLER_TRANSPORTS:
+            raise ValueError(
+                f"Transport '{transport}' not supported for host {address}")
+        port = decoded_url.port or _DEFAULT_PORTS.get(transport)
+        devtype = None
+        keyfile = None
+
+        try:
+            for i in range(1, len(words[1:])+1):
+                if words[i].startswith('keyfile'):
+                    keyfile = words[i].split('=')[1]
+                elif words[i].startswith('devtype'):
+                    devtype = words[i].split('=')[1]
+                elif words[i].startswith('username'):
+                    username = words[i].split('=')[1]
+                elif words[i].startswith('password'):
+                    password = words[i].split('=')[1]
+                else:
+                    raise ValueError(
+                        f'Unknown parameter: {words[i]} for {address}')
+        except IndexError:
+            if 'password' not in words[i]:
+                raise ValueError(f"Missing '=' in key {words[i]}")
+            raise ValueError("Invalid password spec., missing '='")
+
+        if keyfile and not Path(keyfile).exists():
+            raise ValueError(
+                f"keyfile {keyfile} does not exist"
+            )
+
+        values['username'] = username
+        values['password'] = password
+        values['keyfile'] = keyfile
+        values['devtype'] = devtype
+        values['port'] = port
+        values['address'] = address
+        values['transport'] = transport
+
+        return url
+
+
+class NativeSourceModel(SourceModel):
+    """Native source validation model
+    """
+    hosts: List[HostModel]
+
+    @validator('hosts')
+    def hosts_not_empty(cls, hosts: List):
+        """checks if the hosts list is not empty"""
+        if not hosts:
+            raise ValueError('Empty hosts list')
+        return hosts
+
+
 class SqNativeFile(Source):
     """Source class used to load Suzieq native inventory files
     """
 
-    def __init__(self, input_data) -> None:
-        self.inventory_source = ""
+    def __init__(self, input_data, validate: bool = True) -> None:
         self._cur_inventory = {}
-        super().__init__(input_data)
+        super().__init__(input_data, validate)
 
-    def _validate_config(self, input_data: dict):
-        self._valid_fields.extend(['hosts'])
-        super()._validate_config(input_data)
-
-        if not input_data.get('hosts'):
-            raise InventorySourceError(f"{self._name} The 'hosts' field with "
-                                       "the list of nodes to poll is mandatory"
-                                       )
-
-        if not isinstance(input_data.get('hosts'), list):
-            raise InventorySourceError(f"{self._name} 'hosts' field must be a "
-                                       "list")
+    @classmethod
+    def get_data_model(cls):
+        return NativeSourceModel
 
     def _load(self, input_data):
-        self.inventory_source = input_data
+        if not self._validate:
+            new_hosts = []
+            for h in input_data.get('hosts', []):
+                new_hosts.append(HostModel(**h))
+            input_data['hosts'] = new_hosts
+        super()._load(input_data)
+
         self._cur_inventory = self._get_inventory()
         self.set_inventory(self._cur_inventory)
 
@@ -50,104 +128,22 @@ class SqNativeFile(Source):
         """
         inventory = {}
 
-        nsname = self.inventory_source['namespace']
-
-        hostlist = self.inventory_source.get('hosts', [])
-
-        for address in hostlist:
-            if not isinstance(address, dict):
-                logger.error(f'Ignoring invalid host spec: {address}')
-                continue
-            entry = address.get('url', None)
-            if entry:
-                words = entry.split()
-                decoded_url = urlparse(words[0])
-
-                username = decoded_url.username
-                password = (decoded_url.password or
-                            # self.user_password or #I can't get this info here
-                            None)
-                transport = decoded_url.scheme or "http"
-                port = decoded_url.port or _DEFAULT_PORTS.get(transport)
-                address = decoded_url.hostname
-                devtype = None
-                keyfile = None
-
-                try:
-                    for i in range(1, len(words[1:])+1):
-                        if words[i].startswith('keyfile'):
-                            keyfile = words[i].split('=')[1]
-                        elif words[i].startswith('devtype'):
-                            devtype = words[i].split('=')[1]
-                        elif words[i].startswith('username'):
-                            username = words[i].split('=')[1]
-                        elif words[i].startswith('password'):
-                            password = words[i].split('=')[1]
-                        else:
-                            logger.error('Ignorning Unknown parameter: '
-                                         f'{words[i]} for {address}')
-                except IndexError:
-                    if 'password' not in words[i]:
-                        logger.error(f"Missing '=' in key {words[i]}")
-                    else:
-                        logger.error("Invalid password spec., missing '='")
-                    logger.error(f'Ignoring node {address}')
-                    continue
-
-                if keyfile and not Path(keyfile).exists():
-                    logger.warning(
-                        f"Ignored host {address} not existing because "
-                        f"associated keyfile {keyfile} does not exist"
-                    )
-                    continue
-
-                entry = {
-                    'address': address,
-                    'username': username,
-                    'port': port,
-                    'password': password,
-                    'transport': transport,
-                    'devtype': devtype,
-                    'namespace': nsname,
-                    'ssh_keyfile': keyfile,
-                    'hostname': None,
-                }
-                self._validate_inventory_entry(entry)
-                inventory[f'{nsname}.{address}.{port}'] = entry
-            else:
-                logger.error(f'Ignoring invalid host spec.: {entry}')
+        for host in self._data.hosts:
+            # I cannot use host.dict() due to field names changing
+            entry = {
+                'address': host.address,
+                'username': host.username,
+                'port': host.port,
+                'password': host.password,
+                'transport': host.transport,
+                'devtype': host.devtype,
+                'namespace': self._namespace,
+                'ssh_keyfile': host.keyfile,
+                'hostname': None,
+            }
+            inventory[f'{self._namespace}.{host.address}.{host.port}'] = entry
 
         if not inventory:
             logger.error('No hosts detected in provided inventory file')
 
         return inventory
-
-    def _validate_inventory_entry(self, entry: Dict):
-        """Validate the entry in the inventory file
-
-        Args:
-            entry (dict): the entry to validate
-
-        Returns:
-            bool: True if the entry is valid, False otherwise
-        """
-        if entry['transport'] not in SUPPORTED_POLLER_TRANSPORTS:
-            raise InventorySourceError(f"Transport '{entry['transport']}' not "
-                                       f'supported for host {entry["address"]}'
-                                       )
-
-        # if entry['transport'] == 'https' and not entry['devtype']:
-        #     raise InventorySourceError('Missing devtype in https transport'
-        #                                f' for host {entry["address"]}')
-
-        # if entry['devtype'] == "panos" and not entry['apiKey']:
-        #     raise InventorySourceError(
-        #         f'Missing apiKey for panos host {entry["address"]}')
-
-        if re.match(r'^[0-9a-f:.]', entry['address']):
-            try:
-                ip_address(entry['address'])
-            except ValueError:
-                raise InventorySourceError('Invalid IP address'
-                                           f'{entry["address"]} for host '
-                                           f'{entry["address"]}')

--- a/suzieq/poller/controller/source/netbox.py
+++ b/suzieq/poller/controller/source/netbox.py
@@ -44,7 +44,7 @@ class NetboxServerModel(BaseModel):
 class NetboxSourceModel(SourceModel):
     """Netbox source validation model
     """
-    tag: Optional[str] = Field(default='null')
+    tag: Optional[str] = Field(default='suzieq')
     period: Optional[int] = Field(default=3600)
     token: str
     ssl_verify: Optional[bool] = Field(alias='ssl-verify')

--- a/suzieq/poller/controller/source/netbox.py
+++ b/suzieq/poller/controller/source/netbox.py
@@ -6,20 +6,94 @@ and retrieve the devices inventory
 Classes:
     Netbox: this class dinamically retrieve the inventory from Netbox
 """
+# pylint: disable=no-name-in-module
+# pylint: disable=no-self-argument
+
 import asyncio
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
+
+from pydantic import BaseModel, validator, Field
 
 import aiohttp
 from suzieq.poller.controller.inventory_async_plugin import \
     InventoryAsyncPlugin
-from suzieq.poller.controller.source.base_source import Source
+from suzieq.poller.controller.source.base_source import Source, SourceModel
+from suzieq.poller.controller.utils.inventory_utils import get_sensitive_data
 from suzieq.shared.exceptions import InventorySourceError
 
 _DEFAULT_PORTS = {'http': 80, 'https': 443}
 
 logger = logging.getLogger(__name__)
+
+
+class NetboxServerModel(BaseModel):
+    """Model containing data to connect with Netbox server
+    """
+    host: str
+    protocol: str
+    port: str
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class NetboxSourceModel(SourceModel):
+    """Netbox source validation model
+    """
+    tag: Optional[str] = Field(default='null')
+    period: Optional[int] = Field(default=3600)
+    token: str
+    ssl_verify: Optional[bool] = Field(alias='ssl-verify')
+    server: Union[str, NetboxServerModel] = Field(alias='url')
+    run_once: Optional[bool] = Field(default=False, alias='run_once')
+
+    @validator('server', pre=True)
+    def validate_and_set(cls, url, values):
+        """Validate the field 'url' and set the correct parameters
+        """
+        if isinstance(url, str):
+            url_data = urlparse(url)
+            host = url_data.hostname
+            if not host:
+                raise ValueError(f'Unable to parse hostname {url}')
+            protocol = url_data.scheme or 'http'
+            if protocol not in _DEFAULT_PORTS:
+                raise ValueError(f'Unknown protocol {protocol}')
+            port = url_data.port or _DEFAULT_PORTS.get(protocol)
+            if not port:
+                raise ValueError(f'Unable to parse port {url}')
+            server = NetboxServerModel(host=host, port=port, protocol=protocol)
+            ssl_verify = values['ssl_verify']
+            if ssl_verify is None:
+                if server.protocol == 'http':
+                    ssl_verify = False
+                else:
+                    ssl_verify = True
+            else:
+                if server.protocol == 'http' and ssl_verify:
+                    raise ValueError(
+                        'Cannot use ssl_verify=True with http host')
+            values['ssl_verify'] = ssl_verify
+            return server
+        elif isinstance(url, NetboxServerModel):
+            return url
+        else:
+            raise ValueError('Unknown input type')
+
+    @validator('token')
+    def validate_token(cls, token):
+        """checks if the token can be load as sensible data
+        """
+        try:
+            if token == 'ask':
+                return token
+            return get_sensitive_data(token)
+        except InventorySourceError as e:
+            raise ValueError(e)
 
 
 class Netbox(Source, InventoryAsyncPlugin):
@@ -28,87 +102,33 @@ class Netbox(Source, InventoryAsyncPlugin):
 
     """
 
-    def __init__(self, config_data: dict) -> None:
+    def __init__(self, config_data: dict, validate: bool = True) -> None:
         self._status = 'init'
         self._session: aiohttp.ClientSession = None
-        self._tag = ''
-        self._host = ''
-        self._namespace = ''
-        self._period = 3600
-        self._run_once = ''
-        self._token = ''
-        self._ssl_verify = None
+        self._server: NetboxServerModel = None
 
-        super().__init__(config_data)
+        super().__init__(config_data, validate)
 
-    def _load(self, input_data: dict):
-        """Load the configuration data in the object
+    @classmethod
+    def get_data_model(cls):
+        return NetboxSourceModel
 
-        Args:
-            input_data ([dict]): Input configuration data
-
-        Raises:
-            InventorySourceError: invalid config
-        """
-
-        if not input_data:
-            raise InventorySourceError('no netbox_config provided')
-
-        url = input_data.get('url')
-
-        url_data = urlparse(url)
-        self._protocol = url_data.scheme or 'http'
-        self._port = url_data.port or _DEFAULT_PORTS.get(self._protocol, None)
-        self._host = url_data.hostname
-
-        if not self._protocol or not self._port or not self._host:
-            raise InventorySourceError(f'{self._name}: invalid url provided')
-
-        self._tag = input_data.get('tag', 'null')
-        self._namespace = input_data.get('namespace')
-        self._period = input_data.get('period', 3600)
-        self._run_once = input_data.get('run_once', False)
-        self._token = input_data.get('token')
-        self._ssl_verify = input_data.get('ssl-verify', None)
-        if self._ssl_verify is None:
-            if self._protocol == 'http':
-                self._ssl_verify = False
-            elif self._protocol == 'https':
-                self._ssl_verify = True
-        else:
-            if not isinstance(self._ssl_verify, bool):
-                raise InventorySourceError(
-                    f'{self.name} ssl-verify parameter must be a boolean')
-            if self._ssl_verify and self._protocol == 'http':
-                raise InventorySourceError(
-                    f"{self._name}: ssl-verify can be use only with https"
-                )
-
-        logger.debug(f"Source {self._name} load completed")
-
-    def _validate_config(self, input_data) -> list:
-        """Validates the loaded configuration
-
-        Returns:
-            list: the list of errors
-        """
-        self._valid_fields.extend(
-            ['token', 'url', 'tag', 'period', 'ssl-verify'])
-
-        if not self._auth:
-            raise InventorySourceError(
-                f"{self._name} Netbox must have an 'auth' set in the "
-                "'namespaces' section")
-
-        super()._validate_config(input_data)
-
-        miss_fields = [x for x in ['token', 'url', 'namespace']
-                       if x not in input_data]
-
-        if miss_fields:
-            raise InventorySourceError(
-                f'{self._name} Invalid config missing fields {miss_fields}'
+    def _load(self, input_data):
+        # load the server class from the dictionary
+        if not self._validate:
+            input_data['server'] = NetboxServerModel.construct(
+                **input_data.pop('url', {}))
+            input_data['ssl_verify'] = input_data.pop('ssl-verify', False)
+        super()._load(input_data)
+        if self._data.token == 'ask':
+            self._data.token = get_sensitive_data(
+                'ask', f'{self.name} Insert netbox API token: '
             )
+        self._server = self._data.server
+        if not self._auth:
+            raise InventorySourceError(f"{self.name} Netbox must have an "
+                                       "'auth' set in the 'namespaces' section"
+                                       )
 
     def _init_session(self, headers: dict):
         """Initialize the session property
@@ -117,7 +137,7 @@ class Netbox(Source, InventoryAsyncPlugin):
             headers ([dict]): headers to initialize the session
         """
         if not self._session:
-            ssl_option = None if self._ssl_verify else False
+            ssl_option = None if self._data.ssl_verify else False
             self._session = aiohttp.ClientSession(
                 headers=headers,
                 connector=aiohttp.TCPConnector(ssl=ssl_option)
@@ -129,7 +149,7 @@ class Netbox(Source, InventoryAsyncPlugin):
         Returns:
             Dict: token authorization header
         """
-        return {'Authorization': f'Token {self._token}'}
+        return {'Authorization': f'Token {self._data.token}'}
 
     async def get_inventory_list(self) -> List:
         """Contact netbox to retrieve the inventory.
@@ -140,8 +160,8 @@ class Netbox(Source, InventoryAsyncPlugin):
         Returns:
             List: inventory list
         """
-        url = f'{self._protocol}://{self._host}:{self._port}'\
-            f'/api/dcim/devices/?tag={self._tag}'
+        url = f'{self._server.protocol}://{self._server.host}:'\
+            f'{self._server.port}/api/dcim/devices/?tag={self._data.tag}'
         if not self._session:
             headers = self._token_auth_header()
             self._init_session(headers)
@@ -151,7 +171,7 @@ class Netbox(Source, InventoryAsyncPlugin):
                 cur_devices, next_url = await self._get_devices(next_url)
                 devices.extend(cur_devices)
         except Exception as e:
-            raise InventorySourceError(f'{self._name}: error while '
+            raise InventorySourceError(f'{self.name}: error while '
                                        f'getting devices: {e}')
         return devices
 
@@ -174,7 +194,7 @@ class Netbox(Source, InventoryAsyncPlugin):
                 return res.get('results', []), res.get('next')
             else:
                 raise InventorySourceError(
-                    f'{self._name}: error in inventory get '
+                    f'{self.name}: error in inventory get '
                     f'{await response.text()}')
 
     def parse_inventory(self, inventory_list: list) -> Dict:
@@ -241,8 +261,8 @@ class Netbox(Source, InventoryAsyncPlugin):
         while True:
             inventory_list = await self.get_inventory_list()
             logger.debug(
-                f"Received netbox inventory from {self._protocol}"
-                f"://{self._host}:{self._port}")
+                f"Received netbox inventory from {self._server.protocol}"
+                f"://{self._server.host}:{self._server.port}")
             tmp_inventory = self.parse_inventory(inventory_list)
             # Write the inventory and remove the tmp one
             self.set_inventory(tmp_inventory)
@@ -250,7 +270,7 @@ class Netbox(Source, InventoryAsyncPlugin):
             if self._run_once:
                 break
 
-            await asyncio.sleep(self._period)
+            await asyncio.sleep(self._data.period)
 
     async def _stop(self):
         if self._session:

--- a/suzieq/poller/controller/utils/inventory_models.py
+++ b/suzieq/poller/controller/utils/inventory_models.py
@@ -1,0 +1,50 @@
+# pylint: disable=no-name-in-module
+
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class InventoryModel(BaseModel):
+    """Model for the inventory validation
+    """
+    sources: List[Dict] = Field(min_items=1)
+    namespaces: List[Dict] = Field(min_items=1)
+    auths: Optional[List[Dict]]
+    devices: Optional[List[Dict]]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class DeviceModel(BaseModel):
+    """Device model validation
+    """
+    name: str
+    jump_host: Optional[str] = Field(alias='jump-host')
+    jump_host_key_file: Optional[str] = Field(alias='jump-host-key-file')
+    ignore_known_hosts: Optional[bool] = Field(
+        alias='ignore-known-hosts', default=False)
+    transport: Optional[str]
+    port: Optional[str]
+    devtype: Optional[str]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class NamespaceModel(BaseModel):
+    """Namespace model validation
+    """
+    name: str
+    source: str
+    device: Optional[str]
+    auth: Optional[str]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'

--- a/suzieq/poller/controller/utils/inventory_utils.py
+++ b/suzieq/poller/controller/utils/inventory_utils.py
@@ -2,11 +2,80 @@
 This module contains the logic needed to parse the Suzieq native inventory
 file
 """
+# pylint: disable=no-name-in-module
+
+from dataclasses import dataclass
+import getpass
+from ipaddress import ip_address
+from os import getenv
 from pathlib import Path
-from typing import Dict
+import re
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field, ValidationError
 
 import yaml
 from suzieq.shared.exceptions import InventorySourceError
+from suzieq.poller.controller.base_controller_plugin import \
+    ControllerPlugin
+
+
+@dataclass
+class InventoryValidationError:
+    """Dataclass for inventory errors handling.
+
+    location: namespaces, sources, devices, auths
+    name: name of the object raising an exception
+    what: the raised exception
+    """
+    location: str
+    name: str
+    what: Exception
+
+
+class InventoryModel(BaseModel):
+    """Model for the inventory validation
+    """
+    sources: List[Dict] = Field(min_items=1)
+    namespaces: List[Dict] = Field(min_items=1)
+    auths: Optional[List[Dict]]
+    devices: Optional[List[Dict]]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class DeviceModel(BaseModel):
+    """Device model validation
+    """
+    name: str
+    jump_host: Optional[str] = Field(alias='jump-host')
+    jump_host_key_file: Optional[str] = Field(alias='jump-host-key-file')
+    ignore_known_hosts: Optional[bool] = Field(
+        alias='ignore-known-hosts', default=False)
+    transport: Optional[str]
+    port: Optional[str]
+    devtype: Optional[str]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
+
+
+class NamespaceModel(BaseModel):
+    """Namespace model validation
+    """
+    name: str
+    source: str
+    device: Optional[str]
+    auth: Optional[str]
+
+    class Config:
+        """pydantic configuration
+        """
+        extra = 'forbid'
 
 
 def read_inventory(source_file: str) -> Dict:
@@ -26,12 +95,6 @@ def read_inventory(source_file: str) -> Dict:
         raise InventorySourceError(
             f"Inventory file {source_file} doesn't exits")
 
-    inventory = {
-        'sources': {},
-        'devices': {},
-        'auths': {}
-    }
-
     inventory_data = {}
     with open(source_file, 'r') as fp:
         file_content = fp.read()
@@ -40,124 +103,308 @@ def read_inventory(source_file: str) -> Dict:
         except Exception as e:
             raise InventorySourceError(f'Invalid Suzieq inventory file: {e}')
 
-    validate_raw_inventory(inventory_data)
+    return validate_raw_inventory(inventory_data)
 
-    for k in inventory:
-        inventory[k] = get_inventory_config(k, inventory_data)
+    # for k in inventory:
+    #     inventory[k] = get_inventory_config(k, inventory_data)
 
-    inventory['namespaces'] = inventory_data.get('namespaces')
+    # inventory['namespaces'] = inventory_data.get('namespaces')
 
-    return inventory
+    # return inventory
 
 
-def validate_raw_inventory(inventory: dict):
-    """Validate the inventory read from file
+def validate_raw_inventory(inventory: dict) -> Dict:
+    """Validate the inventory read from file and update its content
+    to be easier to load into plugins
 
     Args:
         inventory (dict): inventory read from file
 
+    Returns:
+        Dict: updated inventory
+
     Raises:
         InventorySourceError: invalid inventory
     """
+    # pylint: disable=too-many-nested-blocks
+    # pylint: disable=broad-except
+
+    def find_error(
+            errors: List[InventoryValidationError],
+            name: str, location: str) -> bool:
+        """Checks if the name is already in errors
+        It is used to avoid launching chained exceptions
+
+        Args:
+            errors (List[InventoryValidationError]): list of errors found
+            name (str): name of the object who generated the error
+            location (str): location of the name
+
+        Returns:
+            bool: True if the name is found
+        """
+        # pylint: disable=used-before-assignment
+        # I think it is a bug of pylint. It tells me that e.name
+        # is used before assignement
+        return any((True for e in errors
+                    if (e.location == location and e.name == name)))
+
     if not inventory:
         raise InventorySourceError('The inventory is empty')
 
-    for f in ['sources', 'namespaces']:
-        if f not in inventory:
-            raise InventorySourceError(
-                "'sources' and 'namespaces' fields must be specified")
-
-    main_fields = {
-        'sources': [],
-        'devices': [],
-        'auths': [],
-    }
-    for mf, mf_list in main_fields.items():
-        fields = inventory.get(mf)
+    try:
+        inv_model = InventoryModel(**inventory)
+    except ValidationError as e:
+        output_inv_errors([
+            InventoryValidationError(
+                location='inventory',
+                name='',
+                what=e
+            )])
+    new_inventory = {k: {} for k in inv_model.dict()}
+    base_plugins = ControllerPlugin.get_plugins()
+    errors: List[InventoryValidationError] = []
+    for mf, fields in inv_model.dict().items():
         if not fields:
             # 'devices' and 'auths' can be omitted if not needed
             continue
-        if not isinstance(fields, list):
-            raise InventorySourceError(f'{mf} content must be a list')
-        for value in fields:
-            name = value.get('name')
-            if not name:
-                raise InventorySourceError(
-                    f"{mf} items must have a 'name'")
-            if name in mf_list:
-                raise InventorySourceError(f'{mf}.{name} is not unique')
-            mf_list.append(name)
+        if mf == 'namespaces':
+            # namespaces are validated later
+            continue
 
-            if not isinstance(value, dict):
-                raise InventorySourceError(
-                    f"{mf}.{name} is not a dictionary")
+        global_specs = {}
+        for plugin_specs in fields:
+            try:
+                if 'copy' in plugin_specs:
+                    # copy the content of the other inventory
+                    # into the current inventory and override
+                    # values
+                    copyname = plugin_specs['copy']
+                    if copyname not in global_specs:
+                        if not find_error(errors, copyname, mf):
+                            raise InventorySourceError(
+                                "copy value must be a 'name' of an already "
+                                f"defined {mf}: {copyname} not found"
+                            )
+                        else:
+                            # an error related to 'copyname' was already raised
+                            continue
+                    plugin_specs = copy_inventory_item(
+                        global_specs[copyname]['specs'], plugin_specs)
 
-            if value.get('copy') and not value['copy'] in mf_list:
-                raise InventorySourceError(f'{mf}.{name} value must be a '
-                                           "'name' of an already defined "
-                                           f'{mf} item')
+                if mf == 'auths':
+                    # I don't like this step, but there is no other way
+                    # to validate credentials otherwise
+                    # In a future release I will rename credential_loader to
+                    # auth and get rid of this if
+                    mtype = 'credential_loader'
+                else:
+                    # remove the trailing 's'
+                    mtype = mf[:-1]
+
+                if mtype in base_plugins:
+                    # validate 'auths' and 'sources'
+                    base_plugin_class = base_plugins[mtype]
+                    ptype = plugin_specs.get(
+                        'type', base_plugin_class.default_type())\
+                        .replace('-', '_')
+                    plugin_class = base_plugin_class.get_plugins(ptype)\
+                        .get(ptype)
+                    if not plugin_class:
+                        raise InventorySourceError(
+                            f'Unknown {mf} of type {ptype}')
+                    try:
+                        model_class = plugin_class.get_data_model()
+                    except NotImplementedError:
+                        raise InventorySourceError(
+                            f'Data model not implemented for {ptype}')
+                    validated_obj = model_class(**plugin_specs)
+                    name = validated_obj.name
+
+                elif mf == 'devices':
+                    # validate 'devices'
+                    validated_obj = DeviceModel(**plugin_specs)
+                    name = validated_obj.name
+
+                if name in global_specs:
+                    raise InventorySourceError(
+                        f'{mf}.{name} is not unique')
+                global_specs[name] = {
+                    'validated': validated_obj.dict(by_alias=True),
+                    'specs': plugin_specs
+                }
+            except Exception as e:
+                errors.append(
+                    InventoryValidationError(
+                        location=mf,
+                        name=plugin_specs.get('name'),
+                        what=e
+                    )
+                )
+        new_inventory[mf] = {name: g['validated']
+                             for name, g in global_specs.items()}
+
     # validate 'namespaces'
-    ns_fields = ['name', 'source', 'device', 'auth']
-    for ns in inventory.get('namespaces'):
-
-        if not ns.get('name'):
-            raise InventorySourceError(
-                "all namespaces need 'name' field")
-
-        inv_fields = [x for x in ns if x not in ns_fields]
-        if inv_fields:
-            raise InventorySourceError(
-                f'{ns["name"]} invalid fields {inv_fields}'
+    global_specs = {}
+    for ns_specs in inv_model.namespaces:
+        try:
+            ns = NamespaceModel(**ns_specs)
+        except Exception as e:
+            errors.append(
+                InventoryValidationError(
+                    location='namespaces',
+                    name=ns_specs.get('name'),
+                    what=e
+                )
             )
+            continue
+        for field, value in ns.dict().items():
+            if field == 'name':
+                continue
+            inv_field = field + 's'
+            try:
+                if value and value not in new_inventory[inv_field]:
+                    if find_error(errors, value, 'sources'):
+                        # an error already raised for this object
+                        continue
+                    raise InventorySourceError(
+                        f"No {field} called '{value}'")
+            except Exception as e:
+                errors.append(
+                    InventoryValidationError(
+                        location='namespaces',
+                        name=ns_specs.get('name'),
+                        what=e
+                    )
+                )
 
-        if not ns.get('source'):
-            raise InventorySourceError(
-                f"{ns['name']} all namespaces need 'source' field")
+        global_specs[ns.name] = ns.dict(by_alias=True)
+    new_inventory['namespaces'] = global_specs
 
-        if ns.get('source') not in main_fields['sources']:
-            raise InventorySourceError(
-                f"{ns['name']} No source called '{ns['source']}'")
+    if errors:
+        output_inv_errors(errors)
 
-        if ns.get('device') and ns['device'] not in main_fields['devices']:
-            raise InventorySourceError(
-                f"{ns['name']} No device called '{ns['device']}'")
-
-        if ns.get('auth') and ns['auth'] not in main_fields['auths']:
-            raise InventorySourceError(
-                f"{ns['name']} No auth called '{ns['auth']}'")
+    return new_inventory
 
 
-def get_inventory_config(conf_type: str, inventory: dict) -> dict:
-    """Return the configuration for a the config type as input
-
-    The returned value will contain a dictionary with 'name' as key
-    and the config as value
+def output_inv_errors(errors: List[InventoryValidationError]):
+    """Creates a good looking output for inventory errors
 
     Args:
-        conf_type (str): type of configuration to initialize
-        inventory (dict): inventory to read to collect configuration
+        errors (List[Exception]): list of errors found
+    """
+
+    error_str = '\n'
+    for e in errors:
+        error_str += f'- {e.location}'
+        if e.name:
+            error_str += f'.{e.name}'
+        error_str += ':\n'
+        if isinstance(e.what, ValidationError):
+            for ve in e.what.errors():
+                field = '.'.join(map(str, ve.get('loc', [''])))
+                error_str += f"  + {field}: {ve.get('msg','')}\n"
+        else:
+            error_str += f'  + {str(e.what)}\n'
+        error_str += '\n'
+    raise InventorySourceError(error_str)
+
+
+def copy_inventory_item(orig: Dict, dest: Dict) -> Dict:
+    """Copy the content of orig inside dest for parameters not
+    specified in dest
+
+    Args:
+        orig (Dict): original dict to copy
+        dest (Dict): destination dict to update
 
     Returns:
-        dict: configuration data
+        Dict: updated destination dict
     """
-    configs = {}
-    conf_list = inventory.get(conf_type)
-    if not conf_list:
-        # No configuration specified
-        return {}
+    for k, v in orig.items():
+        if k not in dest:
+            dest[k] = v
+    if 'copy' in dest:
+        dest.pop('copy')
+    return dest
 
-    for conf_obj in conf_list:
-        name = conf_obj.get('name')
-        if name:
-            if conf_obj.get('copy'):
-                # copy the content of the other inventory
-                # into the current inventory and override
-                # values
-                configs[name] = configs[conf_obj['copy']].copy()
-                for k, v in conf_obj.items():
-                    if k not in ['copy']:
-                        configs[name][k] = v
+
+def get_sensitive_data(input_method: str, ask_message: str = '') -> str:
+    """This function is used by the inventory to specify sensitive data
+
+    The valid methods are:
+        - 'plain:' (default): copy the content of input (can be omitted)
+        - 'env:': get the information from an environment variable
+        - 'ask': write the information on the stdin
+
+    Args:
+        input_method (str): string with info for the sensitive value
+        ask_message (str): message to prompt for the 'ask' method
+
+    Raises:
+        InventorySourceError: environment variable not found
+
+    Returns:
+        str: sensitive data
+    """
+    if not input_method:
+        return input_method
+    sens_data = input_method
+    if input_method.startswith('env:'):
+        input_method = input_method.split('env:')[1].strip()
+        sens_data = getenv(input_method, '')
+        if not sens_data:
+            raise InventorySourceError(
+                f'No environment variable called '
+                f"'{input_method}'")
+    elif input_method.startswith('plain:'):
+        sens_data = input_method.split("plain:")[1].strip()
+    elif input_method.startswith('ask'):
+        sens_data = getpass.getpass(ask_message)
+    return sens_data
+
+
+def validate_hostname(in_hostname: str) -> bool:
+    """Validates if the hostname is an ip address or a domain
+
+    Args:
+        in_hostname (str): hostname to evaluate
+
+    Returns:
+        bool: validation result
+    """
+    try:
+        ip_address(in_hostname)
+        return True
+    except ValueError:
+        # check if it was a misspelled ipv4
+        ipv4_pattern = r'^(\d+\.?)+$'
+        if re.fullmatch(ipv4_pattern, in_hostname):
+            # if this pattern matches, it means that the function
+            # ip_address raise an error due to the fact of an misspelled ipv4
+            # e.g. 10.0.1 or 10.0.2555.1
+            return False
+
+        # validate the domain name
+        pattern = r'^([a-zA-Z0-9-.]{1,253})?$'
+        m = re.fullmatch(pattern, in_hostname)
+
+        if not m:
+            return False
+
+        hostname = m.groups()[0]
+
+        # strip trailing dot if any
+        hostname = hostname.strip('.')
+
+        if len(hostname) > 253:
+            return False
+
+        for label in hostname.split('.'):
+            lm = re.fullmatch(r'^([a-zA-Z0-9-]+)$', label)
+            if lm and len(label) < 64 and \
+                    not (label.startswith('-') or label.endswith('-')):
+                continue
             else:
-                configs[name] = conf_obj
-
-    return configs
+                return False
+        return True

--- a/suzieq/poller/controller/utils/inventory_utils.py
+++ b/suzieq/poller/controller/utils/inventory_utils.py
@@ -264,7 +264,7 @@ def validate_raw_inventory(inventory: dict) -> Dict:
             inv_field = field + 's'
             try:
                 if value and value not in new_inventory[inv_field]:
-                    if find_error(errors, value, 'sources'):
+                    if find_error(errors, value, inv_field):
                         # an error already raised for this object
                         continue
                     raise InventorySourceError(

--- a/suzieq/poller/controller/utils/inventory_utils.py
+++ b/suzieq/poller/controller/utils/inventory_utils.py
@@ -2,7 +2,6 @@
 This module contains the logic needed to parse the Suzieq native inventory
 file
 """
-# pylint: disable=no-name-in-module
 
 import getpass
 import re
@@ -11,11 +10,14 @@ from dataclasses import dataclass
 from ipaddress import ip_address
 from os import getenv
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import ValidationError
 from suzieq.poller.controller.base_controller_plugin import ControllerPlugin
+from suzieq.poller.controller.utils.inventory_models import (DeviceModel,
+                                                             InventoryModel,
+                                                             NamespaceModel)
 from suzieq.shared.exceptions import InventorySourceError
 
 
@@ -30,52 +32,6 @@ class InventoryValidationError:
     location: str
     name: str
     what: Exception
-
-
-class InventoryModel(BaseModel):
-    """Model for the inventory validation
-    """
-    sources: List[Dict] = Field(min_items=1)
-    namespaces: List[Dict] = Field(min_items=1)
-    auths: Optional[List[Dict]]
-    devices: Optional[List[Dict]]
-
-    class Config:
-        """pydantic configuration
-        """
-        extra = 'forbid'
-
-
-class DeviceModel(BaseModel):
-    """Device model validation
-    """
-    name: str
-    jump_host: Optional[str] = Field(alias='jump-host')
-    jump_host_key_file: Optional[str] = Field(alias='jump-host-key-file')
-    ignore_known_hosts: Optional[bool] = Field(
-        alias='ignore-known-hosts', default=False)
-    transport: Optional[str]
-    port: Optional[str]
-    devtype: Optional[str]
-
-    class Config:
-        """pydantic configuration
-        """
-        extra = 'forbid'
-
-
-class NamespaceModel(BaseModel):
-    """Namespace model validation
-    """
-    name: str
-    source: str
-    device: Optional[str]
-    auth: Optional[str]
-
-    class Config:
-        """pydantic configuration
-        """
-        extra = 'forbid'
 
 
 def read_inventory(source_file: str) -> Dict:

--- a/suzieq/poller/sq_poller.py
+++ b/suzieq/poller/sq_poller.py
@@ -49,7 +49,8 @@ async def start_controller(user_args: argparse.Namespace, config_data: Dict):
         controller.init()
         await controller.run()
     except (SqPollerConfError, InventorySourceError, PollingError) as error:
-        print(f"ERROR: {error}")
+        if not log_stdout:
+            print(f"ERROR: {error}")
         logger.error(error)
         sys.exit(-1)
 

--- a/suzieq/poller/sq_poller.py
+++ b/suzieq/poller/sq_poller.py
@@ -16,6 +16,7 @@ from suzieq.shared.exceptions import InventorySourceError, PollingError, \
     SqPollerConfError
 from suzieq.shared.utils import (poller_log_params, init_logger,
                                  load_sq_config, print_version)
+from suzieq.poller.controller.utils.inventory_utils import read_inventory
 
 
 async def start_controller(user_args: argparse.Namespace, config_data: Dict):
@@ -35,6 +36,15 @@ async def start_controller(user_args: argparse.Namespace, config_data: Dict):
                          loglevel, logsize, log_stdout)
 
     try:
+        if user_args.syntax_check:
+            if not user_args.inventory:
+                raise SqPollerConfError(
+                    'With the --syntax-check option the user must specify '
+                    'the inventory file via the -I option')
+            # perform inventory validation and return
+            read_inventory(user_args.inventory)
+            print('Inventory syntax check passed')
+            return
         controller = Controller(user_args, config_data)
         controller.init()
         await controller.run()
@@ -163,6 +173,12 @@ def controller_main():
         '--version',
         action='store_true',
         help='Print suzieq version'
+    )
+
+    parser.add_argument(
+        '--syntax-check',
+        action='store_true',
+        help='Check inventory file syntax and return'
     )
 
     args = parser.parse_args()

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -126,6 +126,7 @@ class Node:
         self.port = kwargs.get("port", 0)
         self.devtype = None
         self.ssh_config_file = kwargs.get("ssh_config_file", None)
+        self.enable_password = kwargs.get('enable_password')
 
         passphrase = kwargs.get("passphrase", None)
         jump_host = kwargs.get("jump_host", "")

--- a/tests/unit/poller/controller/credential_loader/cred_file/data/results/hostname-result.yaml
+++ b/tests/unit/poller/controller/credential_loader/cred_file/data/results/hostname-result.yaml
@@ -3,6 +3,7 @@ native-ns.10.0.0.1:
   hostname: device0
   namespace: native-ns
   passphrase: null
+  password: null
   ssh_keyfile: tests/unit/poller/shared/sample_key
   username: username
 native-ns.10.0.0.2:
@@ -10,6 +11,7 @@ native-ns.10.0.0.2:
   hostname: device1
   namespace: native-ns
   passphrase: my-pass
+  password: null
   ssh_keyfile: tests/unit/poller/shared/sample_key
   username: vagrant
 native-ns.10.0.0.3:
@@ -18,4 +20,5 @@ native-ns.10.0.0.3:
   namespace: native-ns
   passphrase: null
   password: password
+  ssh_keyfile: null
   username: vagrant

--- a/tests/unit/poller/controller/data/exp-inventory.yaml
+++ b/tests/unit/poller/controller/data/exp-inventory.yaml
@@ -1,0 +1,61 @@
+auths:
+  auth0:
+    keyfile: null
+    name: auth0
+    password: strong-passoword
+    ssh-passphrase: null
+    type: null
+    username: null
+devices:
+  dev0:
+    devtype: null
+    ignore-known-hosts: false
+    jump-host: null
+    jump-host-key-file: null
+    name: dev0
+    port: null
+    transport: ssh
+namespaces:
+  native-ns:
+    auth: auth0
+    device: dev0
+    name: native-ns
+    source: native0
+  netbox-ns:
+    auth: auth0
+    device: null
+    name: netbox-ns
+    source: netbox0
+sources:
+  native0:
+    hosts:
+    - address: 192.168.123.164
+      devtype: eos
+      keyfile: null
+      password: null
+      port: 443
+      transport: https
+      url: https://vagrant@192.168.123.164 devtype=eos
+      username: vagrant
+    - address: 192.168.123.70
+      devtype: null
+      keyfile: null
+      password: null
+      port: 22
+      transport: ssh
+      url: ssh://192.168.123.70 username=admin
+      username: admin
+    name: native0
+    type: null
+  netbox0:
+    name: netbox0
+    period: 3600
+    run_once: false
+    ssl-verify: false
+    tag: suzieq
+    token: MY-TOKEN
+    type: netbox
+    url:
+      host: localhost
+      port: '8000'
+      protocol: http

--- a/tests/unit/poller/controller/sources/native/data/inventory/valid_hosts.yaml
+++ b/tests/unit/poller/controller/sources/native/data/inventory/valid_hosts.yaml
@@ -1,6 +1,4 @@
-- url: https://vagrant@192.168.123.252 devtype=eos
 - url: ssh://vagrant@192.168.123.232  keyfile=tests/unit/poller/shared/sample_key
-- url: https://vagrant@192.168.123.164 devtype=eos
 - url: ssh://192.168.123.70 username=admin password=admin
 - url: ssh://vagrant@192.168.123.230  keyfile=tests/unit/poller/shared/sample_key
 - url: ssh://vagrant@192.168.123.54:2023  keyfile=tests/unit/poller/shared/sample_key

--- a/tests/unit/poller/controller/sources/native/data/results/results.yaml
+++ b/tests/unit/poller/controller/sources/native/data/results/results.yaml
@@ -11,19 +11,6 @@ native-ns.192.168.123.123.443:
   ssh_keyfile: null
   transport: https
   username: vagrant
-native-ns.192.168.123.164.443:
-  address: 192.168.123.164
-  devtype: eos
-  hostname: null
-  ignore_known_hosts: false
-  jump_host: null
-  jump_host_key_file: null
-  namespace: native-ns
-  password: null
-  port: 443
-  ssh_keyfile: null
-  transport: https
-  username: vagrant
 native-ns.192.168.123.230.22:
   address: 192.168.123.230
   devtype: null
@@ -49,19 +36,6 @@ native-ns.192.168.123.232.22:
   port: 22
   ssh_keyfile: tests/unit/poller/shared/sample_key
   transport: ssh
-  username: vagrant
-native-ns.192.168.123.252.443:
-  address: 192.168.123.252
-  devtype: eos
-  hostname: null
-  ignore_known_hosts: false
-  jump_host: null
-  jump_host_key_file: null
-  namespace: native-ns
-  password: null
-  port: 443
-  ssh_keyfile: null
-  transport: https
   username: vagrant
 native-ns.192.168.123.54.2023:
   address: 192.168.123.54

--- a/tests/unit/poller/controller/sources/native/test_native.py
+++ b/tests/unit/poller/controller/sources/native/test_native.py
@@ -122,17 +122,30 @@ def test_validate_inventory(default_config):
     with pytest.raises(ValidationError, match=r".*'wrong' not supported.*"):
         SqNativeFile(config.copy(), validate=True)
 
-    # wrong ip address
-    wrong_addresses = [
-        '192.168.0',
-        '192.168.00.1',
-        '10.0.1.9000',
-        'not_a_domain.com'
+
+@pytest.mark.controller_source
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_source_native
+@pytest.mark.asyncio
+@pytest.mark.parametrize('address', [
+    '192.168.0',
+    '192.168.00.1',
+    '10.0.1.9000',
+    'not_a_domain.com'
+])
+def test_wrong_addresses(address: str, default_config):
+    """Validate wrong addresses formats
+
+    Args:
+        address (str): wrong address to validate
+    """
+    config = default_config
+    config['hosts'] = [
+        {'url': f'ssh://vagrant@{address} password=my-password'}
     ]
-    for wa in wrong_addresses:
-        config['hosts'] = [
-            {'url': f'ssh://vagrant@{wa} password=my-password'}
-        ]
-        with pytest.raises(ValidationError,
-                           match=r'.*Invalid hostname or address.*'):
-            SqNativeFile(config.copy(), validate=True)
+    with pytest.raises(ValidationError,
+                       match=r'.*Invalid hostname or address.*'):
+        SqNativeFile(config.copy(), validate=True)

--- a/tests/unit/poller/controller/sources/native/test_native.py
+++ b/tests/unit/poller/controller/sources/native/test_native.py
@@ -1,9 +1,9 @@
 import asyncio
 from typing import Dict
+from pydantic import ValidationError
 
 import pytest
 from suzieq.poller.controller.source.native import SqNativeFile
-from suzieq.shared.exceptions import InventorySourceError
 from tests.unit.poller.shared.utils import (get_src_sample_config,
                                             read_yaml_file)
 
@@ -46,7 +46,7 @@ async def test_valid_config(data_path: str, default_config):
     config = default_config
     config['hosts'] = read_yaml_file(data_path['hosts'])
 
-    src = SqNativeFile(config)
+    src = SqNativeFile(config.copy(), validate=True)
 
     assert src.name == config['name']
     cur_inv = await asyncio.wait_for(src.get_inventory(), 5)
@@ -64,46 +64,28 @@ async def test_invalid_hosts(default_config):
     """Test invalid hosts param
     """
 
-    config = default_config
+    config = default_config.copy()
 
     # empty hosts
     config['hosts'] = []
 
-    with pytest.raises(InventorySourceError):
-        SqNativeFile(config)
+    with pytest.raises(ValidationError):
+        SqNativeFile(config, validate=True)
 
     # 'hosts' not a list
+    config = default_config.copy()
     config['hosts'] = {'not': 'valid'}
-    with pytest.raises(InventorySourceError):
-        SqNativeFile(config)
+    with pytest.raises(ValidationError):
+        SqNativeFile(config, validate=True)
 
     # hosts field not set
+    config = default_config.copy()
     config.pop('hosts')
-    with pytest.raises(InventorySourceError):
-        SqNativeFile(config)
+    with pytest.raises(ValidationError):
+        SqNativeFile(config, validate=True)
 
-    # invalid hosts. Only the last host will be loaded
-    exp_inventory = {
-        'native-ns.192.168.0.1.22': {
-            'address': '192.168.0.1',
-            'devtype': None,
-            'hostname': None,
-            'ignore_known_hosts': False,
-            'jump_host': None,
-            'jump_host_key_file': None,
-            'namespace': 'native-ns',
-            'password': 'my-password',
-            'port': 22,
-            'ssh_keyfile': None,
-            'transport': 'ssh',
-            'username': 'vagrant'
-        }
-    }
-    host = exp_inventory['native-ns.192.168.0.1.22']
-    valid_url = {
-        'url': f"{host['transport']}://{host['address']}:{host['port']} "
-        f"password={host['password']} username={host['username']} wrong=field"
-    }
+    # invalid hosts
+    config = default_config.copy()
     config['hosts'] = [
         # no 'url' key
         {'not-url': 'ssh://vagrant@192.168.0.1 password=my-password'},
@@ -113,13 +95,12 @@ async def test_invalid_hosts(default_config):
         "url= ssh://vagrant@192.168.0.1 password=my-password",
         # key doesn't exists
         {'url': 'ssh://vagrant@192.168.0.1 keyfile=wrong/key/path'},
-        # ignore a parameter
-        valid_url
     ]
-
-    src = SqNativeFile(config)
-    inv = await asyncio.wait_for(src.get_inventory(), 5)
-    assert inv == exp_inventory
+    try:
+        SqNativeFile(config, validate=True)
+    except ValidationError as e:
+        # each invalid host will raise an exception
+        assert len(e.errors()) == len(config['hosts'])
 
 
 @pytest.mark.controller_source
@@ -138,12 +119,20 @@ def test_validate_inventory(default_config):
     config['hosts'] = [
         {'url': 'wrong://vagrant@192.168.0.1 password=my-password'}
     ]
-    with pytest.raises(InventorySourceError):
-        SqNativeFile(config)
+    with pytest.raises(ValidationError, match=r".*'wrong' not supported.*"):
+        SqNativeFile(config.copy(), validate=True)
 
     # wrong ip address
-    config['hosts'] = [
-        {'url': 'ssh://vagrant@192_168_0_1 password=my-password'}
+    wrong_addresses = [
+        '192.168.0',
+        '192.168.00.1',
+        '10.0.1.9000',
+        'not_a_domain.com'
     ]
-    with pytest.raises(InventorySourceError):
-        SqNativeFile(config)
+    for wa in wrong_addresses:
+        config['hosts'] = [
+            {'url': f'ssh://vagrant@{wa} password=my-password'}
+        ]
+        with pytest.raises(ValidationError,
+                           match=r'.*Invalid hostname or address.*'):
+            SqNativeFile(config.copy(), validate=True)

--- a/tests/unit/poller/controller/test_controller.py
+++ b/tests/unit/poller/controller/test_controller.py
@@ -242,7 +242,7 @@ def mock_plugins():
     async def mock_mng_run(self):
         pass
 
-    def mock_src_init(self, inv):
+    def mock_src_init(self, inv, validate=False):
         """This function mocks sources __init__
 
         It contains the call to set_device. By default it
@@ -694,8 +694,8 @@ async def test_controller_empty_inventory(inv_file: str, mock_plugins,
 
     c = generate_controller(args=default_args, inv_file=inv_file)
 
-    with patch.multiple(SqNativeFile, set_device=mock_set_device):
-        with patch.multiple(Netbox, set_device=mock_set_device):
+    with patch.multiple(SqNativeFile, set_device=mock_set_device, name='n'):
+        with patch.multiple(Netbox, set_device=mock_set_device, name='n'):
             c.init()
             with pytest.raises(InventorySourceError,
                                match='No devices to poll'):
@@ -727,6 +727,6 @@ async def test_controller_run_timeout_error(inv_file: str, config_file: str,
 
     c = generate_controller(default_args, inv_file, config_file)
     c.init()
-    with patch.multiple(Netbox, run=mock_netbox_run):
+    with patch.multiple(Netbox, run=mock_netbox_run, name='n'):
         with pytest.raises(InventorySourceError):
             await c.run()

--- a/tests/unit/poller/controller/test_controller_inventory.py
+++ b/tests/unit/poller/controller/test_controller_inventory.py
@@ -1,0 +1,231 @@
+from typing import Dict
+import pytest
+from suzieq.poller.controller.utils.inventory_utils import (
+    read_inventory, validate_raw_inventory,
+    get_sensitive_data, copy_inventory_item)
+from suzieq.shared.exceptions import InventorySourceError
+from tests.unit.poller.shared.utils import read_yaml_file
+# pylint: disable=redefined-outer-name
+
+_INVENTORY_PATH = ['tests/unit/poller/controller/data/inventory.yaml']
+_EXP_INVENTORY_PATH = ['tests/unit/poller/controller/data/exp-inventory.yaml']
+
+
+@pytest.fixture
+def default_inventory() -> Dict:
+    """Return default inventory
+
+    Yields:
+        Dict: default inventory
+    """
+    inventory = {
+        'namespaces': [{
+            'name': 'ns0',
+            'source': 'src0'}],
+        'devices': [{'name': 'dev0'}],
+        'auths': [{'name': 'auth0'}],
+        'sources': [{
+            'name': 'src0',
+            'hosts': [{'url': 'ssh://vagrant@10.255.2.250:22'}]
+        }]
+    }
+    yield inventory
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+@pytest.mark.parametrize('inv_path', _INVENTORY_PATH)
+@pytest.mark.parametrize('exp_inv_path', _EXP_INVENTORY_PATH)
+def test_read_valid_inventory(inv_path: str, exp_inv_path: str):
+    """Test if an inventory is read correctly
+
+    Args:
+        inv_path (str): path to a valid inventory
+        exp_inv_path (str): path to the expected inventory output
+    """
+
+    exp_inventory = read_yaml_file(exp_inv_path)
+
+    inventory = read_inventory(inv_path)
+    assert inventory == exp_inventory
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+@pytest.mark.parametrize('field', ['namespaces', 'sources'])
+def test_mandatory_fields(field: str, default_inventory):
+    """Test that mandatory fields are correctly validated
+
+    Args:
+        field (str): field to check
+    """
+    inventory = default_inventory
+    # empty field
+
+    old_field = inventory.pop(field)
+    inventory[field] = []
+    with pytest.raises(InventorySourceError,
+                       match=r".*{field}: ensure this value has at least 1 "
+                       "items".format(field=field)):
+        validate_raw_inventory(inventory)
+
+    inventory.pop(field)
+
+    with pytest.raises(InventorySourceError,
+                       match=r".* {field}: field required"
+                       .format(field=field)):
+        validate_raw_inventory(inventory)
+
+    inventory[field] = old_field
+    validate_raw_inventory(inventory)
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+@pytest.mark.parametrize('field',
+                         ['namespaces', 'sources', 'devices', 'auths'])
+def test_inventory_fields_validation(field, default_inventory):
+    """Test the validation of the inventory
+    """
+    inventory = default_inventory
+
+    # item is not a list
+    old_value, inventory[field] = inventory[field], 'not-a-list'
+
+    with pytest.raises(InventorySourceError,
+                       match=r'.*{field}: value is not a valid list'
+                       .format(field=field)):
+        validate_raw_inventory(inventory)
+
+    # subitem is not a dictionary
+    inventory[field] = ['not-a-dict']
+    with pytest.raises(InventorySourceError,
+                       match=r'.*{field}.0: value is not a valid dict'
+                       .format(field=field)):
+        validate_raw_inventory(inventory)
+
+    if field == 'namespaces':
+        # missing 'name','source' fields
+        for f in ['name', 'source']:
+            inventory[field] = [old_value[0].copy()]
+            inventory[field][0].pop(f)
+            with pytest.raises(InventorySourceError,
+                               match=r".*{f}: field required"
+                               .format(f=f)):
+                validate_raw_inventory(inventory)
+
+        # invalid 'name'
+        for f in ['source', 'device', 'auth']:
+            inventory[field] = [old_value[0].copy()]
+            inventory[field][0][f] = 'not-a-name'
+            with pytest.raises(InventorySourceError,
+                               match=r".* No {f} called 'not-a-name'"
+                               .format(f=f)):
+                validate_raw_inventory(inventory)
+
+    else:
+        # field without a name
+        inventory[field] = [{'not-name': 'name'}]
+        with pytest.raises(InventorySourceError,
+                           match=r".*name: field required"):
+            validate_raw_inventory(inventory)
+
+        # not unique name
+        inventory[field] = [{'name': 'not-unique'}, {'name': 'not-unique'}]
+        if field == 'sources':
+            _ = [i.update({'hosts': [{'url': 'ssh://vagrant@10.255.2.250:22'}]})
+                 for i in inventory[field]]
+        with pytest.raises(InventorySourceError,
+                           match=f'{field}.not-unique is not unique'):
+            validate_raw_inventory(inventory)
+
+        # wrong copy name
+        inventory[field] = [{'name': 'a-name', 'copy': 'not-a-name'}]
+        with pytest.raises(InventorySourceError,
+                           match=f"copy value must be a 'name' "
+                           f"of an already defined {field}: not-a-name not "
+                           "found"):
+            validate_raw_inventory(inventory)
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+def test_detected_unknown_field(default_inventory):
+    """test if an unknown field is detected"""
+    inventory = default_inventory
+    inventory['not-valid'] = []
+
+    with pytest.raises(InventorySourceError,
+                       match=r".*not-valid: extra fields not permitted"):
+        validate_raw_inventory(inventory)
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+def test_empty_inventory():
+    """Test if an empty inventory is detected
+    """
+    inventory = {}
+    with pytest.raises(InventorySourceError,
+                       match='The inventory is empty'):
+        validate_raw_inventory(inventory)
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+def test_copy_function():
+    """Test that using the 'copy' parameter returns the correct result
+    """
+
+    exp_result = {'src0':
+                  {'name': 'src0', 'value1': 'old', 'value2': 'stable'},
+                  'src1':
+                  {'name': 'src1', 'value1': 'new', 'value2': 'stable'}}
+
+    orig = {'name': 'src0', 'value1': 'old', 'value2': 'stable'}
+    dest = {'name': 'src1', 'value1': 'new', 'copy': 'src0'}
+
+    result = copy_inventory_item(orig, dest)
+    assert orig == exp_result['src0']
+    assert result == exp_result['src1']
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+def test_get_sensitive_data(monkeypatch):
+    """Test sensitive parameters are correctly collected
+    """
+    sens_value = 'sensitive-value'
+
+    # 'env' value
+    env_var_name = 'ENV_VAR'
+    monkeypatch.setenv(env_var_name, sens_value)
+    assert sens_value == get_sensitive_data(f'env:{env_var_name}')
+
+    # 'plain' value
+    assert sens_value == get_sensitive_data(f'plain:{sens_value}')
+    assert sens_value == get_sensitive_data(sens_value)
+
+    monkeypatch.setattr('getpass.getpass', lambda x: sens_value)
+    assert sens_value == get_sensitive_data('ask')

--- a/tests/unit/poller/shared/utils.py
+++ b/tests/unit/poller/shared/utils.py
@@ -84,6 +84,7 @@ def get_src_sample_config(src_type: str) -> Dict:
             'tag': 'suzieq',
             'run_once': True,
             'auth': StaticLoader({
+                'name': 'static0',
                 'username': 'username',
                 'password': 'plain:password'
             }),


### PR DESCRIPTION
This PR:
- adds the possibility to specify the netbox API token via an environment variable
- improve inventory validation

The validation of the inventory is more advanced than a syntactical once:
- validates also the hosts in the native format
- validate ansible input file
- validate netbox ssl-verify parameter is not True for http connections
- validate credential files
- validate env variables
- no additional parameters are allowed