### PR TITLE
Add lastPoll column

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -76,5 +76,6 @@ markers =
     controller_device
     controller_manager
     controller_manager_static
+    recursive
 
 xfail_strict = True

--- a/suzieq/config/schema/address.avsc
+++ b/suzieq/config/schema/address.avsc
@@ -110,6 +110,12 @@
             },
             "description": "List of interface IPv4 and IPv6 addresses",
             "depends": "ipAddressList ip6AddressList"
+        },
+        {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
         }
     ]
 }

--- a/suzieq/config/schema/arpnd.avsc
+++ b/suzieq/config/schema/arpnd.avsc
@@ -66,6 +66,12 @@
             "description": "Unix epach When this record was created, in ms"
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/bgp.avsc
+++ b/suzieq/config/schema/bgp.avsc
@@ -311,6 +311,12 @@
             "description": "Unix epach When this record was created, in ms"
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/devconfig.avsc
+++ b/suzieq/config/schema/devconfig.avsc
@@ -40,6 +40,12 @@
             "description": "Unix epach When this record was created, in ms"
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/device.avsc
+++ b/suzieq/config/schema/device.avsc
@@ -2,9 +2,6 @@
     "namespace": "suzieq",
     "name": "device",
     "type": "record",
-    "depends": [
-        "sqPoller"
-    ],
     "fields": [
         {
             "name": "sqvers",
@@ -86,9 +83,10 @@
             "display": 10
         },
         {
-            "name": "lastSeenTimestamp",
+            "name": "lastPoll",
             "type": "timestamp",
-            "depends": "timestamp"
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
         },
         {
             "name": "active",

--- a/suzieq/config/schema/device.avsc
+++ b/suzieq/config/schema/device.avsc
@@ -2,6 +2,9 @@
     "namespace": "suzieq",
     "name": "device",
     "type": "record",
+    "depends": [
+        "sqPoller"
+    ],
     "fields": [
         {
             "name": "sqvers",
@@ -81,6 +84,11 @@
             "name": "timestamp",
             "type": "timestamp",
             "display": 10
+        },
+        {
+            "name": "lastSeenTimestamp",
+            "type": "timestamp",
+            "depends": "timestamp"
         },
         {
             "name": "active",

--- a/suzieq/config/schema/evpnVni.avsc
+++ b/suzieq/config/schema/evpnVni.avsc
@@ -133,6 +133,12 @@
             "display": 10
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/fs.avsc
+++ b/suzieq/config/schema/fs.avsc
@@ -74,6 +74,12 @@
             "display": 7
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/interfaces.avsc
+++ b/suzieq/config/schema/interfaces.avsc
@@ -165,6 +165,12 @@
             "display": 11
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/inventory.avsc
+++ b/suzieq/config/schema/inventory.avsc
@@ -83,6 +83,12 @@
             "display": 8
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/lldp.avsc
+++ b/suzieq/config/schema/lldp.avsc
@@ -79,6 +79,12 @@
             "display": 7
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/macs.avsc
+++ b/suzieq/config/schema/macs.avsc
@@ -88,6 +88,12 @@
             "display": 8
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/mlag.avsc
+++ b/suzieq/config/schema/mlag.avsc
@@ -168,6 +168,12 @@
             "display": 10
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/ospf.avsc
+++ b/suzieq/config/schema/ospf.avsc
@@ -190,6 +190,12 @@
             "display": 12
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/path.avsc
+++ b/suzieq/config/schema/path.avsc
@@ -125,6 +125,12 @@
             "name": "timestamp",
             "type": "timestamp",
             "display": 17
+        },
+        {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
         }
     ]
 }

--- a/suzieq/config/schema/routes.avsc
+++ b/suzieq/config/schema/routes.avsc
@@ -160,6 +160,12 @@
             "display": 11
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/config/schema/topcpu.avsc
+++ b/suzieq/config/schema/topcpu.avsc
@@ -110,6 +110,12 @@
             "partition": 1
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "timestamp",
             "type": "timestamp"
         },

--- a/suzieq/config/schema/topmem.avsc
+++ b/suzieq/config/schema/topmem.avsc
@@ -114,6 +114,12 @@
             "type": "timestamp"
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean"
         }

--- a/suzieq/config/schema/topology.avsc
+++ b/suzieq/config/schema/topology.avsc
@@ -83,7 +83,7 @@
             "name": "ospf",
             "type": "bool",
             "display": 11,
-            "description": "Is the perr connected via OSPF"
+            "description": "Is the peer connected via OSPF"
         },
         {
             "name": "polled",

--- a/suzieq/config/schema/vlan.avsc
+++ b/suzieq/config/schema/vlan.avsc
@@ -65,6 +65,12 @@
             "display": 7
         },
         {
+            "name": "lastPoll",
+            "type": "timestamp",
+            "depends": "sqPoller:timestamp",
+            "description": "Last polling timestamp for this record"
+        },
+        {
             "name": "active",
             "type": "boolean",
             "description": "If this entry is active or deleted"

--- a/suzieq/engines/pandas/device.py
+++ b/suzieq/engines/pandas/device.py
@@ -55,6 +55,25 @@ class DeviceObj(SqPandasEngine):
         if view == 'latest' and 'status' in df.columns:
             df['status'] = np.where(df.active, df['status'], 'dead')
 
+        if columns == ['*'] or 'lastSeenTimestamp' in columns:
+            # consider only polling events with passed status
+            lastSeen_df = self._get_table_sqobj('sqPoller').get(
+                namespace=kwargs.get('namespace', []),
+                hostname=kwargs.get('hostname', []),
+                service='device',
+                columns='namespace hostname status'.split(),
+                status='pass')
+
+            # filter events: last successful polling for each ns-hostname
+            lastSeen_df = lastSeen_df.set_index(['namespace', 'hostname']) \
+                .query('~index.duplicated(keep="last")') \
+                .drop(columns=['status'], errors='ignore') \
+                .rename(columns={"timestamp": "lastSeenTimestamp"})
+
+            df = df.merge(
+                lastSeen_df, how='left', on=['namespace', 'hostname']) \
+                .fillna(value={'lastSeenTimestamp': 0})
+
         poller_df = self._get_table_sqobj('sqPoller').get(
             namespace=kwargs.get('namespace', []),
             hostname=kwargs.get('hostname', []),
@@ -80,7 +99,7 @@ class DeviceObj(SqPandasEngine):
             df = df.merge(poller_df, on=['namespace', 'hostname'],
                           how='outer', suffixes=['', '_y'])  \
                 .fillna({'bootupTimestamp': 0, 'timestamp': 0,
-                         'active': True}) \
+                         'lastSeenTimestamp': 0, 'active': True}) \
                 .fillna('N/A')
 
             df.status = np.where(

--- a/suzieq/engines/pandas/routes.py
+++ b/suzieq/engines/pandas/routes.py
@@ -16,8 +16,8 @@ class RoutesObj(SqPandasEngine):
         '''Table name'''
         return 'routes'
 
-    def _cons_addnl_fields(self, columns: list,
-                           addnl_fields: list) -> Tuple[list, list]:
+    def _cons_addnl_fields(self, columns: list, addnl_fields: list,
+                           add_prefixlen: bool) -> Tuple[list, list]:
         '''get all the additional columns we need'''
 
         drop_cols = []
@@ -25,9 +25,10 @@ class RoutesObj(SqPandasEngine):
         if columns == ['default']:
             addnl_fields.append('metric')
             drop_cols.append('metric')
-        elif columns != ['*'] and 'metric' not in columns:
-            addnl_fields.append('metric')
-            drop_cols += ['metric']
+        elif columns != ['*']:
+            if 'metric' not in columns:
+                addnl_fields.append('metric')
+                drop_cols += ['metric']
 
             if 'ipvers' not in columns:
                 addnl_fields.append('ipvers')
@@ -37,36 +38,13 @@ class RoutesObj(SqPandasEngine):
                 addnl_fields.append('protocol')
                 drop_cols.append('protocol')
 
+        if add_prefixlen:
+            if columns != ['*'] and all('prefixlen' not in x
+                                        for x in [columns, addnl_fields]):
+                addnl_fields.append('prefixlen')
+                drop_cols.append('prefixlen')
+
         return addnl_fields, drop_cols
-
-    def _fill_in_oifs(self, df: pd.DataFrame()):
-        '''Some NOS do not return an ifname, we need to fix it'''
-
-        def add_oifs(row, ifdict):
-            if row.nexthopIps.size == 0:
-                return row.oifs
-
-            oifs = []
-            for hop in row.nexthopIps:
-                for k, v in ifdict.items():
-                    if hop in [str(x) for x in ip_network(k).hosts()]:
-                        oifs.append(v)
-                        break
-            return np.array(oifs)
-
-        conn_if_dict = df \
-            .query('protocol == "connected"')[['prefix', 'oifs']] \
-            .to_dict(orient='records')
-
-        conn_if_dict = {x['prefix']: x['oifs'][0] for x in conn_if_dict}
-        work_df = df.query('oifs.str.len() == 0').reset_index(drop=True)
-        if not work_df.empty:
-            ok_df = df.query('oifs.str.len() != 0').reset_index(drop=True)
-            work_df['oifs'] = work_df.apply(add_oifs, args=(conn_if_dict,),
-                                            axis=1)
-            df = pd.concat([ok_df, work_df]).reset_index(drop=True)
-
-        return df
 
     def get(self, **kwargs):
         '''Return the routes table for the given filters'''
@@ -79,11 +57,7 @@ class RoutesObj(SqPandasEngine):
 
         columns = kwargs.get('columns', ['default'])
         addnl_fields, drop_cols = self._cons_addnl_fields(
-            columns, addnl_fields)
-
-        if prefixlen and ('prefixlen' not in columns or columns != ['*']):
-            addnl_fields.append('prefixlen')
-            drop_cols.append('prefixlen')
+            columns, addnl_fields, prefixlen != '')
 
         # /32 routes are stored with the /32 prefix, so if user doesn't specify
         # prefix as some folks do, assume /32
@@ -106,7 +80,8 @@ class RoutesObj(SqPandasEngine):
             df = df.loc[df['prefix'] != "127.0.0.0/8"]
             df['prefix'].replace('default', '0.0.0.0/0', inplace=True)
 
-            if prefixlen or 'prefixlen' in columns or (columns == ['*']):
+            if (prefixlen or (columns == ['*']) or
+                    any('prefixlen' in x for x in [columns, addnl_fields])):
                 # This convoluted logic to handle the issue of invalid entries
                 # for prefix in JUNOS routing table
                 df['prefixlen'] = df['prefix'].str.split('/')
@@ -124,7 +99,9 @@ class RoutesObj(SqPandasEngine):
                 # drop in reset_index to not add an additional index col
                 df = df.query(query_str).reset_index(drop=True)
 
-            if columns != ['*'] and 'prefixlen' not in columns:
+            if (columns != ['*'] and
+                all('prefixlen' not in x
+                    for x in [columns, addnl_fields])):
                 drop_cols.append('prefixlen')
 
         if not df.empty and ('numNexthops' in columns or (columns == ['*'])):
@@ -133,9 +110,6 @@ class RoutesObj(SqPandasEngine):
             srs = np.array(list(zip(srs_oif, srs_hops)))
             srs_max = np.amax(srs, 1)
             df.insert(len(df.columns)-1, 'numNexthops', srs_max)
-
-        if not df.empty and 'oifs' in df.columns:
-            df = self._fill_in_oifs(df)
 
         if user_query:
             df = self._handle_user_query_str(df, user_query)
@@ -217,11 +191,15 @@ class RoutesObj(SqPandasEngine):
                 usercols.append('timestamp')
         else:
             usercols = self.schema.get_display_fields(usercols)
-        cols = ["default"]
-        drop_cols = []
+        cols = self.schema.get_display_fields(["default"])
+        for col in usercols:
+            if col not in cols:
+                cols.append(col)
 
-        addnl_fields, drop_cols = self._cons_addnl_fields(
-            cols, addnl_fields)
+        # We call it here, and not use the one in get because we don't
+        # want them dropped
+        addnl_fields, _ = self._cons_addnl_fields(
+            cols, addnl_fields, True)
         rslt = pd.DataFrame()
 
         # if not using a pre-populated dataframe
@@ -233,12 +211,6 @@ class RoutesObj(SqPandasEngine):
 
         if df.empty:
             return df
