### PR TITLE
Fix sqPoller stats and descriptions

### DIFF
--- a/suzieq/cli/sqcmds/SqPollerCmd.py
+++ b/suzieq/cli/sqcmds/SqPollerCmd.py
@@ -51,3 +51,18 @@ class SqPollerCmd(SqCommand):
             'status': status,
             'pollExcdPeriodCount': poll_period_exceeded,
         }
+
+    @command("describe", help="describe the table and its fields")
+    def describe(self):
+        default_lvars = {
+            'service': [],
+            'status': 'all',
+            'pollExcdPeriodCount': '0'
+            }
+
+        # check if lvars are the default args,
+        # if yes clean before calling super
+        if self.lvars == default_lvars:
+            self.lvars = {}
+
+        return super().describe()

--- a/suzieq/config/schema/sqPoller.avsc
+++ b/suzieq/config/schema/sqPoller.avsc
@@ -97,7 +97,8 @@
         {
             "name": "status",
             "type": "long",
-            "display": 3
+            "display": 3,
+            "description": "Service polling status. 0 or 200 means successfully polled, -1 means time timeout, other values mean failed to poll"
         },
         {
             "name": "nodesPolledCnt",

--- a/suzieq/config/schema/sqPoller.avsc
+++ b/suzieq/config/schema/sqPoller.avsc
@@ -21,7 +21,7 @@
                 }
             },
             "display": 4,
-            "description": "Min, max, median of time taken to get data, for this 5-min interval"
+            "description": "[min, max, avg] of time taken to get data, computed over the greater between the last 5 mins and the polling period"
         },
         {
             "name": "totalTime",
@@ -33,7 +33,7 @@
                 }
             },
             "display": 5,
-            "description": "Min, max, median of time taken to get & process data, for this 5-min intervals"
+            "description": "[min, max, avg] of time taken to get & process data,computed over the greater between the last 5 mins and the polling period"
         },
         {
             "name": "svcQsize",
@@ -45,7 +45,7 @@
                 }
             },
             "display": 6,
-            "description": "Min, max, median of service queue size, for this 5-min interval"
+            "description": "[min, max, avg] of service queue size, computed over the greater between the last 5 mins and the polling period"
         },
         {
             "name": "wrQsize",
@@ -57,7 +57,7 @@
                 }
             },
             "display": 7,
-            "description": "Min, max, median of write queue size, for this 5-min interval"
+            "description": "[min, max, avg] of write queue size, computed over the greater between the last 5 mins and the polling period"
         },
         {
             "name": "nodeQsize",
@@ -69,7 +69,7 @@
                 }
             },
             "display": 8,
-            "description": "Min, max, median of node queue size, for this 5-min interval"
+            "description": "[min, max, avg] of node queue size, computed over the greater between the last 5 mins and the polling period"
         },
         {
             "name": "rxBytes",
@@ -81,7 +81,7 @@
                 }
             },
             "display": 9,
-            "description": "Min, max, median of bytes read, for this 5-min interval"
+            "description": "[min, max, avg] of bytes read, computed over the greater between the last 5 mins and the polling period"
         },
         {
             "name": "version",

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -608,6 +608,18 @@ class Service(SqPlugin):
                 }
             )
 
+    def reset_stats(self, stats: ServiceStats) -> None:
+        """Reset the stats arrays.
+        """
+        stats.total_time = []
+        stats.gather_time = []
+        stats.svcQsize = []
+        stats.nodeQsize = []
+        stats.wrQsize = []
+        stats.rxBytes = []
+        stats.empty_count = 0
+        stats.time_excd_count = 0
+
     def compute_basic_stats(self, statsList, newval: int) -> None:
         """Compute min/max/avg for given stats with the new value
 
@@ -808,6 +820,7 @@ class Service(SqPlugin):
                             "schema": self.poller_schema,
                             "partition_cols": self.partition_cols
                         })
+                    self.reset_stats(pernode_stats[statskey])
 
             # Post a cmd to fire up the next poll after the specified period
             if self.run_once == "update":

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -545,3 +545,42 @@ tests:
     7, "description": ""}, {"name": "vlan", "type": "long", "key": "", "display":
     6, "description": "VLAN ID"}, {"name": "vlanName", "type": "string", "key": 2,
     "display": 3, "description": "VLAN name"}]'
+- command: sqPoller describe --format=json
+  data-directory: tests/data/parquet-out/
+  marks: sqPoller describe
+  output: '[{"name": "active", "type": "boolean", "key": "", "display": "", "description":
+    "If this entry is active or deleted"}, {"name": "gatherTime", "type": {"type":
+    "array", "items": {"type": "float", "name": "time"}}, "key": "", "display": 4,
+    "description": "[min, max, avg] of time taken to get data, computed over the greater
+    between the last 5 mins and the polling period"}, {"name": "hostname", "type":
+    "string", "key": 1, "display": 1, "description": "Hostname associated with this
+    record"}, {"name": "namespace", "type": "string", "key": 0, "display": 0, "description":
+    "The namespace associated with this record"}, {"name": "nodeQsize", "type": {"type":
+    "array", "items": {"type": "float", "name": "nodeQsize"}}, "key": "", "display":
+    8, "description": "[min, max, avg] of node queue size, computed over the greater
+    between the last 5 mins and the polling period"}, {"name": "nodesFailedCnt", "type":
+    "long", "key": "", "display": "", "description": "Number of nodes that could not
+    be polled"}, {"name": "nodesPolledCnt", "type": "long", "key": "", "display":
+    "", "description": "Number of nodes polled"}, {"name": "pollExcdPeriodCount",
+    "type": "long", "key": "", "display": 10, "description": "Number of times the
+    poller has exceeded the poll period"}, {"name": "rxBytes", "type": {"type": "array",
+    "items": {"type": "double", "name": "rxBytes"}}, "key": "", "display": 9, "description":
+    "[min, max, avg] of bytes read, computed over the greater between the last 5 mins
+    and the polling period"}, {"name": "service", "type": "string", "key": 2, "display":
+    2, "description": "The polled service (a.k.a table) name"}, {"name": "sqvers",
+    "type": "string", "key": "", "display": "", "description": "Schema version, not
+    selectable"}, {"name": "status", "type": "long", "key": "", "display": 3, "description":
+    "Service polling status. 0 or 200 means successfully polled, -1 means time timeout,
+    other values mean failed to poll"}, {"name": "svcQsize", "type": {"type": "array",
+    "items": {"type": "float", "name": "svcQsize"}}, "key": "", "display": 6, "description":
+    "[min, max, avg] of service queue size, computed over the greater between the
+    last 5 mins and the polling period"}, {"name": "timestamp", "type": "long", "key":
+    "", "display": 11, "description": "The timestamp of the record"}, {"name": "totalTime",
+    "type": {"type": "array", "items": {"type": "float", "name": "time"}}, "key":
+    "", "display": 5, "description": "[min, max, avg] of time taken to get & process
+    data,computed over the greater between the last 5 mins and the polling period"},
+    {"name": "version", "type": "string", "key": "", "display": "", "description":
+    "The suzieq version used to create this record"}, {"name": "wrQsize", "type":
+    {"type": "array", "items": {"type": "float", "name": "wrQsize"}}, "key": "", "display":
+    7, "description": "[min, max, avg] of write queue size, computed over the greater
+    between the last 5 mins and the polling period"}]'


### PR DESCRIPTION
This PR fixes the stats of the sqPoller command in the cli #597 and updates the description fields to better explain their meaning.

Tasks:
 
- [x] fix describe command
- [x] update field documentation
- [x] update test outputs
- [x] figure out a way to use `start-time` and `end-time` to get stats value relative to the selected time window