-
-        if 'prefixlen' not in df.columns:
-            df['prefixlen'] = df['prefix'].str.split('/')
-            df = df[df.prefixlen.str.len() == 2]
-            df['prefixlen'] = df['prefixlen'].str[1].astype('int')
-            drop_cols.append('prefixlen')
 
         # Vectorized operation for faster results with IPv4:
         if ipvers == 4:

--- a/tests/integration/sqcmds/cumulus-samples/route.yml
+++ b/tests/integration/sqcmds/cumulus-samples/route.yml
@@ -7643,3 +7643,35 @@ tests:
     ["192.168.121.1"]}, {"hostname": "leaf04", "nexthopIps": ["192.168.121.1"]}, {"hostname":
     "leaf01", "nexthopIps": ["192.168.121.1"]}, {"hostname": "exit01", "nexthopIps":
     ["192.168.121.1"]}, {"hostname": "spine02", "nexthopIps": ["192.168.121.1"]}]'
+- command: route lpm --address='172.16.1.101' --columns='hostname nexthopIps metric
+    protocol' --format=json --namespace=dual-bgp
+  data-directory: tests/data/parquet/
+  description: handles case of testing columns which are stripped if not specified
+  marks: route lpm cumulus
+  output: '[{"hostname": "exit01", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "metric":
+    20, "protocol": "bgp"}, {"hostname": "spine02", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "metric": 20, "protocol": "bgp"}, {"hostname": "leaf04", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "metric": 20, "protocol": "bgp"}, {"hostname":
+    "exit02", "nexthopIps": ["169.254.253.10"], "metric": 20, "protocol": "bgp"},
+    {"hostname": "exit01", "nexthopIps": ["169.254.254.10"], "metric": 20, "protocol":
+    "bgp"}, {"hostname": "internet", "nexthopIps": ["169.254.127.1", "169.254.127.3"],
+    "metric": 20, "protocol": "bgp"}, {"hostname": "leaf01", "nexthopIps": [""], "metric":
+    20, "protocol": "kernel"}, {"hostname": "spine01", "nexthopIps": ["169.254.0.1",
+    "169.254.0.1"], "metric": 20, "protocol": "bgp"}, {"hostname": "server101", "nexthopIps":
+    [""], "metric": 20, "protocol": "kernel"}, {"hostname": "exit02", "nexthopIps":
+    ["169.254.0.1", "169.254.0.1"], "metric": 20, "protocol": "bgp"}, {"hostname":
+    "leaf02", "nexthopIps": [""], "metric": 20, "protocol": "kernel"}, {"hostname":
+    "leaf03", "nexthopIps": ["169.254.0.1", "169.254.0.1"], "metric": 20, "protocol":
+    "bgp"}, {"hostname": "edge01", "nexthopIps": ["169.254.253.1", "169.254.254.1"],
+    "metric": 20, "protocol": "186"}, {"hostname": "server104", "nexthopIps": ["172.16.4.1"],
+    "metric": 20, "protocol": ""}, {"hostname": "server103", "nexthopIps": ["172.16.3.1"],
+    "metric": 20, "protocol": ""}, {"hostname": "server102", "nexthopIps": ["172.16.2.1"],
+    "metric": 20, "protocol": ""}, {"hostname": "leaf02", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "exit01", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "leaf01", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "leaf04", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "exit02", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "spine01", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "spine02", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}, {"hostname": "leaf03", "nexthopIps": ["192.168.121.1"],
+    "metric": 4278198272, "protocol": ""}]'

--- a/tests/integration/sqcmds/eos-samples/path.yml
+++ b/tests/integration/sqcmds/eos-samples/path.yml
@@ -8,7 +8,158 @@ tests:
 - command: path show --dest=172.16.2.104 --src=172.16.1.101 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   error:
-    error: '[{"error": "ERROR: Invalid dest 172.16.2.104"}]'
+    error: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
+      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174542}, {"pathid": 1, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet3", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174547}, {"pathid": 1, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf03", "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
+      {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 2, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174530}, {"pathid": 2, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174547}, {"pathid": 2, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf03", "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
+      {"pathid": 3, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 3, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174542}, {"pathid": 3, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174547}, {"pathid": 3, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf04", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
+      {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 4, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174530}, {"pathid": 4, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174547}, {"pathid": 4, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf04", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
+      {"pathid": 5, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 5, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174542}, {"pathid": 5, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174549}, {"pathid": 5, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf03", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
+      {"pathid": 6, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 6, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174530}, {"pathid": 6, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet3", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174549}, {"pathid": 6, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf03", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
+      {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 7, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174542}, {"pathid": 7, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet4", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174549}, {"pathid": 7, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf04", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
+      {"pathid": 8, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025174997}, {"pathid": 8, "hopCount": 1, "namespace":
+      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
+      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025174530}, {"pathid": 8, "hopCount": 2, "namespace":
+      "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
+      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025174549}, {"pathid": 8, "hopCount": 3, "namespace": "eos", "hostname":
+      "leaf04", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
+      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543}]'
   marks: path show eos
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=eos
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/junos-samples/path.yml
+++ b/tests/integration/sqcmds/junos-samples/path.yml
@@ -8,7 +8,44 @@ tests:
 - command: path show --dest=172.16.2.104 --src=172.16.1.101 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   error:
-    error: '[{"error": "ERROR: Invalid dest 172.16.2.104"}]'
+    error: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
+      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
+      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+      "error": "", "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace":
+      "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf":
+      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
+      "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
+      Src Mtu", "timestamp": 1623025801173}, {"pathid": 1, "hopCount": 2, "namespace":
+      "junos", "hostname": "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
+      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
+      9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
+      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025802890}, {"pathid": 1, "hopCount": 3, "namespace": "junos", "hostname":
+      "leaf02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
+      "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802263}, {"pathid": 2,
+      "hopCount": 0, "namespace": "junos", "hostname": "server101", "iif": "eth1",
+      "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "",
+      "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 1, "namespace": "junos",
+      "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf",
+      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514, "outMtu":
+      9200, "protocol": "evpn", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.12",
+      "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp":
+      1623025801173}, {"pathid": 2, "hopCount": 2, "namespace": "junos", "hostname":
+      "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2":
+      true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
+      "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12", "macLookup": "",
+      "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802688},
+      {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname": "leaf02", "iif":
+      "xe-0/0/1.0", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2": false, "overlay":
+      true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol": "direct",
+      "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802263}]'
   marks: path show junos
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=junos
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/mixed-samples/all.yml
+++ b/tests/integration/sqcmds/mixed-samples/all.yml
@@ -3764,57 +3764,67 @@ tests:
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
     0, "statusChangeTimestamp": 1624392615426, "active": true, "numNexthops": 1, "prefixlen":
     24}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix":
-    "fe80::205:860f:fc71:8700/128", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "",
+    "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438426,
+    "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
+    "unknown", "metric": 1, "statusChangeTimestamp": 1624392614426, "active": true,
+    "numNexthops": 0, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "vrf": "default", "prefix": "fe80::205:860f:fc71:8700/128", "nexthopIps": [],
+    "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1627395438426, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
+    0, "statusChangeTimestamp": 1624392615426, "active": true, "numNexthops": 1, "prefixlen":
+    128}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix":
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1627395438426,
+    "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
+    "unknown", "metric": 0, "statusChangeTimestamp": 1624392614426, "active": true,
+    "numNexthops": 0, "prefixlen": 128}, {"namespace": "mixed", "hostname": "leaf4-qfx",
+    "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426, "weights": [],
+    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
+    "metric": 42, "statusChangeTimestamp": 1626288402426, "active": true, "numNexthops":
+    2, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
+    "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.4.1"], "oifs": ["xe-0/0/1.0"], "protocol":
+    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
     1627395438426, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 1624392615426,
-    "active": true, "numNexthops": 1, "prefixlen": 128}, {"namespace": "mixed", "hostname":
-    "leaf4-qfx", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.4.1",
+    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1625734327426,
+    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
+    "leaf4-qfx", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.4.1",
     "10.2.4.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
     "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438426,
     "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
-    "unknown", "metric": 42, "statusChangeTimestamp": 1626288402426, "active": true,
+    "unknown", "metric": 42, "statusChangeTimestamp": 1626961853426, "active": true,
     "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf4-qfx",
-    "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.2.4.1"], "oifs":
-    ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
-    4, "action": "forward", "timestamp": 1627395438426, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    41, "statusChangeTimestamp": 1625734327426, "active": true, "numNexthops": 1,
-    "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
-    "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.4.1", "10.2.4.1"], "oifs": ["xe-0/0/0.0",
-    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
-    "action": "forward", "timestamp": 1627395438426, "weights": [], "routeTag": "",
-    "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    42, "statusChangeTimestamp": 1626961853426, "active": true, "numNexthops": 2,
-    "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf4-qfx", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["em0.0"], "protocol":
-    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
-    1627395438426, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 1624392616426,
-    "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace": "mixed", "hostname":
-    "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.2/32", "nexthopIps": [], "oifs":
-    ["em1.0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
-    "local", "timestamp": 1627395438536, "weights": [], "routeTag": "", "asPathList":
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
+    ["em0.0"], "protocol": "static", "source": "", "preference": 5, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438426, "weights": [], "routeTag": "", "asPathList":
     [], "validState": "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp":
-    1624392644536, "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace":
-    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["172.29.151.254"], "oifs": ["em0.0"], "protocol": "static", "source": "", "preference":
-    5, "ipvers": 4, "action": "forward", "timestamp": 1627395438536, "weights": [],
+    1624392616426, "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.2/32",
+    "nexthopIps": [], "oifs": ["em1.0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "local", "timestamp": 1627395438536, "weights": [],
     "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
     "metric": 0, "statusChangeTimestamp": 1624392644536, "active": true, "numNexthops":
-    1, "prefixlen": 0}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
-    "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0",
-    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
-    "action": "forward", "timestamp": 1627395438536, "weights": [], "routeTag": "",
-    "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    42, "statusChangeTimestamp": 1626961854536, "active": true, "numNexthops": 2,
-    "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
-    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "oifs": ["xe-0/0/0.0",
-    "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
-    "action": "forward", "timestamp": 1627395438536, "weights": [], "routeTag": "",
-    "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    42, "statusChangeTimestamp": 1626288127536, "active": true, "numNexthops": 2,
-    "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    1, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["em0.0"], "protocol":
+    "static", "source": "", "preference": 5, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 1624392644536,
+    "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.3.1",
+    "10.2.3.1"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source":
+    "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536,
+    "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
+    "unknown", "metric": 42, "statusChangeTimestamp": 1626961854536, "active": true,
+    "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.3.1", "10.2.3.1"],
+    "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536, "weights": [],
+    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
+    "metric": 42, "statusChangeTimestamp": 1626288127536, "active": true, "numNexthops":
+    2, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
     "prefix": "3.3.3.3/32", "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct",
     "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
@@ -3898,34 +3908,44 @@ tests:
     1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 1624392644536,
     "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "leaf3-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:1300/128", "nexthopIps":
-    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
-    6, "action": "forward", "timestamp": 1627395438536, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    0, "statusChangeTimestamp": 1624392644536, "active": true, "numNexthops": 1, "prefixlen":
-    128}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix":
-    "22.22.22.22/32", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol":
-    "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
-    1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 2, "statusChangeTimestamp": 1625734326536,
-    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "leaf3-qfx", "vrf": "default", "prefix": "172.29.151.0/24", "nexthopIps": [],
-    "oifs": ["em0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
-    4, "action": "forward", "timestamp": 1627395438536, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    0, "statusChangeTimestamp": 1624392644536, "active": true, "numNexthops": 1, "prefixlen":
-    24}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix":
-    "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct", "source":
-    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395438536,
+    "leaf3-qfx", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs":
+    [], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action":
+    "multirecv", "timestamp": 1627395438536, "weights": [], "routeTag": "", "asPathList":
+    [], "validState": "", "hardwareProgrammed": "unknown", "metric": 1, "statusChangeTimestamp":
+    1624392641536, "active": true, "numNexthops": 0, "prefixlen": 32}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "fe80::205:860f:fc71:1300/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "timestamp": 1627395438536, "weights": [],
+    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
+    "metric": 0, "statusChangeTimestamp": 1624392644536, "active": true, "numNexthops":
+    1, "prefixlen": 128}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
+    "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp": 1627395438536,
     "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
-    "unknown", "metric": 0, "statusChangeTimestamp": 1624392644536, "active": true,
-    "numNexthops": 1, "prefixlen": 24}, {"namespace": "mixed", "hostname": "leaf3-qfx",
-    "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.3.1"], "oifs":
+    "unknown", "metric": 0, "statusChangeTimestamp": 1624392643536, "active": true,
+    "numNexthops": 0, "prefixlen": 128}, {"namespace": "mixed", "hostname": "leaf3-qfx",
+    "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.3.1"], "oifs":
     ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers":
     4, "action": "forward", "timestamp": 1627395438536, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    41, "statusChangeTimestamp": 1625734326536, "active": true, "numNexthops": 1,
-    "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
+    2, "statusChangeTimestamp": 1625734326536, "active": true, "numNexthops": 1, "prefixlen":
+    32}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix":
+    "172.29.151.0/24", "nexthopIps": [], "oifs": ["em0.0"], "protocol": "direct",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 1624392644536,
+    "active": true, "numNexthops": 1, "prefixlen": 24}, {"namespace": "mixed", "hostname":
+    "leaf3-qfx", "vrf": "default", "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs":
+    ["em1.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395438536, "weights": [], "routeTag": "", "asPathList":
+    [], "validState": "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp":
+    1624392644536, "active": true, "numNexthops": 1, "prefixlen": 24}, {"namespace":
+    "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps":
+    ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
+    10, "ipvers": 4, "action": "forward", "timestamp": 1627395438536, "weights": [],
+    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
+    "metric": 41, "statusChangeTimestamp": 1625734326536, "active": true, "numNexthops":
+    1, "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default",
     "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.3.1"], "oifs": ["xe-0/0/1.0"], "protocol":
     "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "timestamp":
     1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
@@ -3971,164 +3991,175 @@ tests:
     "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
     "", "metric": 42, "statusChangeTimestamp": 1626961853859, "active": true, "numNexthops":
     4, "prefixlen": 32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf":
-    "management", "prefix": "172.29.151.0/24", "nexthopIps": ["172.29.151.1"], "oifs":
-    ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action":
+    "management", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
+    [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action":
     "forward", "timestamp": 1627395439859, "weights": [], "routeTag": "", "asPathList":
     [], "validState": "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp":
-    1625740370859, "active": true, "numNexthops": 1, "prefixlen": 24}, {"namespace":
-    "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix": "5.5.5.5/32",
-    "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
-    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395439859,
+    1625740371859, "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace":
+    "mixed", "hostname": "spine1-nxos", "vrf": "management", "prefix": "172.29.151.0/24",
+    "nexthopIps": ["172.29.151.1"], "oifs": ["mgmt0"], "protocol": "direct", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859,
     "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
-    "", "metric": 50, "statusChangeTimestamp": 1626430779859, "active": true, "numNexthops":
-    1, "prefixlen": 32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf":
-    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["_nexthopVrf:management"],
-    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625740371859,
-    "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.2.2"],
-    "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
-    "statusChangeTimestamp": 1625740718859, "active": true, "numNexthops": 1, "prefixlen":
-    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "3.3.3.3/32", "nexthopIps": ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol":
-    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
-    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 40, "statusChangeTimestamp": 1626288126859,
-    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps": ["10.1.4.2"],
-    "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 40,
-    "statusChangeTimestamp": 1626288401859, "active": true, "numNexthops": 1, "prefixlen":
-    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.2.4.0/30", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"], "protocol":
-    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
-    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1626288401859,
-    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "management", "prefix": "172.29.151.1/32", "nexthopIps":
-    ["172.29.151.1"], "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [],
-    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "",
-    "metric": 0, "statusChangeTimestamp": 1625740370859, "active": true, "numNexthops":
-    1, "prefixlen": 32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf":
-    "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.1.2"], "oifs": ["Ethernet1/1"],
+    "", "metric": 0, "statusChangeTimestamp": 1625740370859, "active": true, "numNexthops":
+    1, "prefixlen": 24}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf":
+    "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.1.5.2"], "oifs": ["Ethernet1/5"],
     "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
     "timestamp": 1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1626961853859,
+    "", "hardwareProgrammed": "", "metric": 50, "statusChangeTimestamp": 1626430779859,
     "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.2.3.0/30", "nexthopIps": ["10.1.3.2"],
-    "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference": 110,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
-    "statusChangeTimestamp": 1626288126859, "active": true, "numNexthops": 1, "prefixlen":
-    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.2.1.0/30", "nexthopIps": ["10.1.1.2"], "oifs": ["Ethernet1/1"], "protocol":
+    "spine1-nxos", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": ["_nexthopVrf:management"], "protocol": "static", "source": "", "preference":
+    1, "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [],
+    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "",
+    "metric": 0, "statusChangeTimestamp": 1625740371859, "active": true, "numNexthops":
+    1, "prefixlen": 0}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default",
+    "prefix": "2.2.2.2/32", "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol":
     "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1626961853859,
-    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.1.6.2"],
-    "oifs": ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference": 110,
+    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1625740718859,
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.1.3.2"],
+    "oifs": ["Ethernet1/3"], "protocol": "ospf", "source": "", "preference": 110,
     "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 50,
-    "statusChangeTimestamp": 1626937975859, "active": true, "numNexthops": 1, "prefixlen":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 40,
+    "statusChangeTimestamp": 1626288126859, "active": true, "numNexthops": 1, "prefixlen":
     32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.2.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["Ethernet1/2"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    "4.4.4.4/32", "nexthopIps": ["10.1.4.2"], "oifs": ["Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625740651859,
+    "", "hardwareProgrammed": "", "metric": 40, "statusChangeTimestamp": 1626288401859,
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.2.4.0/30", "nexthopIps": ["10.1.4.2"],
+    "oifs": ["Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
+    "statusChangeTimestamp": 1626288401859, "active": true, "numNexthops": 1, "prefixlen":
+    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "management", "prefix":
+    "172.29.151.1/32", "nexthopIps": ["172.29.151.1"], "oifs": ["mgmt0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625740370859,
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.1.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
+    "statusChangeTimestamp": 1626961853859, "active": true, "numNexthops": 1, "prefixlen":
+    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.2.3.0/30", "nexthopIps": ["10.1.3.2"], "oifs": ["Ethernet1/3"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1626288126859,
     "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.1.2.1/32", "nexthopIps": ["10.1.2.1"],
-    "oifs": ["Ethernet1/2"], "protocol": "local", "source": "", "preference": 0, "ipvers":
-    4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "spine1-nxos", "vrf": "default", "prefix": "10.2.1.0/30", "nexthopIps": ["10.1.1.2"],
+    "oifs": ["Ethernet1/1"], "protocol": "ospf", "source": "", "preference": 110,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
+    "statusChangeTimestamp": 1626961853859, "active": true, "numNexthops": 1, "prefixlen":
+    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "6.6.6.6/32", "nexthopIps": ["10.1.6.2"], "oifs": ["Ethernet1/6"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "", "metric": 50, "statusChangeTimestamp": 1626937975859,
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": ["10.1.2.1"],
+    "oifs": ["Ethernet1/2"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
     "statusChangeTimestamp": 1625740651859, "active": true, "numNexthops": 1, "prefixlen":
-    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.1.1/32", "nexthopIps": ["10.1.1.1"], "oifs": ["Ethernet1/1"], "protocol":
+    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.2.1/32", "nexthopIps": ["10.1.2.1"], "oifs": ["Ethernet1/2"], "protocol":
     "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1626896038859,
+    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625740651859,
     "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.3.1"],
-    "oifs": ["Ethernet1/3"], "protocol": "direct", "source": "", "preference": 0,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.1.1/32", "nexthopIps": ["10.1.1.1"],
+    "oifs": ["Ethernet1/1"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
-    "statusChangeTimestamp": 1626288118859, "active": true, "numNexthops": 1, "prefixlen":
-    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.3.1/32", "nexthopIps": ["10.1.3.1"], "oifs": ["Ethernet1/3"], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    "statusChangeTimestamp": 1626896038859, "active": true, "numNexthops": 1, "prefixlen":
+    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.3.0/30", "nexthopIps": ["10.1.3.1"], "oifs": ["Ethernet1/3"], "protocol":
+    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1626288118859,
-    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.2.2.0/30", "nexthopIps": ["10.1.2.2"],
-    "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
-    "statusChangeTimestamp": 1625740718859, "active": true, "numNexthops": 1, "prefixlen":
-    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.1.0/30", "nexthopIps": ["10.1.1.1"], "oifs": ["Ethernet1/1"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1626896038859,
     "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.1.6.1/32", "nexthopIps": ["10.1.6.1"],
-    "oifs": ["Ethernet1/6"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.3.1/32", "nexthopIps": ["10.1.3.1"],
+    "oifs": ["Ethernet1/3"], "protocol": "local", "source": "", "preference": 0, "ipvers":
     4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
-    "statusChangeTimestamp": 1626937966859, "active": true, "numNexthops": 1, "prefixlen":
+    "statusChangeTimestamp": 1626288118859, "active": true, "numNexthops": 1, "prefixlen":
     32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.6.0/30", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1/6"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    "10.2.2.0/30", "nexthopIps": ["10.1.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1625740718859,
+    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.1.1"],
+    "oifs": ["Ethernet1/1"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
+    "statusChangeTimestamp": 1626896038859, "active": true, "numNexthops": 1, "prefixlen":
+    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.6.1/32", "nexthopIps": ["10.1.6.1"], "oifs": ["Ethernet1/6"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1626937966859,
-    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.1/32", "nexthopIps": ["10.1.5.1"],
-    "oifs": ["Ethernet1/5"], "protocol": "local", "source": "", "preference": 0, "ipvers":
-    4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.6.1"],
+    "oifs": ["Ethernet1/6"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
-    "statusChangeTimestamp": 1625740652859, "active": true, "numNexthops": 1, "prefixlen":
-    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.5.0/30", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1/5"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    "statusChangeTimestamp": 1626937966859, "active": true, "numNexthops": 1, "prefixlen":
+    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.5.1/32", "nexthopIps": ["10.1.5.1"], "oifs": ["Ethernet1/5"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625740652859,
-    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "default", "prefix": "10.1.4.1/32", "nexthopIps": ["10.1.4.1"],
-    "oifs": ["Ethernet1/4"], "protocol": "local", "source": "", "preference": 0, "ipvers":
-    4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.5.1"],
+    "oifs": ["Ethernet1/5"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
-    "statusChangeTimestamp": 1626288394859, "active": true, "numNexthops": 1, "prefixlen":
-    32}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
-    "10.1.4.0/30", "nexthopIps": ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    "statusChangeTimestamp": 1625740652859, "active": true, "numNexthops": 1, "prefixlen":
+    30}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "default", "prefix":
+    "10.1.4.1/32", "nexthopIps": ["10.1.4.1"], "oifs": ["Ethernet1/4"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395439859, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1626288394859,
-    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "spine2-nxos", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps": ["10.2.2.2"],
-    "oifs": ["Ethernet1/2"], "protocol": "ospf", "source": "", "preference": 110,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395440281, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 41,
-    "statusChangeTimestamp": 1625734329281, "active": true, "numNexthops": 1, "prefixlen":
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine1-nxos", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.4.1"],
+    "oifs": ["Ethernet1/4"], "protocol": "direct", "source": "", "preference": 0,
+    "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0,
+    "statusChangeTimestamp": 1626288394859, "active": true, "numNexthops": 1, "prefixlen":
+    30}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "2.2.2.2/32", "nexthopIps": ["10.2.2.2"], "oifs": ["Ethernet1/2"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "", "metric": 41, "statusChangeTimestamp": 1625734329281,
+    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395440281, "weights": [], "routeTag": "",
+    "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp":
+    1625734229281, "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace":
+    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "22.22.22.22/32",
+    "nexthopIps": ["22.22.22.22", "22.22.22.22"], "oifs": ["Lo0", "Lo0"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625734227281,
+    "active": true, "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "spine2-nxos", "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.2.1.2",
+    "10.2.2.2", "10.2.3.2", "10.2.4.2"], "oifs": ["Ethernet1/1", "Ethernet1/2", "Ethernet1/3",
+    "Ethernet1/4"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281, "weights": [], "routeTag":
+    "", "asPathList": [], "validState": "", "hardwareProgrammed": "", "metric": 42,
+    "statusChangeTimestamp": 1626961854281, "active": true, "numNexthops": 4, "prefixlen":
     32}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
-    "22.22.22.22/32", "nexthopIps": ["22.22.22.22", "22.22.22.22"], "oifs": ["Lo0",
-    "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1627395440281, "weights": [], "routeTag": "", "asPathList":
-    [], "validState": "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp":
-    1625734227281, "active": true, "numNexthops": 2, "prefixlen": 32}, {"namespace":
-    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "11.11.11.11/32",
-    "nexthopIps": ["10.2.1.2", "10.2.2.2", "10.2.3.2", "10.2.4.2"], "oifs": ["Ethernet1/1",
-    "Ethernet1/2", "Ethernet1/3", "Ethernet1/4"], "protocol": "ospf", "source": "",
-    "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395440281,
-    "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
-    "", "metric": 42, "statusChangeTimestamp": 1626961854281, "active": true, "numNexthops":
-    4, "prefixlen": 32}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf":
-    "default", "prefix": "10.2.6.1/32", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet1/6"],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395440281, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "10.2.6.1/32", "nexthopIps": ["10.2.6.1"], "oifs": ["Ethernet1/6"], "protocol":
+    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1627395440281, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625734317281,
     "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
     "spine2-nxos", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.6.1"],
@@ -4274,105 +4305,110 @@ tests:
     "timestamp": 1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 0,
     "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "1.1.1.1/32", "nexthopIps": ["10.2.2.1",
-    "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol":
-    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
-    1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 42, "statusChangeTimestamp": 1626967044170,
-    "active": true, "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "2.2.2.2/32", "nexthopIps": [], "oifs":
-    ["Loopback0"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
-    4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
+    "leaf2-ios", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag": "",
+    "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
     0, "statusChangeTimestamp": 0, "active": true, "numNexthops": 1, "prefixlen":
-    32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix":
-    "3.3.3.3/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1",
+    0}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix":
+    "1.1.1.1/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1",
     "GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
     4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    41, "statusChangeTimestamp": 1626358644170, "active": true, "numNexthops": 2,
+    42, "statusChangeTimestamp": 1626967044170, "active": true, "numNexthops": 2,
     "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "4.4.4.4/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1",
-    "GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
-    4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    41, "statusChangeTimestamp": 1626358644170, "active": true, "numNexthops": 2,
-    "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1",
-    "GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
-    4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    51, "statusChangeTimestamp": 1626445044170, "active": true, "numNexthops": 2,
-    "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
-    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1626967044170,
-    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": [], "oifs":
-    ["GigabitEthernet0/0"], "protocol": "connected", "source": "", "preference": 0,
-    "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    0, "statusChangeTimestamp": 0, "active": true, "numNexthops": 1, "prefixlen":
-    30}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix":
-    "10.1.2.2/32", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"], "protocol": "local",
+    "prefix": "2.2.2.2/32", "nexthopIps": [], "oifs": ["Loopback0"], "protocol": "connected",
     "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 0,
     "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "10.1.3.0/30", "nexthopIps": ["10.1.2.1"],
+    "leaf2-ios", "vrf": "default", "prefix": "3.3.3.3/32", "nexthopIps": ["10.2.2.1",
+    "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1626358644170,
+    "active": true, "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "4.4.4.4/32", "nexthopIps": ["10.2.2.1",
+    "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1626358644170,
+    "active": true, "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "5.5.5.5/32", "nexthopIps": ["10.2.2.1",
+    "10.1.2.1"], "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 51, "statusChangeTimestamp": 1626445044170,
+    "active": true, "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.1.1.0/30", "nexthopIps": ["10.1.2.1"],
+    "oifs": ["GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights":
+    [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
+    "unknown", "metric": 41, "statusChangeTimestamp": 1626967044170, "active": true,
+    "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.1.2.0/30", "nexthopIps": [], "oifs": ["GigabitEthernet0/0"],
+    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1627395444170, "weights": [], "routeTag": "", "asPathList":
+    [], "validState": "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp":
+    0, "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed",
+    "hostname": "leaf2-ios", "vrf": "default", "prefix": "10.1.2.2/32", "nexthopIps":
+    [], "oifs": ["GigabitEthernet0/0"], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights": [],
+    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
+    "metric": 0, "statusChangeTimestamp": 0, "active": true, "numNexthops": 1, "prefixlen":
+    32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix":
+    "10.1.3.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1626358644170,
+    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.2.1"],
     "oifs": ["GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference":
     110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights":
     [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
     "unknown", "metric": 41, "statusChangeTimestamp": 1626358644170, "active": true,
     "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf2-ios",
-    "vrf": "default", "prefix": "10.1.4.0/30", "nexthopIps": ["10.1.2.1"], "oifs":
+    "vrf": "default", "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"],
+    "oifs": ["GigabitEthernet0/1", "GigabitEthernet0/0"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170,
+    "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
+    "unknown", "metric": 51, "statusChangeTimestamp": 1626941844170, "active": true,
+    "numNexthops": 2, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.2.1"], "oifs":
     ["GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
     4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    41, "statusChangeTimestamp": 1626358644170, "active": true, "numNexthops": 1,
+    41, "statusChangeTimestamp": 1626941844170, "active": true, "numNexthops": 1,
     "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "6.6.6.6/32", "nexthopIps": ["10.2.2.1", "10.1.2.1"], "oifs": ["GigabitEthernet0/1",
-    "GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
-    4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    51, "statusChangeTimestamp": 1626941844170, "active": true, "numNexthops": 2,
-    "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "10.1.6.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
+    "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
     "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
     "timestamp": 1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1626941844170,
+    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1625753844170,
     "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "10.1.5.0/30", "nexthopIps": ["10.1.2.1"],
-    "oifs": ["GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference":
+    "leaf2-ios", "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.2.1"],
+    "oifs": ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference":
     110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights":
     [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
-    "unknown", "metric": 41, "statusChangeTimestamp": 1625753844170, "active": true,
-    "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf2-ios",
-    "vrf": "default", "prefix": "22.22.22.22/32", "nexthopIps": ["10.2.2.1"], "oifs":
-    ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
+    "unknown", "metric": 2, "statusChangeTimestamp": 1625753844170, "active": true,
+    "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf2-ios",
+    "vrf": "default", "prefix": "11.11.11.11/32", "nexthopIps": ["10.1.2.1"], "oifs":
+    ["GigabitEthernet0/0"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
     4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
     "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
     2, "statusChangeTimestamp": 1625753844170, "active": true, "numNexthops": 1, "prefixlen":
     32}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default", "prefix":
-    "11.11.11.11/32", "nexthopIps": ["10.1.2.1"], "oifs": ["GigabitEthernet0/0"],
-    "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 2, "statusChangeTimestamp": 1625753844170,
-    "active": true, "numNexthops": 1, "prefixlen": 32}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "10.2.6.0/30", "nexthopIps": ["10.2.2.1"],
+    "10.2.6.0/30", "nexthopIps": ["10.2.2.1"], "oifs": ["GigabitEthernet0/1"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "timestamp":
+    1627395444170, "weights": [], "routeTag": "", "asPathList": [], "validState":
+    "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1625753844170,
+    "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.2.1"],
     "oifs": ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference":
     110, "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights":
     [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
     "unknown", "metric": 41, "statusChangeTimestamp": 1625753844170, "active": true,
     "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf2-ios",
-    "vrf": "default", "prefix": "10.2.5.0/30", "nexthopIps": ["10.2.2.1"], "oifs":
-    ["GigabitEthernet0/1"], "protocol": "ospf", "source": "", "preference": 110, "ipvers":
-    4, "action": "forward", "timestamp": 1627395444170, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    41, "statusChangeTimestamp": 1625753844170, "active": true, "numNexthops": 1,
-    "prefixlen": 30}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
+    "vrf": "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1627395444170, "weights": [], "routeTag": "", "asPathList":
     [], "validState": "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp":
@@ -4541,49 +4577,12 @@ tests:
     1627395444959, "weights": [], "routeTag": "", "asPathList": [], "validState":
     "", "hardwareProgrammed": "unknown", "metric": 41, "statusChangeTimestamp": 1626967044959,
     "active": true, "numNexthops": 1, "prefixlen": 30}, {"namespace": "mixed", "hostname":
-    "leaf4-qfx", "vrf": "default", "prefix": "224.0.0.5/32", "nexthopIps": [], "oifs":
-    [], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action":
-    "multirecv", "timestamp": 1627395438426, "weights": [], "routeTag": "", "asPathList":
-    [], "validState": "", "hardwareProgrammed": "unknown", "metric": 1, "statusChangeTimestamp":
-    1624392614426, "active": true, "numNexthops": 0, "prefixlen": 32}, {"namespace":
-    "mixed", "hostname": "leaf4-qfx", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
-    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
-    6, "action": "multirecv", "timestamp": 1627395438426, "weights": [], "routeTag":
-    "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
-    0, "statusChangeTimestamp": 1624392614426, "active": true, "numNexthops": 0, "prefixlen":
-    128}, {"namespace": "mixed", "hostname": "leaf3-qfx", "vrf": "default", "prefix":
-    "224.0.0.5/32", "nexthopIps": [], "oifs": [], "protocol": "ospf", "source": "",
-    "preference": 10, "ipvers": 4, "action": "multirecv", "timestamp": 1627395438536,
-    "weights": [], "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed":
-    "unknown", "metric": 1, "statusChangeTimestamp": 1624392641536, "active": true,
-    "numNexthops": 0, "prefixlen": 32}, {"namespace": "mixed", "hostname": "leaf3-qfx",
-    "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
-    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "timestamp":
-    1627395438536, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 1624392643536,
-    "active": true, "numNexthops": 0, "prefixlen": 128}, {"namespace": "mixed", "hostname":
-    "spine1-nxos", "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
-    "oifs": ["GigabitEthernet0/7"], "protocol": "static", "source": "", "preference":
-    1, "ipvers": 4, "action": "forward", "timestamp": 1627395439859, "weights": [],
-    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "",
-    "metric": 0, "statusChangeTimestamp": 1625740371859, "active": true, "numNexthops":
-    1, "prefixlen": 0}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "management",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["GigabitEthernet0/7"],
-    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395440281, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "", "metric": 0, "statusChangeTimestamp": 1625734229281,
-    "active": true, "numNexthops": 1, "prefixlen": 0}, {"namespace": "mixed", "hostname":
-    "leaf2-ios", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
-    "oifs": ["GigabitEthernet0/7"], "protocol": "static", "source": "", "preference":
-    1, "ipvers": 4, "action": "forward", "timestamp": 1627395444170, "weights": [],
-    "routeTag": "", "asPathList": [], "validState": "", "hardwareProgrammed": "unknown",
-    "metric": 0, "statusChangeTimestamp": 0, "active": true, "numNexthops": 1, "prefixlen":
-    0}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix":
-    "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["GigabitEthernet0/7"],
-    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395444959, "weights": [], "routeTag": "", "asPathList": [], "validState":
-    "", "hardwareProgrammed": "unknown", "metric": 0, "statusChangeTimestamp": 0,
-    "active": true, "numNexthops": 1, "prefixlen": 0}]'
+    "leaf1-ios", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395444959, "weights": [], "routeTag": "",
+    "asPathList": [], "validState": "", "hardwareProgrammed": "unknown", "metric":
+    0, "statusChangeTimestamp": 0, "active": true, "numNexthops": 1, "prefixlen":
+    0}]'
 - command: vlan show --columns='*' --format=json --namespace=mixed
   data-directory: tests/data/parquet//
   marks: vlan show mixed all

--- a/tests/integration/sqcmds/mixed-samples/path.yml
+++ b/tests/integration/sqcmds/mixed-samples/path.yml
@@ -1,0 +1,134 @@
+description: Testing path across mixed nodes
+tests:
+- command: path show --src='1.1.1.1' --dest='6.6.6.6' --format=json --namespace=mixed
+  data-directory: tests/data/parquet
+  error:
+    error: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios",
+      "iif": "Loopback0", "oif": "GigabitEthernet0/0", "vrf": "default", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 1514, "outMtu": 1500, "protocol":
+      "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+      "10.1.1.1", "error": "", "timestamp": 1627395444959}, {"pathid": 1, "hopCount":
+      1, "namespace": "mixed", "hostname": "spine1-nxos", "iif": "Ethernet1/1", "oif":
+      "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "error": "Hop MTU
+      < Src Mtu", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
+      "mixed", "hostname": "leaf6-eos", "iif": "Ethernet1", "oif": "Loopback0", "vrf":
+      "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500,
+      "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1627395434695},
+      {"pathid": 2, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios",
+      "iif": "Loopback0", "oif": "GigabitEthernet0/1", "vrf": "default", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 1514, "outMtu": 1500, "protocol":
+      "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+      "10.2.1.1", "error": "", "timestamp": 1627395444959}, {"pathid": 2, "hopCount":
+      1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/1", "oif":
+      "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "error": "Hop MTU
+      < Src Mtu", "timestamp": 1627395440281}, {"pathid": 2, "hopCount": 2, "namespace":
+      "mixed", "hostname": "leaf6-eos", "iif": "Ethernet2", "oif": "Loopback0", "vrf":
+      "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500,
+      "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1627395434695}]'
+  marks: path show all mixed
+- command: path show --src='4.4.4.4' --dest='6.6.6.6' --format=json --namespace=mixed
+  data-directory: tests/data/parquet
+  marks: path show all mixed
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf4-qfx",
+    "iif": "lo0.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.4.1", "timestamp":
+    1627395438426}, {"pathid": 1, "hopCount": 1, "namespace": "mixed", "hostname":
+    "spine1-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/6", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "6.6.6.6", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
+    "mixed", "hostname": "leaf6-eos", "iif": "Ethernet1", "oif": "Loopback0", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "timestamp": 1627395434695}, {"pathid": 2, "hopCount": 0, "namespace": "mixed",
+    "hostname": "leaf4-qfx", "iif": "lo0.0", "oif": "xe-0/0/1.0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "10.2.4.1", "timestamp": 1627395438426}, {"pathid": 2, "hopCount":
+    1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/4", "oif":
+    "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "timestamp": 1627395440281},
+    {"pathid": 2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf6-eos", "iif":
+    "Ethernet2", "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1627395434695}]'
+- command: path show --src='4.4.4.4' --dest='2.2.2.2' --format=json --namespace=mixed
+  data-directory: tests/data/parquet
+  error:
+    error: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf4-qfx",
+      "iif": "lo0.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay":
+      false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol": "ospf",
+      "ipLookup": "2.2.2.2/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.4.1",
+      "error": "", "timestamp": 1627395438426}, {"pathid": 1, "hopCount": 1, "namespace":
+      "mixed", "hostname": "spine1-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/2",
+      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup":
+      "", "macLookup": "", "nexthopIp": "2.2.2.2", "error": "", "timestamp": 1627395439859},
+      {"pathid": 1, "hopCount": 2, "namespace": "mixed", "hostname": "leaf2-ios",
+      "iif": "GigabitEthernet0/0", "oif": "Loopback0", "vrf": "default", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1514, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1627395437566}, {"pathid": 2, "hopCount":
+      0, "namespace": "mixed", "hostname": "leaf4-qfx", "iif": "lo0.0", "oif": "xe-0/0/1.0",
+      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+      65536, "outMtu": 1500, "protocol": "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup":
+      "", "macLookup": "", "nexthopIp": "10.2.4.1", "error": "", "timestamp": 1627395438426},
+      {"pathid": 2, "hopCount": 1, "namespace": "mixed", "hostname": "spine2-nxos",
+      "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf": "default", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+      "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+      "2.2.2.2", "error": "", "timestamp": 1627395440281}, {"pathid": 2, "hopCount":
+      2, "namespace": "mixed", "hostname": "leaf2-ios", "iif": "GigabitEthernet0/1",
+      "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 1500, "outMtu": 1514, "protocol": "", "ipLookup": "", "vtepLookup":
+      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
+      1627395437566}]'
+  marks: path show all mixed
+- command: path show --src='5.5.5.5' --dest='3.3.3.3' --format=json --namespace=mixed
+  data-directory: tests/data/parquet
+  marks: path show all mixed
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf5-eos",
+    "iif": "Loopback0", "oif": "Ethernet1", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "3.3.3.3/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.5.1", "timestamp":
+    1627395437620}, {"pathid": 1, "hopCount": 1, "namespace": "mixed", "hostname":
+    "spine1-nxos", "iif": "Ethernet1/5", "oif": "Ethernet1/3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "ospf", "ipLookup": "3.3.3.3/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "3.3.3.3", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
+    "mixed", "hostname": "leaf3-qfx", "iif": "xe-0/0/0.0", "oif": "lo0.0", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "timestamp": 1627395435943}, {"pathid": 2, "hopCount": 0, "namespace": "mixed",
+    "hostname": "leaf5-eos", "iif": "Loopback0", "oif": "Ethernet2", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "3.3.3.3/32", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "10.2.5.1", "timestamp": 1627395437620}, {"pathid": 2, "hopCount":
+    1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/5", "oif":
+    "Ethernet1/3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "3.3.3.3/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "3.3.3.3", "timestamp": 1627395440281},
+    {"pathid": 2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf3-qfx", "iif":
+    "xe-0/0/1.0", "oif": "lo0.0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1627395435943}]'
+- command: path show --src='10.1.1.2' --dest='10.2.6.2' --format=json --namespace=mixed
+  data-directory: tests/data/parquet
+  marks: path show all mixed
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios",
+    "iif": "GigabitEthernet0/0", "oif": "GigabitEthernet0/1", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "ospf", "ipLookup": "10.2.6.0/30", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.2.1.1", "timestamp": 1627395444959}, {"pathid": 1, "hopCount": 1, "namespace":
+    "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/1", "oif": "Ethernet2",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "direct", "ipLookup": "10.2.6.0/30", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1627395440281}]'

--- a/tests/integration/sqcmds/mixed-samples/route.yml
+++ b/tests/integration/sqcmds/mixed-samples/route.yml
@@ -648,38 +648,37 @@ tests:
     "prefix": "169.254.0.0/24", "nexthopIps": [], "oifs": ["em1.0"], "protocol": "direct",
     "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1627395438536}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "management",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol":
+    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
+    1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos", "vrf": "management",
     "prefix": "172.29.151.0/24", "nexthopIps": ["172.29.151.1"], "oifs": ["mgmt0"],
     "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
     "timestamp": 1627395439859}, {"namespace": "mixed", "hostname": "spine1-nxos",
     "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs":
     ["_nexthopVrf:management"], "protocol": "static", "source": "", "preference":
     1, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
-    "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["172.29.151.254"], "oifs": ["_nexthopVrf:management"], "protocol": "static",
-    "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
-    1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "management",
-    "prefix": "172.29.151.0/24", "nexthopIps": ["172.29.151.2"], "oifs": ["mgmt0"],
-    "protocol": "direct", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf":
-    "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf1-ios",
-    "vrf": "default", "prefix": "172.29.151.0/24", "nexthopIps": [], "oifs": ["GigabitEthernet0/7"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1627395444959}, {"namespace": "mixed", "hostname": "spine1-nxos",
-    "vrf": "management", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
-    "oifs": ["GigabitEthernet0/7"], "protocol": "static", "source": "", "preference":
-    1, "ipvers": 4, "action": "forward", "timestamp": 1627395439859}, {"namespace":
     "mixed", "hostname": "spine2-nxos", "vrf": "management", "prefix": "0.0.0.0/0",
-    "nexthopIps": ["172.29.151.254"], "oifs": ["GigabitEthernet0/7"], "protocol":
-    "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp":
-    1627395440281}, {"namespace": "mixed", "hostname": "leaf2-ios", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["GigabitEthernet0/7"],
+    "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1627395440281},
+    {"namespace": "mixed", "hostname": "spine2-nxos", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["_nexthopVrf:management"],
     "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395444170}, {"namespace": "mixed", "hostname": "leaf1-ios", "vrf":
-    "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"], "oifs": ["GigabitEthernet0/7"],
-    "protocol": "static", "source": "", "preference": 1, "ipvers": 4, "action": "forward",
-    "timestamp": 1627395444959}]'
+    "timestamp": 1627395440281}, {"namespace": "mixed", "hostname": "spine2-nxos",
+    "vrf": "management", "prefix": "172.29.151.0/24", "nexthopIps": ["172.29.151.2"],
+    "oifs": ["mgmt0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "timestamp": 1627395440281}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["172.29.151.254"],
+    "oifs": [], "protocol": "static", "source": "", "preference": 1, "ipvers": 4,
+    "action": "forward", "timestamp": 1627395444170}, {"namespace": "mixed", "hostname":
+    "leaf2-ios", "vrf": "default", "prefix": "172.29.151.0/24", "nexthopIps": [],
+    "oifs": ["GigabitEthernet0/7"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1627395444170}, {"namespace":
+    "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "172.29.151.0/24",
+    "nexthopIps": [], "oifs": ["GigabitEthernet0/7"], "protocol": "connected", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1627395444959},
+    {"namespace": "mixed", "hostname": "leaf1-ios", "vrf": "default", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["172.29.151.254"], "oifs": [], "protocol": "static", "source":
+    "", "preference": 1, "ipvers": 4, "action": "forward", "timestamp": 1627395444959}]'
 - command: route show --prefixlen=">24" --format=json --namespace=mixed
   data-directory: tests/data/parquet//
   marks: route show filter prefixlen mixed
@@ -2652,3 +2651,20 @@ tests:
     "numRows": 8}, {"prefix": "3.3.3.3/32", "numRows": 8}, {"prefix": "4.4.4.4/32",
     "numRows": 8}, {"prefix": "5.5.5.5/32", "numRows": 8}, {"prefix": "6.6.6.6/32",
     "numRows": 8}, {"prefix": "0.0.0.0/0", "numRows": 10}]'
+- command: route lpm --address='2.2.2.2' --columns='hostname nexthopIps metric protocol'
+    --format=json --namespace=mixed
+  data-directory: tests/data/parquet/
+  description: handles case of testing columns which are stripped if not specified
+  marks: route lpm mixed
+  output: '[{"hostname": "leaf6-eos", "nexthopIps": ["10.1.6.1", "10.2.6.1"], "metric":
+    51, "protocol": "ospf"}, {"hostname": "leaf5-eos", "nexthopIps": ["10.1.5.1",
+    "10.2.5.1"], "metric": 51, "protocol": "ospf"}, {"hostname": "leaf1-ios", "nexthopIps":
+    ["10.2.1.1", "10.1.1.1"], "metric": 42, "protocol": "ospf"}, {"hostname": "leaf4-qfx",
+    "nexthopIps": ["10.1.4.1", "10.2.4.1"], "metric": 42, "protocol": "ospf"}, {"hostname":
+    "leaf2-ios", "nexthopIps": [], "metric": 0, "protocol": "connected"}, {"hostname":
+    "leaf3-qfx", "nexthopIps": ["10.1.3.1", "10.2.3.1"], "metric": 42, "protocol":
+    "ospf"}, {"hostname": "spine2-nxos", "nexthopIps": ["10.2.2.2"], "metric": 41,
+    "protocol": "ospf"}, {"hostname": "spine1-nxos", "nexthopIps": ["10.1.2.2"], "metric":
+    41, "protocol": "ospf"}, {"hostname": "spine2-nxos", "nexthopIps": ["172.29.151.254"],
+    "metric": 0, "protocol": "static"}, {"hostname": "spine1-nxos", "nexthopIps":
+    ["172.29.151.254"], "metric": 0, "protocol": "static"}]'

--- a/tests/integration/sqcmds/nxos-samples/path.yml
+++ b/tests/integration/sqcmds/nxos-samples/path.yml
@@ -7,9 +7,143 @@ tests:
   marks: path show nxos
 - command: path show --dest=172.16.2.104 --src=172.16.1.101 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: Invalid dest 172.16.2.104"}]'
   marks: path show nxos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "nxos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 1, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "timestamp": 1619275257674}, {"pathid": 1, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 1, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "Ethernet1/3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
+    2, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 2, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "timestamp": 1619275257446}, {"pathid": 2, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 2, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "Ethernet1/3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
+    3, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "timestamp": 1619275257674}, {"pathid": 3, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 3, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "Ethernet1/4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}, {"pathid":
+    4, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 4, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "timestamp": 1619275257446}, {"pathid": 4, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 4, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "Ethernet1/4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}, {"pathid":
+    5, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 5, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "timestamp": 1619275257674}, {"pathid": 5, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 5, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "Ethernet1/3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
+    6, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 6, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "timestamp": 1619275257446}, {"pathid": 6, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 6, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "Ethernet1/3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
+    7, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 7, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "timestamp": 1619275257674}, {"pathid": 7, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 7, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "Ethernet1/4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}, {"pathid":
+    8, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
+    {"pathid": 8, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "timestamp": 1619275257446}, {"pathid": 8, "hopCount": 2, "namespace": "nxos",
+    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 8, "hopCount":
+    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "Ethernet1/4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   error:

--- a/tests/integration/sqcmds/nxos-samples/route.yml
+++ b/tests/integration/sqcmds/nxos-samples/route.yml
@@ -5394,3 +5394,33 @@ tests:
     ["10.255.2.1"]}, {"hostname": "leaf03", "nexthopIps": ["10.255.2.1"]}, {"hostname":
     "exit01", "nexthopIps": ["10.255.2.1"]}, {"hostname": "leaf02", "nexthopIps":
     ["10.255.2.1"]}]'
+- command: route lpm --address='172.16.1.101' --columns='hostname nexthopIps metric
+    protocol' --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  description: handles case of testing columns which are stripped if not specified
+  marks: route lpm nxos
+  output: '[{"hostname": "exit02", "nexthopIps": ["10.0.0.112"], "metric": 0, "protocol":
+    "bgp"}, {"hostname": "leaf01", "nexthopIps": ["172.16.1.101"], "metric": 0, "protocol":
+    "hmm"}, {"hostname": "leaf04", "nexthopIps": ["10.0.0.112"], "metric": 0, "protocol":
+    "bgp"}, {"hostname": "exit01", "nexthopIps": ["10.0.0.112"], "metric": 0, "protocol":
+    "bgp"}, {"hostname": "leaf03", "nexthopIps": ["10.0.0.112"], "metric": 0, "protocol":
+    "bgp"}, {"hostname": "leaf02", "nexthopIps": ["172.16.1.101"], "metric": 0, "protocol":
+    "hmm"}, {"hostname": "exit01", "nexthopIps": ["169.254.254.10"], "metric": 0,
+    "protocol": "bgp"}, {"hostname": "exit02", "nexthopIps": ["169.254.253.2"], "metric":
+    0, "protocol": "bgp"}, {"hostname": "exit02", "nexthopIps": ["169.254.253.10"],
+    "metric": 0, "protocol": "bgp"}, {"hostname": "dcedge01", "nexthopIps": ["169.254.127.3"],
+    "metric": 0, "protocol": "bgp"}, {"hostname": "exit01", "nexthopIps": ["169.254.254.2"],
+    "metric": 0, "protocol": "bgp"}, {"hostname": "firewall01", "nexthopIps": ["169.254.253.5",
+    "169.254.254.5"], "metric": 20, "protocol": "bgp"}, {"hostname": "server101",
+    "nexthopIps": [""], "metric": 20, "protocol": "kernel"}, {"hostname": "server302",
+    "nexthopIps": ["172.16.3.254"], "metric": 20, "protocol": ""}, {"hostname": "server102",
+    "nexthopIps": ["172.16.3.254"], "metric": 20, "protocol": ""}, {"hostname": "server301",
+    "nexthopIps": ["172.16.2.254"], "metric": 20, "protocol": ""}, {"hostname": "leaf01",
+    "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "exit02", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "leaf04", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "spine01", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "spine02", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "leaf03", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "exit01", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}, {"hostname":
+    "leaf02", "nexthopIps": ["10.255.2.1"], "metric": 0, "protocol": "static"}]'

--- a/tests/integration/sqcmds/panos-samples/path.yml
+++ b/tests/integration/sqcmds/panos-samples/path.yml
@@ -287,3 +287,152 @@ tests:
       false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 0, "protocol":
       "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
       "Dst MTU != Src MTU", "timestamp": 1639476254171}]'
+- command: path show --namespace=panos --dest='172.16.2.254' --src='10.0.0.200' --format=json
+  data-directory: tests/data/parquet/
+  description: shows off recursive route handling in path
+  error:
+    error: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "firewall01",
+      "iif": "loopback", "oif": "ethernet1/1.3", "vrf": "default", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+      "169.254.254.5", "error": "", "timestamp": 1639476253357}, {"pathid": 1, "hopCount":
+      1, "namespace": "panos", "hostname": "exit01", "iif": "swp3.3", "oif": "swp1",
+      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "", "timestamp":
+      1639476253487}, {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname":
+      "spine01", "iif": "swp5", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
+      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+      "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error":
+      "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount": 3, "namespace": "panos",
+      "hostname": "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2":
+      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 2, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 2, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit02", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.21", "error": "", "timestamp": 1639476253487}, {"pathid":
+      2, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp6",
+      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 2, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 3, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 3, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit01", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.21", "error": "", "timestamp": 1639476253487}, {"pathid":
+      3, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp5",
+      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 3, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 4, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 4, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit02", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.21", "error": "", "timestamp": 1639476253487}, {"pathid":
+      4, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp6",
+      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 4, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 5, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 5, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit01", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
+      5, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp5",
+      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 5, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 6, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 6, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit02", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
+      6, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp6",
+      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 6, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 7, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 7, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit01", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
+      7, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp5",
+      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 7, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 8, "hopCount":
+      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
+      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
+      "timestamp": 1639476253357}, {"pathid": 8, "hopCount": 1, "namespace": "panos",
+      "hostname": "exit02", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
+      8, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp6",
+      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
+      1639476253487}, {"pathid": 8, "hopCount": 3, "namespace": "panos", "hostname":
+      "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
+      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
+      "Dst MTU != Src MTU", "timestamp": 1639476254836}]'
+  marks: path show panos recursive

--- a/tests/integration/sqcmds/panos-samples/prefixlen.yml
+++ b/tests/integration/sqcmds/panos-samples/prefixlen.yml
@@ -3,11 +3,35 @@ tests:
 - command: route show --prefixlen="32" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
-  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix":
-    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
-    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
@@ -273,87 +297,74 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="< 32" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
-    "nexthopIps": ["169.254.254.6"], "oifs": ["ethernet1/1.3"], "protocol": "connected",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
     "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.8/30", "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"],
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
+    "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.8/30",
+    "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"],
-    "oifs": ["ethernet1/2.3"], "protocol": "connected", "source": "", "preference":
+    "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
+    "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
-    "nexthopIps": ["169.254.253.2"], "oifs": ["ethernet1/2.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf",
-    "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"], "protocol":
-    "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
-    "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
-    ["eth0"], "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
-    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
-    ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
-    ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.250",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
     "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
     {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16",
@@ -502,38 +513,48 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24",
     "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="> 16" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -544,97 +565,113 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
-    "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
-    "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
-    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31",
-    "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
-    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"], "protocol":
+    "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
     "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
     "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
-    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
-    "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs":
-    ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
-    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
-    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt",
+    "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
+    "source": "10.255.2.250", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"], "protocol":
+    "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"],
+    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["Vlan10"],
+    "protocol": "kernel", "source": "172.16.1.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
     "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
@@ -968,65 +1005,38 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs": [], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::1/128", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.200/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
-    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen=">24" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -1037,149 +1047,165 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
-    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
-    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
-    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
-    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
-    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
-    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
-    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
-    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
-    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
-    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
-    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
-    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
-    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
-    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
-    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
     "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
     "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32",
     "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32",
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
-    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
-    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.103", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
     "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
@@ -1340,54 +1366,38 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="! 32" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
@@ -1402,37 +1412,40 @@ tests:
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.250", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.250",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
     "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
     {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16",
@@ -1581,64 +1594,44 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24",
     "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs": [], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::1/128", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
-    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="<= 16" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
-  output: '[{"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix":
-    "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs": ["swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs": ["swp4"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "server101", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253490}, {"namespace": "panos", "hostname": "server101", "vrf": "default",
-    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"],
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol":
+    "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"],
     "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102", "vrf":
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf":
     "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
     "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102", "vrf":
-    "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server301",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs":
-    ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server301",
-    "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.2.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}]'
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
+    "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs":
+    ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "server101", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server101", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.1.254"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server102", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server102", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server301", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname":
+    "server301", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.2.254"],
+    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --hostname="leaf01" --prefixlen="<=16" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
@@ -1655,11 +1648,35 @@ tests:
 - command: route show --prefixlen="32" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
-  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix":
-    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
-    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
     "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
@@ -1925,48 +1942,38 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="! 32" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
@@ -1981,37 +1988,40 @@ tests:
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.250", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.250",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
+    "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24",
+    "nexthopIps": [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
     "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
     {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.0.0/16",
@@ -2160,27 +2170,7 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24",
     "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs": [], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::1/128", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
-    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefix="172.16.253.1" --prefixlen="<32" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefixlen

--- a/tests/integration/sqcmds/panos-samples/route.yml
+++ b/tests/integration/sqcmds/panos-samples/route.yml
@@ -4,19 +4,43 @@ tests:
   data-directory: tests/data/parquet/
   marks: route show
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -27,16 +51,35 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"],
+    "protocol": "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
+    ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
     {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
@@ -481,105 +524,60 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs": [], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::1/128", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.200/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
-    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --columns=hostname --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show
   output: '[{"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
     {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
-    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "leaf03"},
+    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
+    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
+    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
+    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
+    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
+    {"hostname": "firewall01"}, {"hostname": "leaf03"}, {"hostname": "leaf03"}, {"hostname":
+    "leaf03"}, {"hostname": "leaf03"}, {"hostname": "leaf03"}, {"hostname": "dcedge01"},
     {"hostname": "leaf03"}, {"hostname": "leaf03"}, {"hostname": "leaf03"}, {"hostname":
-    "leaf03"}, {"hostname": "dcedge01"}, {"hostname": "leaf03"}, {"hostname": "leaf03"},
-    {"hostname": "leaf03"}, {"hostname": "leaf02"}, {"hostname": "leaf02"}, {"hostname":
     "leaf02"}, {"hostname": "leaf02"}, {"hostname": "leaf02"}, {"hostname": "leaf02"},
     {"hostname": "leaf02"}, {"hostname": "leaf02"}, {"hostname": "leaf02"}, {"hostname":
-    "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
-    {"hostname": "leaf03"}, {"hostname": "spine01"}, {"hostname": "spine01"}, {"hostname":
+    "leaf02"}, {"hostname": "leaf02"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf03"}, {"hostname":
     "spine01"}, {"hostname": "spine01"}, {"hostname": "spine01"}, {"hostname": "spine01"},
     {"hostname": "spine01"}, {"hostname": "spine01"}, {"hostname": "spine01"}, {"hostname":
-    "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"},
+    "spine01"}, {"hostname": "spine01"}, {"hostname": "spine02"}, {"hostname": "spine02"},
     {"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname":
-    "spine02"}, {"hostname": "spine01"}, {"hostname": "server302"}, {"hostname": "server302"},
-    {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname":
-    "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"},
+    "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname": "spine01"},
+    {"hostname": "server302"}, {"hostname": "server302"}, {"hostname": "leaf03"},
     {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname":
     "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"},
+    {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname":
+    "leaf04"}, {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "server302"},
     {"hostname": "server302"}, {"hostname": "server302"}, {"hostname": "server302"},
-    {"hostname": "server302"}, {"hostname": "leaf03"}, {"hostname": "leaf02"}, {"hostname":
-    "leaf02"}, {"hostname": "spine02"}, {"hostname": "exit02"}, {"hostname": "exit01"},
+    {"hostname": "leaf03"}, {"hostname": "leaf02"}, {"hostname": "leaf02"}, {"hostname":
+    "spine02"}, {"hostname": "exit02"}, {"hostname": "exit01"}, {"hostname": "exit01"},
     {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname":
     "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"},
-    {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname":
-    "exit02"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"},
-    {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname":
+    {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname":
     "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"},
-    {"hostname": "dcedge01"}, {"hostname": "dcedge01"}, {"hostname": "dcedge01"},
-    {"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "spine02"}, {"hostname":
-    "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"},
+    {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname":
+    "exit01"}, {"hostname": "exit01"}, {"hostname": "exit01"}, {"hostname": "dcedge01"},
+    {"hostname": "dcedge01"}, {"hostname": "dcedge01"}, {"hostname": "exit01"}, {"hostname":
+    "exit02"}, {"hostname": "spine02"}, {"hostname": "exit02"}, {"hostname": "exit02"},
     {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname":
-    "exit02"}, {"hostname": "exit02"}, {"hostname": "leaf01"}, {"hostname": "exit02"},
-    {"hostname": "leaf01"}, {"hostname": "leaf01"}, {"hostname": "leaf01"}, {"hostname":
+    "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"},
+    {"hostname": "leaf01"}, {"hostname": "exit02"}, {"hostname": "leaf01"}, {"hostname":
     "leaf01"}, {"hostname": "leaf01"}, {"hostname": "leaf01"}, {"hostname": "leaf01"},
     {"hostname": "leaf01"}, {"hostname": "leaf01"}, {"hostname": "leaf01"}, {"hostname":
-    "leaf01"}, {"hostname": "leaf01"}, {"hostname": "exit02"}, {"hostname": "exit02"},
+    "leaf01"}, {"hostname": "leaf01"}, {"hostname": "leaf01"}, {"hostname": "leaf01"},
     {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname":
     "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"},
-    {"hostname": "server101"}, {"hostname": "server101"}, {"hostname": "server101"},
-    {"hostname": "server101"}, {"hostname": "server101"}, {"hostname": "server102"},
-    {"hostname": "server102"}, {"hostname": "server102"}, {"hostname": "server102"},
-    {"hostname": "server102"}, {"hostname": "server301"}, {"hostname": "server301"},
-    {"hostname": "server301"}, {"hostname": "server301"}, {"hostname": "server301"},
-    {"hostname": "server301"}, {"hostname": "server102"}, {"hostname": "server101"},
-    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
-    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
-    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
-    {"hostname": "firewall01"}, {"hostname": "firewall01"}, {"hostname": "firewall01"},
-    {"hostname": "firewall01"}, {"hostname": "firewall01"}]'
+    {"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "server101"}, {"hostname":
+    "server101"}, {"hostname": "server101"}, {"hostname": "server101"}, {"hostname":
+    "server101"}, {"hostname": "server102"}, {"hostname": "server102"}, {"hostname":
+    "server102"}, {"hostname": "server102"}, {"hostname": "server102"}, {"hostname":
+    "server301"}, {"hostname": "server301"}, {"hostname": "server301"}, {"hostname":
+    "server301"}, {"hostname": "server301"}, {"hostname": "server301"}, {"hostname":
+    "server102"}, {"hostname": "server101"}]'
 - command: route summarize --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route summarize
@@ -656,47 +654,43 @@ tests:
     1639476253490}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
     "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol":
     "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt",
-    "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
-    "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"], "oifs":
-    ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
-    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol": "", "source":
+    "", "preference": 4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["169.254.127.2"], "oifs": ["swp4"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "mgmt", "prefix":
+    "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source":
+    "", "preference": 4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": [""], "oifs": [""], "protocol": "", "source": "", "preference":
+    4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf01", "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.127.0"], "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp", "source": "",
+    "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt", "prefix": "0.0.0.0/0",
+    "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "",
+    "preference": 4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0",
+    "nexthopIps": [""], "oifs": [""], "protocol": "", "source": "", "preference":
+    4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "exit02", "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps":
+    ["10.255.2.1"], "oifs": ["eth0"], "protocol": "", "source": "", "preference":
+    4278198272, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps":
+    [""], "oifs": [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers":
     4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
-    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 4278198272, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
+    "leaf04", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
     [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
     "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
-    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
     "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
     "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
@@ -707,237 +701,49 @@ tests:
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
     "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
     "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}]'
 - command: route lpm --address="10.0.0.12" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route lpm
-  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix":
+  output: '[{"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix":
     "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
-    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
-    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server101",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server301",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server302",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
-    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"],
-    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf01", "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
-    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 4278198272, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "exit02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
-    [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
-    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
-- command: route lpm --address="10.0.0.12" --hostname="server101 server103" --format=json --namespace=panos
-  data-directory: tests/data/parquet/
-  marks: route lpm
-  output: '[{"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix":
-    "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"], "protocol":
-    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253490}]'
-- command: route lpm --address="10.0.0.12" --format=json --namespace=panos
-  data-directory: tests/data/parquet/
-  marks: route lpm
-  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix":
-    "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
-    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
-    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server101",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server301",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server302",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
-    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "exit01", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"],
-    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf01", "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
-    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 4278198272, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "exit02", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
-    [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
-    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
-    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
-- command: route lpm --address="10.0.0.11" --format=json --namespace=panos
-  data-directory: tests/data/parquet/
-  marks: route lpm
-  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix":
-    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
     "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
     "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf":
-    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"],
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"],
     "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
-    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32",
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server302",
     "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
     ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server102",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server101",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102",
     "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
     ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server301",
     "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"], "oifs":
-    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server101",
-    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
     ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "exit01",
     "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"],
@@ -954,10 +760,10 @@ tests:
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
     "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
     "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "exit01",
     "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
     "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
     "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
@@ -966,11 +772,8 @@ tests:
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
     "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
     "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01", "vrf":
-    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
-    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
     "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
     "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
     "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
@@ -990,10 +793,205 @@ tests:
     "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
     "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
     "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}]'
+- command: route lpm --address="10.0.0.12" --hostname="server101 server103" --format=json
+    --namespace=panos
+  data-directory: tests/data/parquet/
+  marks: route lpm
+  output: '[{"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix":
+    "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs": ["bond0"], "protocol":
+    "", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253490}]'
+- command: route lpm --address="10.0.0.12" --format=json --namespace=panos
+  data-directory: tests/data/parquet/
+  marks: route lpm
+  output: '[{"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix":
+    "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
+    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"],
+    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server302",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server101",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server301",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf02", "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["eth0"], "protocol": "", "source": "", "preference": 4278198272, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
+    [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}]'
+- command: route lpm --address="10.0.0.11" --format=json --namespace=panos
+  data-directory: tests/data/parquet/
+  marks: route lpm
+  output: '[{"namespace": "panos", "hostname": "exit01", "vrf": "default", "prefix":
+    "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
+    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server301",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.2.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server102",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "server302",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.3.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server101",
+    "vrf": "default", "prefix": "10.0.0.0/24", "nexthopIps": ["172.16.1.254"], "oifs":
+    ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253490}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.2"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
+    [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf01", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "internet-vrf", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.127.0"],
+    "oifs": ["swp4"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs":
+    [""], "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit01",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "exit02", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "prefix": "0.0.0.0/0", "nexthopIps": [""], "oifs": [""], "protocol":
+    "", "source": "", "preference": 4278198272, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf":
+    "mgmt", "prefix": "0.0.0.0/0", "nexthopIps": ["10.255.2.1"], "oifs": ["eth0"],
+    "protocol": "", "source": "", "preference": 4278198272, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}]'
 - command: route show --prefix='10.0.0.134' --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show prefix
@@ -1051,175 +1049,211 @@ tests:
   data-directory: tests/data/parquet/
   marks: route show prefix negate
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.4/30", "nexthopIps": ["169.254.254.6"], "oifs": ["ethernet1/1.3"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.8/30", "nexthopIps": ["169.254.253.10"],
-    "oifs": ["ethernet1/2.4"], "protocol": "connected", "source": "", "preference":
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
-    "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"], "protocol": "connected",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.4/30",
+    "nexthopIps": ["169.254.254.6"], "oifs": ["ethernet1/1.3"], "protocol": "connected",
     "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
+    "prefix": "169.254.253.8/30", "nexthopIps": ["169.254.253.10"], "oifs": ["ethernet1/2.4"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
-    "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
-    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
+    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [], "protocol": "bgp",
     "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf",
-    "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"], "protocol":
-    "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
-    "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
-    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"],
+    "oifs": ["ethernet1/2.3"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.0/30",
+    "nexthopIps": ["169.254.253.2"], "oifs": ["ethernet1/2.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "10.0.0.200/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
+    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt",
-    "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
-    "source": "10.255.2.250", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
-    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
     "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24",
-    "nexthopIps": [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
+    "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
+    "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
+    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31",
+    "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24",
-    "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
+    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32",
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"], "protocol":
+    "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"],
+    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
+    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
+    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
+    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11",
+    "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.118", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
     ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
     ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
     ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
     ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
     ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
     "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
     "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
     "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine02",
-    "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
-    "protocol": "kernel", "source": "10.255.2.118", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"],
-    "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"],
-    "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"],
-    "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"],
-    "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11",
-    "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1",
-    "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
-    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.117", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "server302", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": [""], "oifs": ["bond0"], "protocol": "kernel", "source": "172.16.3.202",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "mgmt", "prefix": "10.255.2.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.187",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
-    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "evpn-vrf",
-    "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"],
-    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "mgmt", "prefix":
+    "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source":
+    "10.255.2.117", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["Vlan10"], "protocol":
+    "kernel", "source": "172.16.1.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf":
+    "default", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["bond0"], "protocol":
+    "kernel", "source": "172.16.3.202", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf":
+    "default", "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "dhcp", "source": "10.255.2.103", "preference": 20, "ipvers": 4, "action": "forward",
     "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
-    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"],
-    "protocol": "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
-    ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol":
+    "kernel", "source": "10.255.2.187", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
     {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
@@ -1501,46 +1535,7 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.0/24",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "10.0.0.200/32", "nexthopIps": [], "oifs": [], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
-    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps":
-    ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefix='2001:db8:0:1::/64' --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show
@@ -1553,19 +1548,33 @@ tests:
   data-directory: tests/data/parquet/
   marks: route show filter prefixlen panos
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -1576,149 +1585,165 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
-    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
-    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
-    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
-    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
-    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
-    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
-    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
-    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
-    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
-    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
-    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
-    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
-    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
-    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
-    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
     "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
     "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32",
     "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32",
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
-    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
-    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.103", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
     "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
@@ -1879,61 +1904,42 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="<=24" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show filter prefixlen panos
-  output: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix":
-    "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"], "protocol": "kernel",
-    "source": "172.16.2.254", "preference": 20, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
-    "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
+  output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "leaf03",
+    "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"],
+    "protocol": "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4,
     "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
-    ["eth0"], "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
-    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs":
-    ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
+    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs":
     ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    "hostname": "dcedge01", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.250", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.112"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
+    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
     ["10.0.0.134"], "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
     "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
@@ -2063,37 +2069,38 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server102", "vrf": "default", "prefix": "10.0.0.0/24",
     "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"], "protocol": "", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [], "protocol": "bgp",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
-    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen=">24" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show filter prefixlen panos
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -2104,149 +2111,165 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
-    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
-    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
-    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
-    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
-    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
-    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
-    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
-    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
-    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
-    "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
-    "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
-    "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
-    "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
-    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
-    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
     "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
     "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.21/32",
-    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.22/32",
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
+    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
+    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32",
     "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.31/32",
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.13", "10.0.0.14"],
+    "oifs": ["swp3", "swp4"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.12/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
-    "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf04",
+    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
     "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "server302", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps":
-    [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.103", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
+    "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32",
-    "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol":
-    "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    {"namespace": "panos", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.112/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
+    "source": "10.255.2.103", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
     "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1",
     "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
@@ -2407,55 +2430,48 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen=">=24" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show filter prefixlen panos
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
+    "172.16.1.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": [],
+    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.8/30", "nexthopIps": ["169.254.254.10"],
+    "oifs": ["ethernet1/1.4"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.0/30",
+    "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
     1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "172.16.3.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
+    "oifs": [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -2466,97 +2482,113 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan20"], "protocol": "kernel", "source": "172.16.2.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps":
-    [""], "oifs": ["Vlan30"], "protocol": "kernel", "source": "172.16.3.254", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "dcedge01",
-    "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"],
-    "protocol": "kernel", "source": "10.255.2.250", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"],
-    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31",
-    "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
-    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps":
-    ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "172.16.2.0/24", "nexthopIps": [""], "oifs": ["Vlan20"], "protocol":
+    "kernel", "source": "172.16.2.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"],
     "protocol": "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4,
     "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"],
-    "oifs": ["vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"],
-    "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs":
-    ["Vlan10"], "protocol": "kernel", "source": "172.16.1.254", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
-    ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32",
-    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32",
-    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32",
-    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
-    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
-    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "mgmt",
+    "prefix": "10.255.2.0/24", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "kernel",
+    "source": "10.255.2.250", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": ["10.0.0.112"], "oifs": ["vlan999"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
+    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf03", "vrf": "mgmt", "prefix": "10.255.2.0/24", "nexthopIps":
+    [""], "oifs": ["eth0"], "protocol": "kernel", "source": "10.255.2.186", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
+    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "evpn-vrf",
+    "prefix": "172.16.3.0/24", "nexthopIps": [""], "oifs": ["Vlan30"], "protocol":
+    "kernel", "source": "172.16.3.254", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps": ["10.0.0.134"], "oifs": ["vlan999"],
+    "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"],
+    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf":
+    "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps": [""], "oifs": ["Vlan10"],
+    "protocol": "kernel", "source": "172.16.1.254", "preference": 20, "ipvers": 4,
+    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
+    "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
+    "leaf03", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21",
+    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
+    ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps":
+    ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps":
+    ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"],
+    "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf",
+    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
     "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
@@ -2890,65 +2922,38 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.1.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.6/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [],
-    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "172.16.2.0/24", "nexthopIps": ["169.254.253.5", "169.254.254.5"],
-    "oifs": ["ethernet1/2.3", "ethernet1/1.3"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "172.16.3.0/24",
-    "nexthopIps": ["169.254.253.5", "169.254.254.5"], "oifs": ["ethernet1/2.3", "ethernet1/1.3"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs": [], "protocol":
-    "local", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::1/128", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.200/32", "nexthopIps": [], "oifs": [], "protocol": "local",
-    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "10.0.0.41/32", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
-    ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen="!24" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: route show filter prefixlen panos
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix":
-    "169.254.254.8/30", "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"],
+    "169.254.254.6/32", "nexthopIps": [], "oifs": [], "protocol": "local", "source":
+    "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.8/30",
+    "nexthopIps": ["169.254.254.10"], "oifs": ["ethernet1/1.4"], "protocol": "connected",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.10/32", "nexthopIps": [], "oifs": [], "protocol": "local",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"], "oifs": ["ethernet1/1.2"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.254.0/30", "nexthopIps": ["169.254.254.2"],
-    "oifs": ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::/127",
-    "nexthopIps": ["2001:1::1"], "oifs": ["ethernet1/1.2"], "protocol": "connected",
-    "source": "", "preference": 0, "ipvers": 6, "action": "forward", "timestamp":
-    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs": ["ethernet1/2.2"],
-    "protocol": "connected", "source": "", "preference": 0, "ipvers": 6, "action":
+    "vrf": "default", "prefix": "2001:1::/127", "nexthopIps": ["2001:1::1"], "oifs":
+    ["ethernet1/1.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:1::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "2001:2::/127", "nexthopIps": ["2001:2::1"], "oifs":
+    ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference": 0, "ipvers":
+    6, "action": "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname":
+    "firewall01", "vrf": "default", "prefix": "2001:2::1/128", "nexthopIps": [], "oifs":
+    [], "protocol": "local", "source": "", "preference": 0, "ipvers": 6, "action":
+    "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.10/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.254.4/30", "nexthopIps": ["169.254.254.6"],
     "oifs": ["ethernet1/1.3"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
@@ -2959,115 +2964,134 @@ tests:
     "prefix": "169.254.253.4/30", "nexthopIps": ["169.254.253.6"], "oifs": ["ethernet1/2.3"],
     "protocol": "connected", "source": "", "preference": 0, "ipvers": 4, "action":
     "forward", "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
     "vrf": "default", "prefix": "169.254.253.0/30", "nexthopIps": ["169.254.253.2"],
     "oifs": ["ethernet1/2.2"], "protocol": "connected", "source": "", "preference":
     0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
+    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
+    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
+    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": [], "protocol": "bgp",
+    "source": "", "preference": 0, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253357}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs":
+    [], "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.253.6/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
+    "vrf": "default", "prefix": "169.254.254.2/32", "nexthopIps": [], "oifs": [],
+    "protocol": "local", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.12/32",
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.14/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03",
-    "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"],
-    "oifs": ["vlan999", "vlan999"], "protocol": "bgp", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "evpn-vrf",
+    "prefix": "10.0.0.200/32", "nexthopIps": ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999",
+    "vlan999"], "protocol": "bgp", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
     "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32",
+    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.31/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
-    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps":
-    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
-    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
     "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
-    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
-    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs":
-    ["swp1"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
-    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs":
-    ["swp3"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs":
-    ["swp4"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
-    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
-    "10.0.0.13", "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2",
-    "swp3", "swp4", "swp5", "swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps":
-    ["10.0.0.31"], "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
-    ["10.0.0.32"], "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference":
-    20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps":
-    ["10.0.0.11", "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
-    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
-    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32",
-    "nexthopIps": ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol":
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    1639476253487}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
+    "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1",
+    "swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf02",
+    "vrf": "default", "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.21"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.22/32",
+    "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
     "prefix": "10.0.0.11/32", "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
     "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
     "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
     "prefix": "10.0.0.14/32", "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
-    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
-    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    1639476253487}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
     "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4",
     "swp5", "swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
     4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
+    "spine01", "vrf": "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"],
     "oifs": ["swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
     4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
+    "spine01", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"],
     "oifs": ["swp6"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
     4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "server302", "vrf": "default", "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"],
-    "oifs": ["bond0"], "protocol": "", "source": "", "preference": 20, "ipvers": 4,
-    "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos", "hostname":
-    "leaf03", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21",
-    "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
+    "spine01", "vrf": "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11",
+    "10.0.0.12"], "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace":
-    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
+    "panos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["swp3", "swp4"], "protocol": "ospf", "source":
+    "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32",
+    "nexthopIps": ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.12/32",
+    "nexthopIps": ["10.0.0.12"], "oifs": ["swp2"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.13/32",
+    "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253487},
+    {"namespace": "panos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
+    "10.0.0.32"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp5", "swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.31"], "oifs": ["swp5"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.32"], "oifs": ["swp6"], "protocol":
+    "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
+    1639476253487}, {"namespace": "panos", "hostname": "server302", "vrf": "default",
+    "prefix": "172.16.0.0/16", "nexthopIps": ["172.16.3.254"], "oifs": ["bond0"],
+    "protocol": "", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
+    "timestamp": 1639476253487}, {"namespace": "panos", "hostname": "leaf03", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
+    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
+    "ipvers": 4, "action": "forward", "timestamp": 1639476253487}, {"namespace": "panos",
+    "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "10.0.0.200/32", "nexthopIps":
     ["10.0.0.31", "10.0.0.32"], "oifs": ["vlan999", "vlan999"], "protocol": "bgp",
     "source": "", "preference": 20, "ipvers": 4, "action": "forward", "timestamp":
     1639476253487}, {"namespace": "panos", "hostname": "leaf04", "vrf": "default",
@@ -3293,41 +3317,7 @@ tests:
     "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
     {"namespace": "panos", "hostname": "server101", "vrf": "default", "prefix": "10.255.2.1/32",
     "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.9",
-    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490},
-    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:1::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "2001:2::1/128",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 6, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.10/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.200/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "10.0.0.41/32",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["ethernet1/2.4", "ethernet1/1.4"],
-    "protocol": "bgp", "source": "", "preference": 0, "ipvers": 4, "action": "forward",
-    "timestamp": 1639476253357}, {"namespace": "panos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "0.0.0.0/0", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["ethernet1/2.4", "ethernet1/1.4"], "protocol": "bgp", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.253.6/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}, {"namespace":
-    "panos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.254.2/32",
-    "nexthopIps": [], "oifs": [], "protocol": "local", "source": "", "preference":
-    0, "ipvers": 4, "action": "forward", "timestamp": 1639476253357}]'
+    "preference": 20, "ipvers": 4, "action": "forward", "timestamp": 1639476253490}]'
 - command: route show --prefixlen=">128" --format=json --namespace=panos
   data-directory: tests/data/parquet/
   error:
@@ -3372,21 +3362,22 @@ tests:
   marks: route unique panos
   output: '[{"prefixlen": 0}, {"prefixlen": 16}, {"prefixlen": 24}, {"prefixlen":
     30}, {"prefixlen": 31}, {"prefixlen": 32}, {"prefixlen": 127}, {"prefixlen": 128}]'
-- command: route lpm --address='172.16.1.101' --columns='hostname nexthopIps' --format=json --namespace=panos
+- command: route lpm --address='172.16.1.101' --columns='hostname nexthopIps' --format=json
+    --namespace=panos
   data-directory: tests/data/parquet/
   marks: route lpm panos
-  output: '[{"hostname": "leaf03", "nexthopIps": ["10.0.0.112"]}, {"hostname": "leaf04",
-    "nexthopIps": ["10.0.0.112"]}, {"hostname": "firewall01", "nexthopIps": ["169.254.253.5",
-    "169.254.254.5"]}, {"hostname": "server101", "nexthopIps": [""]}, {"hostname":
-    "leaf01", "nexthopIps": [""]}, {"hostname": "exit02", "nexthopIps": ["10.0.0.112"]},
-    {"hostname": "exit01", "nexthopIps": ["10.0.0.112"]}, {"hostname": "leaf02", "nexthopIps":
-    [""]}, {"hostname": "server302", "nexthopIps": ["172.16.3.254"]}, {"hostname":
-    "server301", "nexthopIps": ["172.16.2.254"]}, {"hostname": "server102", "nexthopIps":
-    ["172.16.3.254"]}, {"hostname": "spine01", "nexthopIps": ["10.255.2.1"]}, {"hostname":
-    "leaf03", "nexthopIps": ["10.255.2.1"]}, {"hostname": "exit02", "nexthopIps":
-    ["169.254.127.2"]}, {"hostname": "leaf02", "nexthopIps": ["10.255.2.1"]}, {"hostname":
-    "leaf01", "nexthopIps": ["10.255.2.1"]}, {"hostname": "leaf04", "nexthopIps":
-    ["10.255.2.1"]}, {"hostname": "exit01", "nexthopIps": ["169.254.127.0"]}, {"hostname":
-    "dcedge01", "nexthopIps": ["10.255.2.1"]}, {"hostname": "exit01", "nexthopIps":
-    ["10.255.2.1"]}, {"hostname": "exit02", "nexthopIps": ["10.255.2.1"]}, {"hostname":
-    "spine02", "nexthopIps": ["10.255.2.1"]}]'
+  output: '[{"hostname": "firewall01", "nexthopIps": ["169.254.253.5", "169.254.254.5"]},
+    {"hostname": "leaf03", "nexthopIps": ["10.0.0.112"]}, {"hostname": "leaf02", "nexthopIps":
+    [""]}, {"hostname": "exit02", "nexthopIps": ["10.0.0.112"]}, {"hostname": "server101",
+    "nexthopIps": [""]}, {"hostname": "exit01", "nexthopIps": ["10.0.0.112"]}, {"hostname":
+    "leaf04", "nexthopIps": ["10.0.0.112"]}, {"hostname": "leaf01", "nexthopIps":
+    [""]}, {"hostname": "server301", "nexthopIps": ["172.16.2.254"]}, {"hostname":
+    "server102", "nexthopIps": ["172.16.3.254"]}, {"hostname": "server302", "nexthopIps":
+    ["172.16.3.254"]}, {"hostname": "leaf01", "nexthopIps": ["10.255.2.1"]}, {"hostname":
+    "leaf02", "nexthopIps": ["10.255.2.1"]}, {"hostname": "exit02", "nexthopIps":
+    ["169.254.127.2"]}, {"hostname": "exit01", "nexthopIps": ["169.254.127.0"]}, {"hostname":
+    "exit01", "nexthopIps": ["10.255.2.1"]}, {"hostname": "exit02", "nexthopIps":
+    ["10.255.2.1"]}, {"hostname": "spine01", "nexthopIps": ["10.255.2.1"]}, {"hostname":
+    "spine02", "nexthopIps": ["10.255.2.1"]}, {"hostname": "leaf04", "nexthopIps":
+    ["10.255.2.1"]}, {"hostname": "leaf03", "nexthopIps": ["10.255.2.1"]}, {"hostname":
+    "dcedge01", "nexthopIps": ["10.255.2.1"]}]'


### PR DESCRIPTION
This PR partially addresses #573 adding to all the tables the new augmented column `lastPoll` that shows the timestamp of the last successful polling event for that record. In case there is no polling data yet, 0 is shown (this is possible in case of run once and no data present in the sqPoller table). The column is not shown by default, only when specified with `columns='*'` or `columns='lastPoll'`.

Tasks:

- [x] add augmented column to table schemas
- [x] write logic to get the lastPoll timestamp from the sqPoller table
- [x] manual testing adding and removing nodes
- [ ] update test data