### PR TITLE
Rename assert status subcommand to result

### DIFF
--- a/suzieq/cli/sqcmds/BgpCmd.py
+++ b/suzieq/cli/sqcmds/BgpCmd.py
@@ -79,9 +79,9 @@ class BgpCmd(SqCommand):
         return super().show()
 
     @command("assert")
-    @argument("status", description="Show only assert that matches this value",
+    @argument("result", description="Show only assert that matches this value",
               choices=["all", "fail", "pass"])
-    def aver(self, status: str = "all") -> pd.DataFrame:
+    def aver(self, result: str = "all") -> pd.DataFrame:
         """Assert BGP is functioning properly"""
 
         now = time.time()
@@ -89,7 +89,7 @@ class BgpCmd(SqCommand):
         df = self._invoke_sqobj(self.sqobj.aver,
                                 namespace=self.namespace,
                                 hostname=self.hostname,
-                                status=status,
+                                result=result,
                                 **self.lvars,
                                 )
         self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)

--- a/suzieq/cli/sqcmds/EvpnVniCmd.py
+++ b/suzieq/cli/sqcmds/EvpnVniCmd.py
@@ -44,9 +44,9 @@ class EvpnVniCmd(SqCommand):
         }
 
     @command("assert")
-    @argument("status", description="Show only assert that matches this value",
+    @argument("result", description="Show only assert that matches this value",
               choices=["all", "fail", "pass"])
-    def aver(self, status: str = 'pass'):
+    def aver(self, result: str = 'all'):
         """Assert VXLAN Forwarding is functioning properly"""
 
         now = time.time()
@@ -54,7 +54,7 @@ class EvpnVniCmd(SqCommand):
         df = self._invoke_sqobj(self.sqobj.aver,
                                 hostname=self.hostname,
                                 namespace=self.namespace,
-                                status=status,
+                                result=result,
                                 **self.lvars,
                                 )
         self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)

--- a/suzieq/cli/sqcmds/InterfaceCmd.py
+++ b/suzieq/cli/sqcmds/InterfaceCmd.py
@@ -72,13 +72,13 @@ class InterfaceCmd(SqCommand):
         choices=["mtu-value"],
     )
     @argument("value", description="Value to match against")
-    @argument("status", description="Show only assert that matches this value",
+    @argument("result", description="Show only assert that matches this value",
               choices=["all", "fail", "pass"])
     @argument("ignore_missing_peer",
               description="Treat missing peer as passing assert check",
               choices=["True", "False"])
     def aver(self, what: str = "",
-             value: str = '', status: str = 'all',
+             value: str = '', result: str = 'all',
              ignore_missing_peer: str = "False"):
         """Assert aspects about the interface
         """
@@ -99,7 +99,7 @@ class InterfaceCmd(SqCommand):
                                 namespace=self.namespace,
                                 what=what,
                                 matchval=value.split(),
-                                status=status,
+                                result=result,
                                 ignore_missing_peer=(
                                     ignore_missing_peer == "True"),
                                 **self.lvars,

--- a/suzieq/cli/sqcmds/OspfCmd.py
+++ b/suzieq/cli/sqcmds/OspfCmd.py
@@ -57,9 +57,9 @@ class OspfCmd(SqCommand):
         }
 
     @command("assert")
-    @argument("status", description="Show only assert that matches this value",
+    @argument("result", description="Show only assert that matches this value",
               choices=["all", "fail", "pass"])
-    def aver(self, status: str = 'all') -> pd.DataFrame:
+    def aver(self, result: str = 'all') -> pd.DataFrame:
         """
         Test OSPF runtime state is without errors
         """
@@ -68,7 +68,7 @@ class OspfCmd(SqCommand):
         df = self._invoke_sqobj(self.sqobj.aver,
                                 namespace=self.namespace,
                                 hostname=self.hostname,
-                                status=status,
+                                result=result,
                                 **self.lvars,
                                 )
         self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -478,7 +478,7 @@ class SqCommand(SqPlugin):
             result = 0
         elif df.columns.to_list() == ['error']:
             result = 1
-        elif df.loc[df['assert'] != "pass"].empty:
+        elif df.loc[df['result'] != "pass"].empty:
             result = 0
         else:
             result = -1

--- a/suzieq/engines/pandas/evpnVni.py
+++ b/suzieq/engines/pandas/evpnVni.py
@@ -180,14 +180,14 @@ class EvpnvniObj(SqPandasEngine):
                        "secVtepIp", "timestamp"]
 
         kwargs.pop("columns", None)  # Loose whatever's passed
-        status = kwargs.pop('status', 'all')
+        result = kwargs.pop('result', 'all')
 
         df = self.get(columns=assert_cols, **kwargs)
         if df.empty:
             df = pd.DataFrame(columns=assert_cols)
-            if status != 'pass':
+            if result != 'pass':
                 df['assertReason'] = 'No data found'
-                df['assert'] = 'fail'
+                df['result'] = 'fail'
             return df
 
         df["assertReason"] = [[] for _ in range(len(df))]
@@ -272,17 +272,17 @@ class EvpnvniObj(SqPandasEngine):
         #                                args=(mac_df, ), axis=1)
 
         # Fill out the assert column
-        df['assert'] = df.apply(lambda x: 'pass'
+        df['result'] = df.apply(lambda x: 'pass'
                                 if len(x.assertReason) == 0 else 'fail',
                                 axis=1)
 
-        if status == 'fail':
+        if result == 'fail':
             df = df.query('assertReason.str.len() != 0')
-        elif status == "pass":
+        elif result == "pass":
             df = df.query('assertReason.str.len() == 0')
 
         return df[['namespace', 'hostname', 'vni', 'type',
-                   'assertReason', 'assert', 'timestamp']] \
+                   'assertReason', 'result', 'timestamp']] \
             .explode(column='assertReason') \
             .fillna({'assertReason': '-'})
 

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -99,10 +99,12 @@ class InterfacesObj(SqPandasEngine):
     def aver(self, what="", **kwargs) -> pd.DataFrame:
         """Assert that interfaces are in good state"""
 
+        ignore_missing_peer = kwargs.pop('ignore_missing_peer', False)
+
         if what == "mtu-value":
             result_df = self._assert_mtu_value(**kwargs)
         else:
-            result_df = self._assert_interfaces(**kwargs)
+            result_df = self._assert_interfaces(ignore_missing_peer, **kwargs)
         return result_df
 
     def summarize(self, **kwargs) -> pd.DataFrame:
@@ -202,11 +204,10 @@ class InterfacesObj(SqPandasEngine):
         return result_df
 
     # pylint: disable=too-many-statements
-    def _assert_interfaces(self, **kwargs) -> pd.DataFrame:
+    def _assert_interfaces(self, ignore_missing_peer: bool, **kwargs) -> pd.DataFrame:
         """Workhorse routine that validates MTU match for specified input"""
         columns = kwargs.pop('columns', [])
         result = kwargs.pop('result', 'all')
-        ignore_missing_peer = kwargs.pop('ignore_missing_peer', False)
         state = kwargs.pop('state', '')
         iftype = kwargs.pop('type', [])
 

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -204,7 +204,8 @@ class InterfacesObj(SqPandasEngine):
         return result_df
 
     # pylint: disable=too-many-statements
-    def _assert_interfaces(self, ignore_missing_peer: bool, **kwargs) -> pd.DataFrame:
+    def _assert_interfaces(self, ignore_missing_peer: bool, **kwargs) \
+            -> pd.DataFrame:
         """Workhorse routine that validates MTU match for specified input"""
         columns = kwargs.pop('columns', [])
         result = kwargs.pop('result', 'all')

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -182,7 +182,7 @@ class InterfacesObj(SqPandasEngine):
                    "timestamp"]
 
         matchval = kwargs.pop('matchval', [])
-        status = kwargs.pop('status', '')
+        result = kwargs.pop('result', '')
 
         matchval = [int(x) for x in matchval]
 
@@ -190,25 +190,22 @@ class InterfacesObj(SqPandasEngine):
                         .query('ifname != "lo"')
 
         if not result_df.empty:
-            result_df['status'] = result_df.apply(
+            result_df['result'] = result_df.apply(
                 lambda x, matchval: 'pass' if x['mtu'] in matchval else 'fail',
                 axis=1, args=(matchval,))
 
-        if status == "fail":
-            result_df = result_df.query('status == "fail"')
-        elif status == "pass":
-            result_df = result_df.query('status == "pass"')
+        if result == "fail":
+            result_df = result_df.query('result == "fail"')
+        elif result == "pass":
+            result_df = result_df.query('result == "pass"')
 
-        if not result_df.empty:
-            return result_df.rename(columns={'status': 'assert'})
-        else:
-            return result_df
+        return result_df
 
     # pylint: disable=too-many-statements
     def _assert_interfaces(self, **kwargs) -> pd.DataFrame:
         """Workhorse routine that validates MTU match for specified input"""
         columns = kwargs.pop('columns', [])
-        status = kwargs.pop('status', 'all')
+        result = kwargs.pop('result', 'all')
         ignore_missing_peer = kwargs.pop('ignore_missing_peer', False)
         state = kwargs.pop('state', '')
         iftype = kwargs.pop('type', [])
@@ -249,8 +246,8 @@ class InterfacesObj(SqPandasEngine):
 
         if_df = self.get(columns=columns, type=iftype, state=state, **kwargs)
         if if_df.empty:
-            if status != 'pass':
-                if_df['assert'] = 'fail'
+            if result != 'pass':
+                if_df['result'] = 'fail'
                 if_df['assertReason'] = 'No data'
 
             return if_df
@@ -302,9 +299,9 @@ class InterfacesObj(SqPandasEngine):
             if_df['vlanList'] = [[] for i in range(len(if_df))]
 
         if lldp_df.empty:
-            if status != 'pass':
+            if result != 'pass':
                 if_df['assertReason'] = 'No LLDP peering info'
-                if_df['assert'] = 'fail'
+                if_df['result'] = 'fail'
 
             return if_df
 
@@ -354,9 +351,9 @@ class InterfacesObj(SqPandasEngine):
             .drop_duplicates(subset=['namespace', 'hostname', 'ifname'])
 
         if combined_df.empty:
-            if status != 'pass':
+            if result != 'pass':
                 if_df['assertReason'] = 'No LLDP peering info'
-                if_df['assert'] = 'fail'
+                if_df['result'] = 'fail'
 
             return if_df
 
@@ -452,24 +449,27 @@ class InterfacesObj(SqPandasEngine):
             else ['VLAN set mismatch'], args=(mlag_peerlinks,), axis=1)
 
         if ignore_missing_peer:
-            combined_df['check'] = combined_df.apply(
+            combined_df['result'] = combined_df.apply(
                 lambda x: 'fail'
                 if (len(x.assertReason) and
                     (x.assertReason[0] != 'No Peer Found'))
                 else 'pass', axis=1)
         else:
-            combined_df['check'] = combined_df.apply(
+            combined_df['result'] = combined_df.apply(
                 lambda x: 'fail' if (len(x.assertReason)) else 'pass', axis=1)
 
-        if status == "fail":
-            combined_df = combined_df.query('check == "fail"').reset_index()
-        elif status == "pass":
-            combined_df = combined_df.query('check == "pass"').reset_index()
+        if result == "fail":
+            combined_df = combined_df.query('result == "fail"').reset_index()
+        elif result == "pass":
+            combined_df = combined_df.query('result == "pass"').reset_index()
+
+        combined_df['assertReason'] = combined_df['assertReason'].apply(
+            lambda x: x if len(x) else '-'
+        )
 
         return combined_df[['namespace', 'hostname', 'ifname', 'state',
-                            'peerHostname', 'peerIfname', 'check',
-                            'assertReason', 'timestamp']] \
-            .rename({'check': 'assert'}, axis=1)
+                            'peerHostname', 'peerIfname', 'result',
+                            'assertReason', 'timestamp']]
 
     def _add_portmode(self, df: pd.DataFrame):
         """Add the switchport-mode i.e. acceess/trunk/routed'''

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -241,7 +241,13 @@ class ViewValues(str, Enum):
     changes = "changes"
 
 
-class AssertStatusValues(str, Enum):
+class AssertResultValue(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    ALL = "all"
+
+
+class SqPollerStatus(str, Enum):
     PASS = "pass"
     FAIL = "fail"
     ALL = "all"
@@ -312,7 +318,7 @@ async def query_bgp(verb: CommonExtraVerbs, request: Request,
                     state: BgpStateValues = Query(None),
                     vrf: List[str] = Query(None),
                     asn: List[str] = Query(None),
-                    status: AssertStatusValues = Query(None),
+                    result: AssertResultValue = Query(None),
                     query_str: str = None, what: str = None,
                     ):
     function_name = inspect.currentframe().f_code.co_name
@@ -367,7 +373,7 @@ async def query_evpnVni(verb: CommonExtraVerbs, request: Request,
                         columns: List[str] = Query(default=["default"]),
                         vni: List[str] = Query(None),
                         priVtepIp: List[str] = Query(None),
-                        status: AssertStatusValues = None,
+                        result: AssertResultValue = None,
                         query_str: str = None, what: str = None,
                         ):
     function_name = inspect.currentframe().f_code.co_name
@@ -407,7 +413,7 @@ async def query_interface(verb: CommonExtraVerbs, request: Request,
                           mtu: List[str] = Query(None),
                           ifindex: List[str] = Query(None),
                           matchval: int = Query(None, alias="value"),
-                          status: AssertStatusValues = Query(None),
+                          result: AssertResultValue = Query(None),
                           ignore_missing_peer: bool = Query(False),
                           vlan: List[str] = Query(None),
                           portmode: List[str] = Query(None),
@@ -540,7 +546,7 @@ async def query_ospf(verb: CommonExtraVerbs, request: Request,
                      state: OspfStateValues = Query(None),
                      area: List[str] = Query(None),
                      vrf: List[str] = Query(None),
-                     status: AssertStatusValues = None,
+                     result: AssertResultValue = None,
                      query_str: str = None, what: str = None,
                      ):
     function_name = inspect.currentframe().f_code.co_name
@@ -595,7 +601,7 @@ async def query_sqPoller(verb: CommonVerbs, request: Request,
                          namespace: List[str] = Query(None),
                          columns: List[str] = Query(default=["default"]),
                          service: str = None,
-                         status: AssertStatusValues = Query(None),
+                         status: SqPollerStatus = Query(None),
                          query_str: str = None, what: str = None,
                          pollExcdPeriodCount: str = None,
                          ):

--- a/suzieq/sqobjects/bgp.py
+++ b/suzieq/sqobjects/bgp.py
@@ -13,9 +13,9 @@ class BgpObj(SqObject):
                                 'vrf', 'peer', 'asn', 'query_str']
         self._valid_arg_vals = {
             'state': ['Established', 'NotEstd', 'dynamic', ''],
-            'status': ['all', 'pass', 'fail'],
+            'result': ['all', 'pass', 'fail'],
         }
-        self._valid_assert_args = self._valid_get_args + ['status']
+        self._valid_assert_args = self._valid_get_args + ['result']
 
     def humanize_fields(self, df: pd.DataFrame, _=None) -> pd.DataFrame:
         '''Humanize the timestamp and boot time fields'''

--- a/suzieq/sqobjects/evpnVni.py
+++ b/suzieq/sqobjects/evpnVni.py
@@ -8,7 +8,7 @@ class EvpnvniObj(SqObject):
         super().__init__(table='evpnVni', **kwargs)
         self._valid_get_args = ['namespace', 'hostname', 'columns', 'vni',
                                 'priVtepIp', 'query_str']
-        self._valid_assert_args = self._valid_get_args + ['status']
+        self._valid_assert_args = self._valid_get_args + ['result']
         self._valid_arg_vals = {
-            'status': ['all', 'pass', 'fail'],
+            'result': ['all', 'pass', 'fail'],
         }

--- a/suzieq/sqobjects/interfaces.py
+++ b/suzieq/sqobjects/interfaces.py
@@ -13,11 +13,11 @@ class InterfacesObj(SqObject):
                                 'state', 'type', 'mtu', 'master', 'ifindex',
                                 'vrf', 'portmode', 'vlan', 'query_str']
         self._valid_assert_args = self._valid_get_args + \
-            ['what', 'matchval', 'status', 'ignore_missing_peer']
+            ['what', 'matchval', 'result', 'ignore_missing_peer']
         self._valid_arg_vals = {
             'state': ['up', 'down', 'notConnected', '!up', '!down',
                       '!notConnected', ''],
-            'status': ['all', 'pass', 'fail'],
+            'result': ['all', 'pass', 'fail'],
         }
         self._unique_def_column = ['type']
 

--- a/suzieq/sqobjects/ospf.py
+++ b/suzieq/sqobjects/ospf.py
@@ -14,11 +14,11 @@ class OspfObj(SqObject):
         self._addnl_nbr_fields = ['state']
         self._valid_get_args = ['namespace', 'hostname', 'columns', 'area',
                                 'vrf', 'ifname', 'state', 'query_str']
-        self._valid_assert_args = self._valid_get_args + ['status']
+        self._valid_assert_args = self._valid_get_args + ['result']
         self._valid_arg_vals = {
             'state': ['full', 'other', 'passive', '!full', '!passive',
                       '!other', ''],
-            'status': ['all', 'pass', 'fail'],
+            'result': ['all', 'pass', 'fail'],
         }
 
     def humanize_fields(self, df: pd.DataFrame, _=None) -> pd.DataFrame:

--- a/tests/integration/sqcmds/common-samples/help.yml
+++ b/tests/integration/sqcmds/common-samples/help.yml
@@ -177,10 +177,10 @@ tests:
     \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
     [0m\n - peer: \e[36m\e[1mIP address(es), in quotes, or the interface name(s),\
     \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
-    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
-    \ of time window, try natural language spec\e[0m\n - state: \e[36m\e[1mState of\
-    \ VLAN to query\e[0m\n - status: \e[36m\e[1mShow only assert that matches this\
-    \ value\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e[0m\n -\
+    \ query format to further filter the output\e[0m\n - result: \e[36m\e[1mShow only\
+    \ assert that matches this value\e[0m\n - start_time: \e[36m\e[1mStart of time\
+    \ window, try natural language spec\e[0m\n - state: \e[36m\e[1mState of VLAN to\
+    \ query\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e[0m\n -\
     \ vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
 - command: bgp help --command=show
   data-directory: tests/data/eos/parquet-out/
@@ -378,10 +378,10 @@ tests:
     [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
     \ space separated\e[0m\n - priVtepIp: \e[36m\e[1mPrimary VTEP IP(s), space separated\e\
     [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
-    \ further filter the output\e[0m\n - start_time: \e[36m\e[1mStart of time window,\
-    \ try natural language spec\e[0m\n - status: \e[36m\e[1mShow only assert that\
-    \ matches this value\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e\
-    [0m\n - vni: \e[36m\e[1mVNI ID(s), space separated\e[0m\n"
+    \ further filter the output\e[0m\n - result: \e[36m\e[1mShow only assert that\
+    \ matches this value\e[0m\n - start_time: \e[36m\e[1mStart of time window, try\
+    \ natural language spec\e[0m\n - view: \e[36m\e[1mView all records or just the\
+    \ latest\e[0m\n - vni: \e[36m\e[1mVNI ID(s), space separated\e[0m\n"
 - command: evpnVni help --command=summarize
   data-directory: tests/data/eos/parquet-out/
   format: text
@@ -466,10 +466,10 @@ tests:
     [0m\n - mtu: \e[36m\e[1mMTU(s), space separated, can use <, >, <=, >=, !\e[0m\n\
     \ - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - portmode: \e\
     [36m\e[1mPortmode(s), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing\
-    \ blank terminated pandas query format to further filter the output\e[0m\n - start_time:\
-    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e\
-    [36m\e[1mState of VLAN to query\e[0m\n - status: \e[36m\e[1mShow only assert that\
-    \ matches this value\e[0m\n - type: \e[36m\e[1mFilter by type\e[0m\n - value:\
+    \ blank terminated pandas query format to further filter the output\e[0m\n - result:\
+    \ \e[36m\e[1mShow only assert that matches this value\e[0m\n - start_time: \e\
+    [36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e[36m\e\
+    [1mState of VLAN to query\e[0m\n - type: \e[36m\e[1mFilter by type\e[0m\n - value:\
     \ \e[36m\e[1mValue to match against\e[0m\n - view: \e[36m\e[1mView all records\
     \ or just the latest\e[0m\n - vlan: \e[36m\e[1mVLAN(s), space separated, can use\
     \ <, >, <=, >=, !\e[0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n - what:\
@@ -1104,11 +1104,11 @@ tests:
     \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
     \ - ifname: \e[36m\e[1mInterface name(s), space separated\e[0m\n - namespace:\
     \ \e[36m\e[1mNamespace(s), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing\
-    \ blank terminated pandas query format to further filter the output\e[0m\n - start_time:\
-    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e\
-    [36m\e[1mState of VLAN to query\e[0m\n - status: \e[36m\e[1mShow only assert that\
-    \ matches this value\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e\
-    [0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
+    \ blank terminated pandas query format to further filter the output\e[0m\n - result:\
+    \ \e[36m\e[1mShow only assert that matches this value\e[0m\n - start_time: \e\
+    [36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e[36m\e\
+    [1mState of VLAN to query\e[0m\n - view: \e[36m\e[1mView all records or just the\
+    \ latest\e[0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
 - command: ospf help --command=show
   data-directory: tests/data/eos/parquet-out/
   format: text

--- a/tests/integration/sqcmds/cumulus-samples/bgp.yml
+++ b/tests/integration/sqcmds/cumulus-samples/bgp.yml
@@ -394,7 +394,8 @@ tests:
     "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
     "pfxRx": 6, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
     1616681583504}]'
-- command: bgp show --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp show --columns=hostname --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp show filter
   output: '[{"hostname": "edge01"}, {"hostname": "edge01"}, {"hostname": "edge01"},
@@ -429,7 +430,8 @@ tests:
     {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "spine02"}, {"hostname":
     "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"},
     {"hostname": "spine02"}]'
-- command: bgp show --columns='*' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp show --columns='*' --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp show filter
   output: '[{"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer":
@@ -1861,7 +1863,8 @@ tests:
   output: '[{"hostname": "edge01"}, {"hostname": "exit01"}, {"hostname": "exit02"},
     {"hostname": "internet"}, {"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname":
     "leaf03"}, {"hostname": "leaf04"}, {"hostname": "spine01"}, {"hostname": "spine02"}]'
-- command: bgp unique --count=True --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique
   output: '[{"hostname": "internet", "numRows": 4}, {"hostname": "leaf01", "numRows":
@@ -1869,7 +1872,8 @@ tests:
     {"hostname": "leaf04", "numRows": 6}, {"hostname": "edge01", "numRows": 12}, {"hostname":
     "exit02", "numRows": 15}, {"hostname": "exit01", "numRows": 16}, {"hostname":
     "spine02", "numRows": 18}, {"hostname": "spine01", "numRows": 20}]'
-- command: bgp unique --columns=hostname --format=json --count=True --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --columns=hostname --format=json --count=True --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique
   output: '[{"hostname": "internet", "numRows": 4}, {"hostname": "leaf01", "numRows":
@@ -1882,236 +1886,236 @@ tests:
   error:
     error: '[{"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer":
       "swp2", "asn": 65000, "peerAsn": 0, "state": "NotEstd", "peerHostname": "",
-      "assert": "fail", "assertReason": "Waiting for Peer IPv6 LLA:", "timestamp":
+      "result": "fail", "assertReason": "Waiting for Peer IPv6 LLA:", "timestamp":
       1616681583200}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
       "peer": "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822492},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616644822492},
       {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer": "eth1.3",
       "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644822492}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822492}, {"namespace":
       "dual-evpn", "hostname": "edge01", "vrf": "default", "peer": "eth1.4", "asn":
-      65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01", "assert":
+      65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1616644822492}, {"namespace": "dual-evpn",
       "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn": 65530, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
+      65202, "state": "Established", "peerHostname": "exit02", "result": "pass", "assertReason":
       "-", "timestamp": 1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01",
       "vrf": "default", "peer": "eth2.3", "asn": 65530, "peerAsn": 65202, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01",
       "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn": 65202, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1616644822492}, {"namespace": "dual-evpn", "hostname": "spine02",
       "vrf": "default", "peer": "swp2", "asn": 65000, "peerAsn": 65102, "state": "Established",
-      "peerHostname": "leaf02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf02", "result": "pass", "assertReason": "-", "timestamp":
       1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
       "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-      "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616644822793},
+      "leaf03", "result": "pass", "assertReason": "-", "timestamp": 1616644822793},
       {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer":
       "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established", "peerHostname":
-      "leaf04", "assert": "pass", "assertReason": "-", "timestamp": 1616644822793},
+      "leaf04", "result": "pass", "assertReason": "-", "timestamp": 1616644822793},
       {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer":
       "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "pass", "assertReason": "-", "timestamp": 1616644822793},
+      "exit02", "result": "pass", "assertReason": "-", "timestamp": 1616644822793},
       {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer":
       "swp1", "asn": 65000, "peerAsn": 65101, "state": "Established", "peerHostname":
-      "leaf01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822793},
+      "leaf01", "result": "pass", "assertReason": "-", "timestamp": 1616644822793},
       {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer":
       "swp6", "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822793},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616644822793},
       {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
       "swp1", "asn": 65000, "peerAsn": 65101, "state": "Established", "peerHostname":
-      "leaf01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822861},
+      "leaf01", "result": "pass", "assertReason": "-", "timestamp": 1616644822861},
       {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
       "swp2", "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname":
-      "leaf02", "assert": "pass", "assertReason": "-", "timestamp": 1616644822861},
+      "leaf02", "result": "pass", "assertReason": "-", "timestamp": 1616644822861},
       {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
       "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-      "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616644822861},
+      "leaf03", "result": "pass", "assertReason": "-", "timestamp": 1616644822861},
       {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
       "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established", "peerHostname":
-      "leaf04", "assert": "pass", "assertReason": "-", "timestamp": 1616644822861},
+      "leaf04", "result": "pass", "assertReason": "-", "timestamp": 1616644822861},
       {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
       "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "pass", "assertReason": "-", "timestamp": 1616644822861},
+      "exit02", "result": "pass", "assertReason": "-", "timestamp": 1616644822861},
       {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
       "swp6", "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822861},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616644822861},
       {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp1",
       "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
       "dual-evpn", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "asn":
       65201, "peerAsn": 25253, "state": "Established", "peerHostname": "internet",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
       "dual-evpn", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp5.4",
       "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
       "dual-evpn", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "swp5.3", "asn":
-      65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01", "assert":
+      65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01", "result":
       "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn",
       "hostname": "exit01", "vrf": "default", "peer": "swp5.2", "asn": 65201, "peerAsn":
-      65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
+      65530, "state": "Established", "peerHostname": "edge01", "result": "pass", "assertReason":
       "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
       "vrf": "default", "peer": "swp2", "asn": 65201, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1616644822941}, {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default",
       "peer": "swp1", "asn": 65202, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822972},
+      "spine01", "result": "pass", "assertReason": "-", "timestamp": 1616644822972},
       {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default", "peer": "swp2",
       "asn": 65202, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644822972}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822972}, {"namespace":
       "dual-evpn", "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "asn":
-      65202, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01", "assert":
+      65202, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01", "result":
       "pass", "assertReason": "-", "timestamp": 1616644822972}, {"namespace": "dual-evpn",
       "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp5.3", "asn": 65202, "peerAsn":
-      65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
+      65530, "state": "Established", "peerHostname": "edge01", "result": "pass", "assertReason":
       "-", "timestamp": 1616644822972}, {"namespace": "dual-evpn", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
       "timestamp": 1616644822972}, {"namespace": "dual-evpn", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state":
-      "Established", "peerHostname": "internet", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "internet", "result": "pass", "assertReason":
       "-", "timestamp": 1616644822972}, {"namespace": "dual-evpn", "hostname": "leaf03",
       "vrf": "default", "peer": "swp2", "asn": 65103, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default",
       "peer": "swp1", "asn": 65103, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      "spine01", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
       {"namespace": "dual-evpn", "hostname": "internet", "vrf": "default", "peer":
       "swp1", "asn": 25253, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616644822996},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616644822996},
       {"namespace": "dual-evpn", "hostname": "internet", "vrf": "default", "peer":
       "swp2", "asn": 25253, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "pass", "assertReason": "-", "timestamp": 1616644822996},
+      "exit02", "result": "pass", "assertReason": "-", "timestamp": 1616644822996},
       {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
       "asn": 65101, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823039}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823039}, {"namespace":
       "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn":
       65101, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823039}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823039}, {"namespace":
       "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer": "swp2", "asn":
       65104, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823113}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823113}, {"namespace":
       "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer": "swp1", "asn":
       65104, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823113}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823113}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "vrf": "default", "peer": "swp1", "asn":
       65102, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823117}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823117}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "vrf": "default", "peer": "swp2", "asn":
       65102, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823117}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823117}, {"namespace":
       "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.2", "asn":
-      65530, "peerAsn": 65000, "state": "Established", "peerHostname": "exit01", "assert":
+      65530, "peerAsn": 65000, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1616681582563}, {"namespace": "ospf-ibgp",
       "hostname": "edge01", "vrf": "default", "peer": "eth1.3", "asn": 65530, "peerAsn":
-      65000, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
+      65000, "state": "Established", "peerHostname": "exit01", "result": "pass", "assertReason":
       "-", "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname": "edge01",
       "vrf": "default", "peer": "eth1.4", "asn": 65530, "peerAsn": 65001, "state":
-      "Established", "peerHostname": "exit01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit01", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname": "edge01",
       "vrf": "default", "peer": "eth2.2", "asn": 65530, "peerAsn": 65000, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname": "edge01",
       "vrf": "default", "peer": "eth2.3", "asn": 65530, "peerAsn": 65000, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname": "edge01",
       "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn": 65001, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65001, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp6", "asn": 65001, "peerAsn": 25253, "state":
-      "Established", "peerHostname": "internet", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "internet", "result": "pass", "assertReason":
       "-", "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01",
       "vrf": "default", "peer": "swp5.2", "asn": 65000, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01",
       "vrf": "evpn-vrf", "peer": "swp5.3", "asn": 65000, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
       "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01",
       "vrf": "default", "peer": "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616681582980},
+      "spine01", "result": "pass", "assertReason": "-", "timestamp": 1616681582980},
       {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default", "peer": "swp2",
       "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583091}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "default",
       "peer": "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583091}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583091}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583091}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "evpn-vrf",
       "peer": "swp5.3", "asn": 65000, "peerAsn": 65530, "state": "Established", "peerHostname":
-      "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616681583200},
+      "edge01", "result": "pass", "assertReason": "-", "timestamp": 1616681583200},
       {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "internet-vrf", "peer":
       "swp5.4", "asn": 65001, "peerAsn": 65530, "state": "Established", "peerHostname":
-      "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616681583200},
+      "edge01", "result": "pass", "assertReason": "-", "timestamp": 1616681583200},
       {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "internet-vrf", "peer":
       "swp6", "asn": 65001, "peerAsn": 25253, "state": "Established", "peerHostname":
-      "internet", "assert": "pass", "assertReason": "-", "timestamp": 1616681583200},
+      "internet", "result": "pass", "assertReason": "-", "timestamp": 1616681583200},
       {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer": "swp1",
       "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616681583200}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616681583200}, {"namespace":
       "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "asn":
-      65000, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01", "assert":
+      65000, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01", "result":
       "pass", "assertReason": "-", "timestamp": 1616681583200}, {"namespace": "ospf-ibgp",
       "hostname": "spine01", "vrf": "default", "peer": "swp6", "asn": 65000, "peerAsn":
-      65000, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
+      65000, "state": "Established", "peerHostname": "exit01", "result": "pass", "assertReason":
       "-", "timestamp": 1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine01",
       "vrf": "default", "peer": "swp5", "asn": 65000, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit02", "result": "pass", "assertReason": "-", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp4", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf04", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf04", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp3", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf03", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf03", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default",
       "peer": "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "internet", "vrf": "default",
       "peer": "swp2", "asn": 25253, "peerAsn": 65001, "state": "Established", "peerHostname":
-      "exit02", "assert": "pass", "assertReason": "-", "timestamp": 1616681583330},
+      "exit02", "result": "pass", "assertReason": "-", "timestamp": 1616681583330},
       {"namespace": "ospf-ibgp", "hostname": "internet", "vrf": "default", "peer":
       "swp1", "asn": 25253, "peerAsn": 65001, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616681583330},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616681583330},
       {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1",
       "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583393}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default",
       "peer": "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583393}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp6", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616681583504},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616681583504},
       {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer":
       "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583504}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583504}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp3", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf03", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf03", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583504}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp4", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "leaf04", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "leaf04", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583504}]'
   marks: bgp assert
 - command: bgp assert --namespace=dual-bgp --format=json
@@ -2119,349 +2123,351 @@ tests:
   error:
     error: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
       "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616638469998},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616638469998},
       {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4",
       "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
       "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn":
-      65530, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "assert":
+      65530, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp",
       "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
+      65202, "state": "Established", "peerHostname": "exit02", "result": "pass", "assertReason":
       "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "spine02",
       "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-      "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf04", "result": "pass", "assertReason": "-", "timestamp":
       1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-      "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470426},
+      "leaf03", "result": "pass", "assertReason": "-", "timestamp": 1616638470426},
       {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
       "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
       "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "asn":
-      65000, "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
+      65000, "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "result":
       "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
       "hostname": "spine02", "vrf": "default", "peer": "swp5", "asn": 65000, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "fail", "assertReason":
+      65202, "state": "Established", "peerHostname": "exit02", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
       "hostname": "spine02", "vrf": "default", "peer": "swp6", "asn": 65000, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "fail", "assertReason":
+      65201, "state": "Established", "peerHostname": "exit01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
       "hostname": "internet", "vrf": "default", "peer": "swp1", "asn": 25253, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
+      65201, "state": "Established", "peerHostname": "exit01", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
       "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state":
-      "Established", "peerHostname": "internet", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "internet", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
       "vrf": "default", "peer": "swp2", "asn": 65202, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname":
       "exit02", "vrf": "default", "peer": "swp1", "asn": 65202, "peerAsn": 65000,
-      "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp",
       "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "asn": 65202, "peerAsn":
-      65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
+      65530, "state": "Established", "peerHostname": "edge01", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "internet",
       "vrf": "default", "peer": "swp2", "asn": 25253, "peerAsn": 65202, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit02", "result": "pass", "assertReason": "-", "timestamp":
       1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
       "peer": "swp6", "asn": 65201, "peerAsn": 25253, "state": "Established", "peerHostname":
-      "internet", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
+      "internet", "result": "pass", "assertReason": "-", "timestamp": 1616638470555},
       {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
       "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace":
       "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "asn": 65201,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "assert":
+      "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1616638470555},
       {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp1",
       "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
       "peer": "swp5.4", "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname":
-      "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
+      "edge01", "result": "pass", "assertReason": "-", "timestamp": 1616638470555},
       {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp6",
       "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "exit02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established", "peerHostname":
-      "leaf04", "assert": "pass", "assertReason": "-", "timestamp": 1616638470647},
+      "leaf04", "result": "pass", "assertReason": "-", "timestamp": 1616638470647},
       {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp3",
       "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname": "leaf03",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
       "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2", "asn":
-      65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02", "assert":
+      65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02", "result":
       "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp",
       "hostname": "spine01", "vrf": "default", "peer": "swp1", "asn": 65000, "peerAsn":
-      65101, "state": "Established", "peerHostname": "leaf01", "assert": "pass", "assertReason":
+      65101, "state": "Established", "peerHostname": "leaf01", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp", "hostname": "leaf04",
       "vrf": "default", "peer": "swp2", "asn": 65104, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
       "peer": "swp1", "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616638471112},
+      "spine01", "result": "pass", "assertReason": "-", "timestamp": 1616638471112},
       {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "peer": "swp2",
       "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
       "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1", "asn": 65104,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine01", "assert":
+      "peerAsn": 65000, "state": "Established", "peerHostname": "spine01", "result":
       "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
       "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine02", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
       "hostname": "leaf01", "vrf": "default", "peer": "swp1", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine01", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
       "hostname": "leaf03", "vrf": "default", "peer": "swp1", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine01", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471475}, {"namespace": "dual-bgp",
       "hostname": "leaf03", "vrf": "default", "peer": "swp2", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine02", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471475}]'
   marks: bgp assert
-- command: bgp assert --status=pass --namespace=dual-bgp --format=json
+- command: bgp assert --result=pass --namespace=dual-bgp --format=json
   data-directory: tests/data/parquet
   marks: bgp assert
   output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
     "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-    "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616638469998},
+    "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616638469998},
     {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4",
     "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
     "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn": 65530,
-    "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "assert":
+    "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "result":
     "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp",
     "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn":
-    65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
+    65202, "state": "Established", "peerHostname": "exit02", "result": "pass", "assertReason":
     "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "spine02",
     "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-    "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "leaf04", "result": "pass", "assertReason": "-", "timestamp":
     1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
     "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-    "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470426},
+    "leaf03", "result": "pass", "assertReason": "-", "timestamp": 1616638470426},
     {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
     "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
     "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "asn": 65000,
-    "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
+    "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "result":
     "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
     "hostname": "internet", "vrf": "default", "peer": "swp1", "asn": 25253, "peerAsn":
-    65201, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
+    65201, "state": "Established", "peerHostname": "exit01", "result": "pass", "assertReason":
     "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
     "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-    "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+    "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
     "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
     "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state": "Established",
-    "peerHostname": "internet", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "internet", "result": "pass", "assertReason": "-", "timestamp":
     1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
     "peer": "swp5.2", "asn": 65202, "peerAsn": 65530, "state": "Established", "peerHostname":
-    "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616638470550},
+    "edge01", "result": "pass", "assertReason": "-", "timestamp": 1616638470550},
     {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "peer": "swp2",
     "asn": 25253, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638470550}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616638470550}, {"namespace":
     "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "asn":
-    65201, "peerAsn": 25253, "state": "Established", "peerHostname": "internet", "assert":
+    65201, "peerAsn": 25253, "state": "Established", "peerHostname": "internet", "result":
     "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace": "dual-bgp",
     "hostname": "exit01", "vrf": "default", "peer": "swp5.2", "asn": 65201, "peerAsn":
-    65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
+    65530, "state": "Established", "peerHostname": "edge01", "result": "pass", "assertReason":
     "-", "timestamp": 1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01",
     "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65201, "peerAsn": 65530, "state":
-    "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+    "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
     "timestamp": 1616638470555}, {"namespace": "dual-bgp", "hostname": "spine01",
     "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-    "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "leaf04", "result": "pass", "assertReason": "-", "timestamp":
     1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
     "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-    "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470647},
+    "leaf03", "result": "pass", "assertReason": "-", "timestamp": 1616638470647},
     {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2",
     "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
     "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp1", "asn": 65000,
-    "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
+    "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "result":
     "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp",
     "hostname": "leaf04", "vrf": "default", "peer": "swp2", "asn": 65104, "peerAsn":
-    65000, "state": "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+    65000, "state": "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
     "-", "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02",
     "vrf": "default", "peer": "swp1", "asn": 65102, "peerAsn": 65000, "state": "Established",
-    "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "spine01", "result": "pass", "assertReason": "-", "timestamp":
     1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
     "peer": "swp2", "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname":
-    "spine02", "assert": "pass", "assertReason": "-", "timestamp": 1616638471112},
+    "spine02", "result": "pass", "assertReason": "-", "timestamp": 1616638471112},
     {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1",
     "asn": 65104, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
     "dual-bgp", "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn": 65101,
-    "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "assert":
+    "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "result":
     "pass", "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
     "hostname": "leaf01", "vrf": "default", "peer": "swp1", "asn": 65101, "peerAsn":
-    65000, "state": "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+    65000, "state": "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
     "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname": "leaf03",
     "vrf": "default", "peer": "swp1", "asn": 65103, "peerAsn": 65000, "state": "Established",
-    "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "spine01", "result": "pass", "assertReason": "-", "timestamp":
     1616638471475}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
     "peer": "swp2", "asn": 65103, "peerAsn": 65000, "state": "Established", "peerHostname":
-    "spine02", "assert": "pass", "assertReason": "-", "timestamp": 1616638471475}]'
-- command: bgp assert --status=fail --namespace=dual-bgp --format=json
+    "spine02", "result": "pass", "assertReason": "-", "timestamp": 1616638471475}]'
+- command: bgp assert --result=fail --namespace=dual-bgp --format=json
   data-directory: tests/data/parquet
   error:
     error: '[{"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer":
       "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "exit02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp6", "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "exit01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470426}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
       "peer": "swp2", "asn": 65202, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
       "peer": "swp1", "asn": 65202, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
       "peer": "swp2", "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
       "peer": "swp1", "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470555}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp6", "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "exit01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "exit02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470647}]'
   marks: bgp assert
-- command: bgp assert --status=all --namespace=dual-bgp --format=json
+- command: bgp assert --result=all --namespace=dual-bgp --format=json
   data-directory: tests/data/parquet
   error:
     error: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
       "eth1.2", "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1616638469998},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1616638469998},
       {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4",
       "asn": 65530, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace":
       "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "asn":
-      65530, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "assert":
+      65530, "peerAsn": 65202, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp",
       "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "asn": 65530, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "pass", "assertReason":
+      65202, "state": "Established", "peerHostname": "exit02", "result": "pass", "assertReason":
       "-", "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "spine02",
       "vrf": "default", "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established",
-      "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf04", "result": "pass", "assertReason": "-", "timestamp":
       1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
       "peer": "swp3", "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname":
-      "leaf03", "assert": "pass", "assertReason": "-", "timestamp": 1616638470426},
+      "leaf03", "result": "pass", "assertReason": "-", "timestamp": 1616638470426},
       {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
       "asn": 65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace":
       "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "asn":
-      65000, "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "assert":
+      65000, "peerAsn": 65101, "state": "Established", "peerHostname": "leaf01", "result":
       "pass", "assertReason": "-", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
       "hostname": "spine02", "vrf": "default", "peer": "swp5", "asn": 65000, "peerAsn":
-      65202, "state": "Established", "peerHostname": "exit02", "assert": "fail", "assertReason":
+      65202, "state": "Established", "peerHostname": "exit02", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
       "hostname": "spine02", "vrf": "default", "peer": "swp6", "asn": 65000, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "fail", "assertReason":
+      65201, "state": "Established", "peerHostname": "exit01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1616638470426}, {"namespace": "dual-bgp",
       "hostname": "internet", "vrf": "default", "peer": "swp1", "asn": 25253, "peerAsn":
-      65201, "state": "Established", "peerHostname": "exit01", "assert": "pass", "assertReason":
+      65201, "state": "Established", "peerHostname": "exit01", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp5.4", "asn": 65202, "peerAsn": 65530, "state":
-      "Established", "peerHostname": "edge01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "edge01", "result": "pass", "assertReason": "-",
       "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp6", "asn": 65202, "peerAsn": 25253, "state":
-      "Established", "peerHostname": "internet", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "internet", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02",
       "vrf": "default", "peer": "swp2", "asn": 65202, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname":
       "exit02", "vrf": "default", "peer": "swp1", "asn": 65202, "peerAsn": 65000,
-      "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1616638470550}, {"namespace": "dual-bgp",
       "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "asn": 65202, "peerAsn":
-      65530, "state": "Established", "peerHostname": "edge01", "assert": "pass", "assertReason":
+      65530, "state": "Established", "peerHostname": "edge01", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "internet",
       "vrf": "default", "peer": "swp2", "asn": 25253, "peerAsn": 65202, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit02", "result": "pass", "assertReason": "-", "timestamp":
       1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
       "peer": "swp6", "asn": 65201, "peerAsn": 25253, "state": "Established", "peerHostname":
-      "internet", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
+      "internet", "result": "pass", "assertReason": "-", "timestamp": 1616638470555},
       {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
       "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname": "edge01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638470555}, {"namespace":
       "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "asn": 65201,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "assert":
+      "peerAsn": 65000, "state": "Established", "peerHostname": "spine02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1616638470555},
       {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp1",
       "asn": 65201, "peerAsn": 65000, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf",
       "peer": "swp5.4", "asn": 65201, "peerAsn": 65530, "state": "Established", "peerHostname":
-      "edge01", "assert": "pass", "assertReason": "-", "timestamp": 1616638470555},
+      "edge01", "result": "pass", "assertReason": "-", "timestamp": 1616638470555},
       {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp6",
       "asn": 65000, "peerAsn": 65201, "state": "Established", "peerHostname": "exit01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp5", "asn": 65000, "peerAsn": 65202, "state": "Established", "peerHostname":
-      "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "exit02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
       "peer": "swp4", "asn": 65000, "peerAsn": 65104, "state": "Established", "peerHostname":
-      "leaf04", "assert": "pass", "assertReason": "-", "timestamp": 1616638470647},
+      "leaf04", "result": "pass", "assertReason": "-", "timestamp": 1616638470647},
       {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp3",
       "asn": 65000, "peerAsn": 65103, "state": "Established", "peerHostname": "leaf03",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace":
       "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2", "asn":
-      65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02", "assert":
+      65000, "peerAsn": 65102, "state": "Established", "peerHostname": "leaf02", "result":
       "pass", "assertReason": "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp",
       "hostname": "spine01", "vrf": "default", "peer": "swp1", "asn": 65000, "peerAsn":
-      65101, "state": "Established", "peerHostname": "leaf01", "assert": "pass", "assertReason":
+      65101, "state": "Established", "peerHostname": "leaf01", "result": "pass", "assertReason":
       "-", "timestamp": 1616638470647}, {"namespace": "dual-bgp", "hostname": "leaf04",
       "vrf": "default", "peer": "swp2", "asn": 65104, "peerAsn": 65000, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
       "peer": "swp1", "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616638471112},
+      "spine01", "result": "pass", "assertReason": "-", "timestamp": 1616638471112},
       {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "peer": "swp2",
       "asn": 65102, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace":
       "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp1", "asn": 65104,
-      "peerAsn": 65000, "state": "Established", "peerHostname": "spine01", "assert":
+      "peerAsn": 65000, "state": "Established", "peerHostname": "spine01", "result":
       "pass", "assertReason": "-", "timestamp": 1616638471112}, {"namespace": "dual-bgp",
       "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine02", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
       "hostname": "leaf01", "vrf": "default", "peer": "swp1", "asn": 65101, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine01", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471143}, {"namespace": "dual-bgp",
       "hostname": "leaf03", "vrf": "default", "peer": "swp1", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine01", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine01", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471475}, {"namespace": "dual-bgp",
       "hostname": "leaf03", "vrf": "default", "peer": "swp2", "asn": 65103, "peerAsn":
-      65000, "state": "Established", "peerHostname": "spine02", "assert": "pass",
+      65000, "state": "Established", "peerHostname": "spine02", "result": "pass",
       "assertReason": "-", "timestamp": 1616638471475}]'
   marks: bgp assert cumulus
-- command: bgp assert --status=whatever --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp assert --result=whatever --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp assert cumulus
   output: '[]'
-- command: bgp assert --hostname=leaf01 --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp assert --hostname=leaf01 --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer":
       "swp1", "asn": 65101, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "pass", "assertReason": "-", "timestamp": 1616644823039},
+      "spine01", "result": "pass", "assertReason": "-", "timestamp": 1616644823039},
       {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer": "swp2",
       "asn": 65101, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1616644823039}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823039}, {"namespace":
       "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer": "swp2", "asn":
       65000, "peerAsn": 65000, "state": "Established", "peerHostname": "spine02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}]'
   marks: bgp assert cumulus
 - command: bgp assert --hostname=leaf01 --namespace=ospf-ibgp --format=json
@@ -2469,13 +2475,14 @@ tests:
   error:
     error: '[{"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer":
       "swp2", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default",
       "peer": "swp1", "asn": 65000, "peerAsn": 65000, "state": "Established", "peerHostname":
-      "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine01", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1616681583330}]'
   marks: bgp assert cumulus
-- command: bgp unique --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --columns=hostname --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique
   output: '[{"hostname": "edge01"}, {"hostname": "exit01"}, {"hostname": "exit02"},

--- a/tests/integration/sqcmds/cumulus-samples/evpnVni.yml
+++ b/tests/integration/sqcmds/cumulus-samples/evpnVni.yml
@@ -87,7 +87,8 @@ tests:
     "hostname": "leaf01", "vni": 24, "type": "L2", "vlan": 24, "state": "up", "mcastGroup":
     "0.0.0.0", "remoteVtepCnt": 1, "priVtepIp": "10.0.0.112", "secVtepIp": "", "timestamp":
     1616681582726}]'
-- command: evpnVni show --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni show --columns=hostname --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni show cumulus
   output: '[{"hostname": "exit02"}, {"hostname": "exit02"}, {"hostname": "exit02"},
@@ -120,13 +121,15 @@ tests:
   marks: evpnVni unique cumulus
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
     {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}]'
-- command: evpnVni unique --count=True --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni unique --count=True --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni unique cumulus
   output: '[{"hostname": "exit01", "numRows": 4}, {"hostname": "exit02", "numRows":
     4}, {"hostname": "leaf01", "numRows": 6}, {"hostname": "leaf02", "numRows": 6},
     {"hostname": "leaf03", "numRows": 6}, {"hostname": "leaf04", "numRows": 6}]'
-- command: evpnVni unique --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni unique --columns=hostname --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni unique cumulus
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
@@ -135,63 +138,64 @@ tests:
   data-directory: tests/data/parquet/
   marks: evpnVni assert cumulus
   output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24.0, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616644822033}, {"namespace":
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822033}, {"namespace":
     "dual-evpn", "hostname": "exit02", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822167},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
     {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
+    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616644822167},
+    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
     {"namespace": "dual-evpn", "hostname": "exit01", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822168}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822169},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822169},
     {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
+    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822253}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822253},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822253},
     {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616681581879},
+    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616681581879},
     {"namespace": "ospf-ibgp", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "vni": 104001.0, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 104001.0, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1616681581987}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616681582166},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582166},
     {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681582386}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616681582523},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582523},
     {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681582726}]'
-- command: evpnVni show --columns='hostname vni' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni show --columns='hostname vni' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni show filter cumulus
   output: '[{"hostname": "exit02", "vni": 24}, {"hostname": "exit02", "vni": 13},
@@ -209,7 +213,8 @@ tests:
     104001}, {"hostname": "leaf04", "vni": 13}, {"hostname": "exit02", "vni": 104001},
     {"hostname": "leaf01", "vni": 13}, {"hostname": "leaf01", "vni": 104001}, {"hostname":
     "leaf01", "vni": 24}]'
-- command: evpnVni show --columns='hostname vni remoteVtepCnt' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni show --columns='hostname vni remoteVtepCnt' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni show filter cumulus
   output: '[{"hostname": "exit02", "vni": 24, "remoteVtepCnt": 3}, {"hostname": "exit02",
@@ -234,7 +239,8 @@ tests:
     "vni": 104001, "remoteVtepCnt": 0}, {"hostname": "leaf01", "vni": 13, "remoteVtepCnt":
     1}, {"hostname": "leaf01", "vni": 104001, "remoteVtepCnt": 0}, {"hostname": "leaf01",
     "vni": 24, "remoteVtepCnt": 1}]'
-- command: evpnVni show --columns='hostname vni remoteVtepCnt remoteVtepList' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni show --columns='hostname vni remoteVtepCnt remoteVtepList' --format=json
+    --namespace='ospf-single dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni show filter cumulus
   output: '[{"hostname": "exit02", "vni": 24, "remoteVtepCnt": 3, "remoteVtepList":
@@ -274,7 +280,8 @@ tests:
     "leaf01", "vni": 13, "remoteVtepCnt": 1, "remoteVtepList": ["10.0.0.134"]}, {"hostname":
     "leaf01", "vni": 104001, "remoteVtepCnt": 0, "remoteVtepList": []}, {"hostname":
     "leaf01", "vni": 24, "remoteVtepCnt": 1, "remoteVtepList": ["10.0.0.134"]}]'
-- command: evpnVni show --columns='hostname vni remoteVtepList' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni show --columns='hostname vni remoteVtepList' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni show filter cumulus
   output: '[{"hostname": "exit02", "vni": 24, "remoteVtepList": ["10.0.0.134", "10.0.0.112",
@@ -306,140 +313,146 @@ tests:
     "exit02", "vni": 104001, "remoteVtepList": []}, {"hostname": "leaf01", "vni":
     13, "remoteVtepList": ["10.0.0.134"]}, {"hostname": "leaf01", "vni": 104001, "remoteVtepList":
     []}, {"hostname": "leaf01", "vni": 24, "remoteVtepList": ["10.0.0.134"]}]'
-- command: evpnVni assert --status=pass --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni assert --result=pass --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni assert cumulus
   output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24.0, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616644822033}, {"namespace":
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822033}, {"namespace":
     "dual-evpn", "hostname": "exit02", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822167},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
     {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
+    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616644822167},
+    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
     {"namespace": "dual-evpn", "hostname": "exit01", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822168}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822169},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822169},
     {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
+    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822253}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822253},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822253},
     {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616681581879},
+    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616681581879},
     {"namespace": "ospf-ibgp", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "vni": 104001.0, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 104001.0, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1616681581987}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616681582166},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582166},
     {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681582386}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616681582523},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582523},
     {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681582726}]'
-- command: evpnVni assert --status=fail --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni assert --result=fail --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni assert cumulus
   output: '[]'
-- command: evpnVni assert --status=all --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni assert --result=all --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni assert cumulus
   output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24.0, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616644822033}, {"namespace":
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822033}, {"namespace":
     "dual-evpn", "hostname": "exit02", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822167},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
     {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
+    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616644822167},
+    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
     {"namespace": "dual-evpn", "hostname": "exit01", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822168}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822169},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822169},
     {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
+    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616644822253}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616644822253},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822253},
     {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1616681581879},
+    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616681581879},
     {"namespace": "ospf-ibgp", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "vni": 104001.0, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 104001.0, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1616681581987}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616681582166},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582166},
     {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681582386}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "assert": "pass", "timestamp": 1616681582523},
+    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582523},
     {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "assert":
+    "-", "result": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
     1616681582726}]'
-- command: evpnVni assert --status=whatever --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni assert --result=whatever --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni assert cumulus
   output: '[]'
-- command: evpnVni unique --columns=vni --format=json --count=True --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni unique --columns=vni --format=json --count=True --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni unique cumulus
   output: '[{"vni": 13, "numRows": 10}, {"vni": 24, "numRows": 10}, {"vni": 104001,
     "numRows": 12}]'
-- command: evpnVni show --priVtepIp='10.0.0.112' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: evpnVni show --priVtepIp='10.0.0.112' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni show cumulus filter
   output: '[{"namespace": "dual-evpn", "hostname": "leaf01", "vni": 24, "type": "L2",

--- a/tests/integration/sqcmds/cumulus-samples/interface.yml
+++ b/tests/integration/sqcmds/cumulus-samples/interface.yml
@@ -1365,7 +1365,8 @@ tests:
     "hostname": "leaf01", "ifname": "swp1", "state": "up", "adminState": "up", "type":
     "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.11/32"],
     "ip6AddressList": ["fe80::5054:ff:fee6:f5c/64"], "timestamp": 1616681582844}]'
-- command: interface show --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface show --columns=hostname --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface show
   output: '[{"hostname": "server102"}, {"hostname": "server102"}, {"hostname": "server102"},
@@ -1527,14 +1528,16 @@ tests:
   output: '[{"type": "bond"}, {"type": "bond_slave"}, {"type": "bridge"}, {"type":
     "ethernet"}, {"type": "loopback"}, {"type": "macvlan"}, {"type": "vlan"}, {"type":
     "vrf"}, {"type": "vxlan"}]'
-- command: interface unique --count=True --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface unique --count=True --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface unique
   output: '[{"type": "macvlan", "numRows": 12}, {"type": "bridge", "numRows": 16},
     {"type": "vxlan", "numRows": 26}, {"type": "bond", "numRows": 32}, {"type": "vrf",
     "numRows": 37}, {"type": "loopback", "numRows": 42}, {"type": "bond_slave", "numRows":
     48}, {"type": "vlan", "numRows": 62}, {"type": "ethernet", "numRows": 166}]'
-- command: interface unique --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface unique --columns=hostname --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface unique
   output: '[{"hostname": "edge01"}, {"hostname": "exit01"}, {"hostname": "exit02"},
@@ -1545,702 +1548,703 @@ tests:
 - command: interface assert --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   error:
-    error: '[{"namespace": "ospf-single", "hostname": "leaf01", "ifname": "vlan10",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
-      "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    error: '[{"namespace": "ospf-single", "hostname": "leaf03", "ifname": "vlan10",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
+      "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
       "hostname": "leaf02", "ifname": "vlan10", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "vlan10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "dual-evpn", "hostname": "edge01",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "vlan10", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "dual-evpn", "hostname": "edge01",
+      "ifname": "eth2.2", "state": "up", "peerHostname": "exit02", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822307}, {"namespace":
+      "dual-evpn", "hostname": "edge01", "ifname": "eth2.3", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2.4",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822307}, {"namespace": "dual-evpn",
+      "hostname": "edge01", "ifname": "eth1.2", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616644822307},
+      {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1.3", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01",
       "ifname": "eth1.4", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822307}, {"namespace":
-      "dual-evpn", "hostname": "edge01", "ifname": "eth1.3", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1.2",
-      "state": "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822307}, {"namespace": "dual-evpn",
-      "hostname": "edge01", "ifname": "eth2.2", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616644822307},
-      {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2.4", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01",
-      "ifname": "eth2.3", "state": "up", "peerHostname": "exit02", "peerIfname": "swp5",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822307}, {"namespace":
-      "dual-evpn", "hostname": "exit01", "ifname": "vlan24", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "exit02", "ifname": "vlan24", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn",
-      "hostname": "exit01", "ifname": "vlan13", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan13", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "exit02", "ifname": "vlan13", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan13", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn",
-      "hostname": "exit01", "ifname": "swp5.3", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth1", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp5.2", "state":
-      "up", "peerHostname": "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
-      "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822307}, {"namespace":
       "dual-evpn", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
       "dual-evpn", "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-      "dual-evpn", "hostname": "exit02", "ifname": "swp5.2", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5.3",
-      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "exit02", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.4", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
-      "ifname": "eth1.3", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681581517}, {"namespace":
-      "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.2", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "vlan13", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "vlan13", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "ifname": "vlan24", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan24", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "vlan24", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan24", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01",
+      "peerIfname": "eth1", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp5.3", "state":
+      "up", "peerHostname": "edge01", "peerIfname": "eth1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "ifname": "swp5.2", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "exit02", "ifname": "swp5.4", "state": "up", "peerHostname":
+      "edge01", "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5.2",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "swp5.3", "state": "up", "peerHostname": "edge01",
+      "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.2", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+      "ifname": "eth1.4", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681581517}, {"namespace":
+      "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.3", "state": "up", "peerHostname":
+      "exit01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
       1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2.4",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
       "hostname": "edge01", "ifname": "eth2.3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681581517},
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616681581517},
       {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2.2", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "exit01",
-      "ifname": "swp5.3", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
-      "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.4",
-      "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+      "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+      "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
+      "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.3", "state": "up", "peerHostname":
+      "edge01", "peerIfname": "eth1", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
       "hostname": "exit01", "ifname": "vlan4001", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582085},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582085},
       {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "vlan4001", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
       "hostname": "leaf03", "ifname": "vlan4001", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
       {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan4001", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
       "hostname": "exit02", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp": 1616681582248},
-      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.2", "state":
-      "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-      "ifname": "swp5.3", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582248}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
-      "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp": 1616681582248},
+      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.3", "state":
+      "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+      "ifname": "swp5.2", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582248}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325},
+      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf01", "ifname": "vlan24", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844},
+      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "ifname": "vlan13", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523},
+      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
-      "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up",
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
+      "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan13", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf01", "ifname": "vlan13", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf04", "ifname": "vlan24", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-single", "hostname": "server102",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up",
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
+      "timestamp": 1616681582844}, {"namespace": "ospf-single", "hostname": "server102",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
       "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352402674}, {"namespace":
       "ospf-single", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352402674}, {"namespace": "ospf-single", "hostname": "server101", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352402674}, {"namespace": "ospf-single", "hostname": "server104", "ifname":
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
       "ospf-single", "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352402700}, {"namespace": "ospf-single", "hostname": "server101", "ifname":
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
+      "ospf-single", "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352402700}, {"namespace": "ospf-single", "hostname": "server103", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
-      "ospf-single", "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352402700}, {"namespace": "ospf-single", "hostname": "server104", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
-      "ospf-single", "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "ospf-single", "hostname": "server104", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352402700}, {"namespace": "ospf-single", "hostname": "edge01", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402916}, {"namespace":
-      "ospf-single", "hostname": "exit02", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "internet", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "ospf-single", "hostname": "leaf03", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf04", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "spine01", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
       "ospf-single", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname":
-      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine01", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf01",
-      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
-      "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02",
-      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
-      "swp4", "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit01", "ifname": "swp3", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp6", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit01",
-      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp6",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname":
-      "swp4", "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-      "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "spine01", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine01", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-      "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "spine01", "ifname": "swp5", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf03",
-      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
+      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "swp6", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
+      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "internet", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp5", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
+      "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
       "ospf-single", "hostname": "leaf04", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname":
-      "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp4", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "dual-evpn",
-      "hostname": "server102", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616644822254}, {"namespace": "dual-evpn", "hostname": "server101", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
-      "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
-      "dual-evpn", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822254},
-      {"namespace": "dual-evpn", "hostname": "server102", "ifname": "eth2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server103",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
-      "dual-evpn", "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "spine01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
+      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname": "exit02",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
+      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03",
+      "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "spine01", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
+      "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
+      "exit01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
+      "swp6", "state": "up", "peerHostname": "exit01", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
+      "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp1", "state":
+      "up", "peerHostname": "spine01", "peerIfname": "swp3", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit02",
+      "ifname": "swp4", "state": "up", "peerHostname": "exit02", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf03", "ifname":
+      "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp3", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp4", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp3", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit01",
+      "ifname": "swp3", "state": "up", "peerHostname": "exit01", "peerIfname": "swp4",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
+      "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp6", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "exit02", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp1", "state":
+      "up", "peerHostname": "spine01", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02",
+      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
+      "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "dual-evpn",
+      "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616644822254}, {"namespace": "dual-evpn", "hostname": "server103", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn",
       "hostname": "server103", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
+      "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server103", "ifname": "eth2", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254},
+      {"namespace": "dual-evpn", "hostname": "server102", "ifname": "eth2", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server101",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server102", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616644822254}, {"namespace": "dual-evpn", "hostname": "server101", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
-      "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822254},
+      "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254},
+      {"namespace": "dual-evpn", "hostname": "server101", "ifname": "eth1", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server102",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn",
+      "hostname": "server104", "ifname": "eth2", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822255},
       {"namespace": "dual-evpn", "hostname": "server104", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644822255}, {"namespace": "dual-evpn", "hostname":
       "server104", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644822255}, {"namespace":
-      "dual-evpn", "hostname": "server104", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822255},
-      {"namespace": "dual-evpn", "hostname": "server104", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822255}, {"namespace": "dual-evpn", "hostname":
-      "edge01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822307},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822880},
-      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822255}, {"namespace":
+      "dual-evpn", "hostname": "server104", "ifname": "bond0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822255}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth0",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname":
+      "spine02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
       "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-      "dual-evpn", "hostname": "leaf03", "ifname": "swp5", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond01", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
-      "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn",
-      "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "leaf04", "ifname": "bond01", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
-      "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "internet", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname":
-      "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823051},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace": "dual-evpn",
-      "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823051},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "bond02", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace": "dual-evpn",
-      "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-      "dual-evpn", "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147},
-      {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "bond02", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823147}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp5", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn",
+      "hostname": "leaf03", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "exit01", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "eth0",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+      "leaf04", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "peerlink", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp6", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond01", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "internet", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644823003}, {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "bond02",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "ifname": "bond01", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823051},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp5", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823051},
+      {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname":
+      "leaf02", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "ifname": "bond01", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147},
       {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "edge01",
-      "ifname": "eth1", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "fail", "assertReason": ["Speed mismatch"], "timestamp": 1616644822307},
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+      "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147},
       {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "fail", "assertReason":
+      "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "fail", "assertReason":
       ["Speed mismatch"], "timestamp": 1616644822307}, {"namespace": "dual-evpn",
-      "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp5", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine02",
+      "hostname": "edge01", "ifname": "eth1", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp5", "result": "fail", "assertReason": ["Speed mismatch"],
+      "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "spine02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result": "fail", "assertReason":
+      ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
+      "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+      "swp2", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp6", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine02",
       "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp2",
-      "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp2", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine02", "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "swp2", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp1", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine01", "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616644822880}, {"namespace":
-      "dual-evpn", "hostname": "spine01", "ifname": "swp5", "state": "up", "peerHostname":
-      "exit02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01", "ifname":
-      "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1", "assert":
-      "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880}, {"namespace":
-      "dual-evpn", "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01",
-      "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1",
-      "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
-      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp1", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp1", "assert": "fail", "assertReason":
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp5", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine01",
+      "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
-      "leaf03", "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-      "dual-evpn", "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth1", "assert": "fail", "assertReason": ["Speed mismatch"],
+      "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
+      "swp1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp5", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01",
+      "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822880}, {"namespace":
+      "dual-evpn", "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname":
+      "leaf03", "peerIfname": "swp1", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname": "leaf03",
+      "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp4",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "swp3", "state": "up", "peerHostname":
+      "leaf04", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp3", "result": "fail",
+      "assertReason": ["MTU mismatch"], "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp3", "result": "fail", "assertReason": ["MTU mismatch"],
       "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "ifname": "swp5", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+      "result": "fail", "assertReason": ["Speed mismatch"], "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp6", "state":
+      "up", "peerHostname": "internet", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
       "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp6",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
       "dual-evpn", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp4",
-      "state": "up", "peerHostname": "leaf04", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn",
-      "hostname": "exit01", "ifname": "swp6", "state": "up", "peerHostname": "internet",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
-      "leaf03", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-      "swp3", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp1", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
-      "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp4", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-      "dual-evpn", "hostname": "exit02", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+      "spine01", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "result": "fail",
+      "assertReason": ["MTU mismatch"], "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp4", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "swp4", "state": "up", "peerHostname":
+      "leaf03", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
       1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5",
-      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "fail",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "fail",
       "assertReason": ["Speed mismatch"], "timestamp": 1616644822983}, {"namespace":
-      "dual-evpn", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
-      "internet", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "internet", "ifname": "swp2", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp": 1616644823003},
-      {"namespace": "dual-evpn", "hostname": "internet", "ifname": "swp1", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp6", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
-      "dual-evpn", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
+      "dual-evpn", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
+      "spine01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp2",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname": "internet",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "internet", "ifname": "swp2", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname": "internet",
+      "ifname": "swp1", "state": "up", "peerHostname": "exit01", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823003}, {"namespace":
       "dual-evpn", "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-      "dual-evpn", "hostname": "leaf02", "ifname": "swp3", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
+      "spine01", "peerIfname": "swp1", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp1",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644823051},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace":
+      "dual-evpn", "hostname": "leaf02", "ifname": "swp4", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
       1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "assert": "fail",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "result": "fail",
       "assertReason": ["MTU mismatch"], "timestamp": 1616644823147}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp2", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644823147}, {"namespace": "ospf-ibgp", "hostname": "server101",
-      "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581492}, {"namespace":
-      "ospf-ibgp", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581492},
+      "spine01", "peerIfname": "swp2", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+      "ospf-ibgp", "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681581492}, {"namespace": "ospf-ibgp",
+      "hostname": "server101", "ifname": "eth1", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581492},
       {"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581492}, {"namespace": "ospf-ibgp", "hostname":
-      "server101", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681581492}, {"namespace":
-      "ospf-ibgp", "hostname": "server103", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
+      "server103", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581509},
+      {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth2", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
       "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
       "hostname": "server104", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
-      "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581517},
-      {"namespace": "ospf-ibgp", "hostname": "server104", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616681581517}, {"namespace":
+      "ospf-ibgp", "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581517},
+      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
-      "edge01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581517},
-      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname":
-      "server102", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681581595}, {"namespace":
-      "ospf-ibgp", "hostname": "server102", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581595},
-      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname":
-      "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582085},
-      {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
-      "exit02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582248},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname":
-      "leaf02", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf02", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-      "ospf-ibgp", "hostname": "internet", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616681582344}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
-      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582391},
-      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-      "leaf04", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-      {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
-      "leaf01", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582844},
+      "server102", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581595},
+      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth2", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681581595}, {"namespace": "ospf-ibgp",
+      "hostname": "server102", "ifname": "eth0", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681581595}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "eth0",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
+      "spine01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582129},
+      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf02", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp5",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+      "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325},
+      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "bond01", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "internet",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582344}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
+      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582523},
+      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "ifname": "peerlink", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523},
+      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "spine02", "ifname": "eth0", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp6",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844},
       {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "bond02", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "edge01",
-      "ifname": "eth1", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "fail", "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp":
-      1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "fail",
-      "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681581517},
-      {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp1", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "swp6", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
-      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp6",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582844},
+      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "fail", "assertReason":
+      ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681581517}, {"namespace":
+      "ospf-ibgp", "hostname": "edge01", "ifname": "eth2", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp5", "result": "fail", "assertReason": ["MTU mismatch",
+      "Speed mismatch"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
+      "exit01", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+      "swp6", "result": "pass", "assertReason": "-", "timestamp": 1616681582085},
+      {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "state":
+      "up", "peerHostname": "spine02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+      "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
       "ospf-ibgp", "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth1", "assert": "fail", "assertReason": ["MTU mismatch",
+      "edge01", "peerIfname": "eth1", "result": "fail", "assertReason": ["MTU mismatch",
       "Speed mismatch"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
-      "exit01", "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
-      "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname":
-      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
-      "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582129},
-      {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-      "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582129}, {"namespace":
+      "spine01", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+      "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582129},
+      {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582129}, {"namespace":
       "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582129}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp6",
-      "state": "up", "peerHostname": "internet", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
-      "hostname": "exit02", "ifname": "swp5", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth2", "assert": "fail", "assertReason": ["MTU mismatch", "Speed
-      mismatch"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
-      "exit02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681582248}, {"namespace":
-      "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf02", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-      "ospf-ibgp", "hostname": "internet", "ifname": "swp1", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582344}, {"namespace": "ospf-ibgp", "hostname": "internet", "ifname":
-      "swp2", "state": "up", "peerHostname": "exit02", "peerIfname": "swp6", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582344}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
-      "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
-      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
+      "exit01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname":
+      "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+      "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04",
+      "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582129},
+      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "state":
+      "up", "peerHostname": "spine01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582248}, {"namespace":
+      "ospf-ibgp", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
+      "internet", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "fail",
+      "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681582248},
+      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf01", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+      "hostname": "internet", "ifname": "swp1", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp": 1616681582344},
+      {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "swp2", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp3",
+      "state": "up", "peerHostname": "leaf04", "peerIfname": "swp3", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname": "leaf04",
+      "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
       {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp4", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "up", "peerHostname": "leaf03", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
       "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace":
-      "ospf-ibgp", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname":
-      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
-      "hostname": "spine02", "ifname": "swp3", "state": "up", "peerHostname": "leaf03",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616681582843},
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582843},
       {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-      "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582843}, {"namespace":
-      "ospf-ibgp", "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf02", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582844}]'
+      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582843}, {"namespace":
+      "ospf-ibgp", "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname":
+      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+      "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582843},
+      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582844}]'
   marks: interface assert
-- command: interface top --what='statusChangeTimestamp' --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface top --what='statusChangeTimestamp' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface top
   output: '[{"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond02", "state":
@@ -2260,1396 +2264,1401 @@ tests:
     "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave",
     "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList":
     [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582391}]'
-- command: interface assert --status=pass --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface assert --result=pass --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface assert cumulus
-  output: '[{"namespace": "ospf-single", "hostname": "leaf01", "ifname": "vlan10",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
-    "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+  output: '[{"namespace": "ospf-single", "hostname": "leaf03", "ifname": "vlan10",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
+    "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
     "hostname": "leaf02", "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "leaf03", "ifname": "vlan10", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-    {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1.4", "state":
-    "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01",
-    "ifname": "eth1.3", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-    "assert": "pass", "assertReason": [], "timestamp": 1616644822307}, {"namespace":
-    "dual-evpn", "hostname": "edge01", "ifname": "eth1.2", "state": "up", "peerHostname":
-    "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2.2",
-    "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname":
-    "edge01", "ifname": "eth2.4", "state": "up", "peerHostname": "exit02", "peerIfname":
-    "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616644822307}, {"namespace":
-    "dual-evpn", "hostname": "edge01", "ifname": "eth2.3", "state": "up", "peerHostname":
-    "exit02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822307}, {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "vlan24",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn",
-    "hostname": "leaf04", "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-    "dual-evpn", "hostname": "exit02", "ifname": "vlan24", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan24", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-    "dual-evpn", "hostname": "leaf03", "ifname": "vlan13", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "vlan13", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02",
-    "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
-    "dual-evpn", "hostname": "leaf02", "ifname": "vlan13", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147},
-    {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp5.3", "state":
-    "up", "peerHostname": "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "ifname": "swp5.2", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
-    "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-    "dual-evpn", "hostname": "exit01", "ifname": "swp5.4", "state": "up", "peerHostname":
-    "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "peerlink.4094",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "leaf01", "ifname": "vlan10", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+    {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2.2", "state":
+    "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01",
+    "ifname": "eth2.3", "state": "up", "peerHostname": "exit02", "peerIfname": "swp5",
+    "result": "pass", "assertReason": "-", "timestamp": 1616644822307}, {"namespace":
+    "dual-evpn", "hostname": "edge01", "ifname": "eth2.4", "state": "up", "peerHostname":
+    "exit02", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1.2",
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname":
+    "edge01", "ifname": "eth1.3", "state": "up", "peerHostname": "exit01", "peerIfname":
+    "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616644822307}, {"namespace":
+    "dual-evpn", "hostname": "edge01", "ifname": "eth1.4", "state": "up", "peerHostname":
+    "exit01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822307}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "peerlink.4094",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
     "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname": "",
-    "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
     "dual-evpn", "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823051},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823051},
     {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "peerlink.4094", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "exit02",
-    "ifname": "swp5.2", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
-    "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-    "dual-evpn", "hostname": "exit02", "ifname": "swp5.3", "state": "up", "peerHostname":
-    "edge01", "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5.4",
-    "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644822983}, {"namespace": "ospf-ibgp", "hostname":
-    "edge01", "ifname": "eth1.4", "state": "up", "peerHostname": "exit01", "peerIfname":
-    "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681581517}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.3", "state": "up", "peerHostname":
-    "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.2",
-    "state": "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf03",
+    "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+    "dual-evpn", "hostname": "leaf04", "ifname": "vlan13", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+    {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "vlan13", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf01",
+    "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
+    "hostname": "leaf02", "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+    "dual-evpn", "hostname": "exit01", "ifname": "vlan24", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+    {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan24", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
+    "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+    "dual-evpn", "hostname": "leaf01", "ifname": "vlan24", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823051},
+    {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "vlan24", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "exit01",
+    "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+    "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+    "dual-evpn", "hostname": "exit01", "ifname": "swp5.3", "state": "up", "peerHostname":
+    "edge01", "peerIfname": "eth1", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp5.2",
+    "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+    "exit02", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname":
+    "eth2", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+    "dual-evpn", "hostname": "exit02", "ifname": "swp5.2", "state": "up", "peerHostname":
+    "edge01", "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5.3",
+    "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "ospf-ibgp", "hostname":
+    "edge01", "ifname": "eth1.2", "state": "up", "peerHostname": "exit01", "peerIfname":
+    "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616681581517}, {"namespace":
+    "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.4", "state": "up", "peerHostname":
+    "exit01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.3",
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
     "edge01", "ifname": "eth2.4", "state": "up", "peerHostname": "exit02", "peerIfname":
-    "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681581517}, {"namespace":
+    "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616681581517}, {"namespace":
     "ospf-ibgp", "hostname": "edge01", "ifname": "eth2.3", "state": "up", "peerHostname":
-    "exit02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+    "exit02", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
     1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2.2",
-    "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
-    "exit01", "ifname": "swp5.3", "state": "up", "peerHostname": "edge01", "peerIfname":
-    "eth1", "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2", "state": "up", "peerHostname":
-    "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.4",
-    "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
+    "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
+    "exit01", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname":
+    "eth1", "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.3", "state": "up", "peerHostname":
+    "edge01", "peerIfname": "eth1", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2",
+    "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
     "exit01", "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
     "ospf-ibgp", "hostname": "exit02", "ifname": "vlan4001", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582248},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582248},
     {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan4001", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
     "hostname": "leaf04", "ifname": "vlan4001", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523},
     {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan4001", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "exit02",
     "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
-    "assert": "pass", "assertReason": [], "timestamp": 1616681582248}, {"namespace":
-    "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.2", "state": "up", "peerHostname":
-    "edge01", "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.3",
-    "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf02", "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink.4094", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681582248}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.3", "state": "up", "peerHostname":
+    "edge01", "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.2",
+    "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf02", "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan24", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan13", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan13", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "peerlink.4094", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink.4094", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
     "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname": "",
-    "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan13", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844},
+    {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp5", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
+    "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
     "ospf-single", "hostname": "leaf01", "ifname": "swp5", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-    {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp5", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
-    "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "leaf03", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-    1616352404640}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp2",
-    "state": "up", "peerHostname": "spine02", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
-    "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-    {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp3", "state":
-    "up", "peerHostname": "exit02", "peerIfname": "swp4", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit02",
-    "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp5",
-    "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "leaf02", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-    1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp1",
-    "state": "up", "peerHostname": "spine01", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "exit01", "ifname": "swp4", "state": "up", "peerHostname": "exit01",
-    "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-    {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp3", "state":
-    "up", "peerHostname": "exit01", "peerIfname": "swp4", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit01",
-    "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp6",
-    "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp1", "state":
+    "up", "peerHostname": "leaf01", "peerIfname": "swp2", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
+    "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp4",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
+    "leaf02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
     1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-    "swp6", "state": "up", "peerHostname": "exit01", "peerIfname": "swp2", "assert":
-    "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "exit02", "ifname": "swp4", "state": "up", "peerHostname": "exit02",
-    "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp5", "state":
-    "up", "peerHostname": "exit02", "peerIfname": "swp2", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
-    "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp2",
-    "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "spine02", "ifname": "swp3", "state": "up", "peerHostname":
-    "leaf03", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-    1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-    "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "assert":
-    "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01",
-    "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-    {"namespace": "ospf-single", "hostname": "spine01", "ifname": "swp6", "state":
-    "up", "peerHostname": "exit01", "peerIfname": "swp1", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
-    "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp1",
-    "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname":
-    "leaf03", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
+    "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp2", "result":
+    "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    "hostname": "spine02", "ifname": "swp4", "state": "up", "peerHostname": "leaf04",
+    "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp3", "state":
+    "up", "peerHostname": "leaf03", "peerIfname": "swp2", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
+    "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "spine01", "ifname": "swp2", "state": "up", "peerHostname":
+    "leaf02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
     1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "assert":
-    "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname": "leaf01",
-    "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
+    "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1", "result":
+    "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04",
+    "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
     {"namespace": "ospf-single", "hostname": "spine01", "ifname": "swp5", "state":
-    "up", "peerHostname": "exit02", "peerIfname": "swp1", "assert": "pass", "assertReason":
-    [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf03",
-    "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp3",
-    "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-    "ospf-single", "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
-    1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname": "swp1",
-    "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "pass",
-    "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-    "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-    "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
+    "up", "peerHostname": "exit02", "peerIfname": "swp1", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
+    "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname": "swp1",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
+    "exit01", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+    1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp4", "result": "pass",
+    "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
+    "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+    {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp4", "state":
+    "up", "peerHostname": "exit02", "peerIfname": "swp3", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit02",
+    "ifname": "swp3", "state": "up", "peerHostname": "exit02", "peerIfname": "swp4",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
+    "spine02", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+    1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp1",
+    "state": "up", "peerHostname": "spine01", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    "hostname": "exit01", "ifname": "swp4", "state": "up", "peerHostname": "exit01",
+    "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+    {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp3", "state":
+    "up", "peerHostname": "exit01", "peerIfname": "swp4", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit01",
+    "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp6",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+    1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
+    "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+    {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp2", "state":
+    "up", "peerHostname": "spine02", "peerIfname": "swp2", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf01",
+    "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp1",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+    "ospf-single", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+    1616352404640}, {"namespace": "dual-evpn", "hostname": "server103", "ifname":
+    "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname":
+    "server103", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254}, {"namespace":
+    "dual-evpn", "hostname": "server102", "ifname": "eth2", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254},
     {"namespace": "dual-evpn", "hostname": "server101", "ifname": "eth2", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server102",
-    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
-    "hostname": "server102", "ifname": "eth2", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822254},
-    {"namespace": "dual-evpn", "hostname": "server103", "ifname": "eth2", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server101",
-    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
-    "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822254},
-    {"namespace": "dual-evpn", "hostname": "server104", "ifname": "eth1", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822255}, {"namespace": "dual-evpn", "hostname": "server104",
-    "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822255}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp5", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond01",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-    "dual-evpn", "hostname": "leaf04", "ifname": "peerlink", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond01", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-    "hostname": "leaf04", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-    "dual-evpn", "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp6", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp5",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-    "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
-    "dual-evpn", "hostname": "leaf01", "ifname": "bond01", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823051},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp5", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "peerlink",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn",
-    "hostname": "leaf02", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-    "dual-evpn", "hostname": "leaf02", "ifname": "swp6", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147},
-    {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp6", "state": "up",
-    "peerHostname": "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason":
-    [], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine02",
-    "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp2",
-    "assert": "pass", "assertReason": [], "timestamp": 1616644822831}, {"namespace":
-    "dual-evpn", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
-    "exit01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp5",
-    "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
-    "leaf03", "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname":
-    "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-    "dual-evpn", "hostname": "exit01", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp1",
-    "state": "up", "peerHostname": "spine01", "peerIfname": "swp6", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
-    "leaf03", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
-    "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-    "dual-evpn", "hostname": "exit01", "ifname": "swp6", "state": "up", "peerHostname":
-    "internet", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp3",
-    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
-    "leaf04", "ifname": "swp4", "state": "up", "peerHostname": "leaf03", "peerIfname":
-    "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-    "dual-evpn", "hostname": "exit02", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-    1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp6",
-    "state": "up", "peerHostname": "internet", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
-    "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-    "dual-evpn", "hostname": "internet", "ifname": "swp2", "state": "up", "peerHostname":
-    "exit02", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-    1616644823003}, {"namespace": "dual-evpn", "hostname": "internet", "ifname": "swp1",
-    "state": "up", "peerHostname": "exit01", "peerIfname": "swp6", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname":
-    "leaf01", "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname":
-    "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
-    "dual-evpn", "hostname": "leaf01", "ifname": "swp3", "state": "up", "peerHostname":
-    "leaf02", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
-    1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp4",
-    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp4", "assert": "pass",
-    "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname":
-    "leaf02", "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname":
-    "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-    "ospf-ibgp", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581492},
-    {"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth1", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server103",
-    "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
-    "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581509},
-    {"namespace": "ospf-ibgp", "hostname": "server104", "ifname": "eth2", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104",
-    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server101",
+    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn",
     "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581595},
-    {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth2", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp5", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp6",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
-    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp5", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp5",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254},
+    {"namespace": "dual-evpn", "hostname": "server104", "ifname": "eth2", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822255}, {"namespace": "dual-evpn", "hostname": "server104",
+    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644822255}, {"namespace": "dual-evpn",
+    "hostname": "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "",
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+    {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond02", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
+    "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn",
+    "hostname": "leaf03", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+    "dual-evpn", "hostname": "leaf03", "ifname": "swp6", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+    {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond02", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
+    "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+    "hostname": "leaf04", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+    "dual-evpn", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+    {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond01", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf01",
+    "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
     "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp5", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp6",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
-    "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
-    "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp": 1616681582085},
-    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "state": "up",
-    "peerHostname": "spine02", "peerIfname": "swp6", "assert": "pass", "assertReason":
-    [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
-    "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname": "swp1",
-    "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
-    "leaf01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp2",
-    "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
-    "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname":
-    "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582129}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname":
-    "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp5",
-    "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
-    "spine01", "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname":
-    "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582129}, {"namespace":
-    "ospf-ibgp", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
-    "internet", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp2",
-    "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681582248}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2",
-    "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf02", "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname":
-    "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp4", "state": "up", "peerHostname":
-    "leaf01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "swp1",
-    "state": "up", "peerHostname": "exit01", "peerIfname": "swp6", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname":
-    "internet", "ifname": "swp2", "state": "up", "peerHostname": "exit02", "peerIfname":
-    "swp6", "assert": "pass", "assertReason": [], "timestamp": 1616681582344}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2",
-    "state": "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname":
-    "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname":
-    "leaf04", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
-    "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-    "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp4", "state": "up", "peerHostname":
-    "leaf03", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp3",
-    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname":
-    "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616681582843}, {"namespace":
-    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
-    "leaf02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp3",
-    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
-    "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616681582843}, {"namespace":
-    "ospf-ibgp", "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname":
-    "exit02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp1",
-    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf01", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp3",
-    "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3", "assert": "pass",
-    "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname":
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823051},
+    {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "bond01", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+    "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
+    "hostname": "leaf01", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace":
+    "dual-evpn", "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147},
+    {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "bond01", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
+    "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+    "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+    "dual-evpn", "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147},
+    {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp6", "state": "up",
+    "peerHostname": "exit01", "peerIfname": "swp2", "result": "pass", "assertReason":
+    "-", "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine02",
+    "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp2",
+    "result": "pass", "assertReason": "-", "timestamp": 1616644822831}, {"namespace":
+    "dual-evpn", "hostname": "spine01", "ifname": "swp5", "state": "up", "peerHostname":
+    "exit02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp6",
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
+    "leaf03", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
+    "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+    "dual-evpn", "hostname": "leaf03", "ifname": "swp3", "state": "up", "peerHostname":
+    "leaf04", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp6",
+    "state": "up", "peerHostname": "internet", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+    "exit01", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
+    "swp6", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+    "dual-evpn", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp3",
+    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
+    "leaf04", "ifname": "swp4", "state": "up", "peerHostname": "leaf03", "peerIfname":
+    "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+    "dual-evpn", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+    1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
+    "exit02", "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+    "dual-evpn", "hostname": "internet", "ifname": "swp2", "state": "up", "peerHostname":
+    "exit02", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+    1616644823003}, {"namespace": "dual-evpn", "hostname": "internet", "ifname": "swp1",
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp6", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname":
     "leaf01", "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname":
-    "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}]'
-- command: interface assert --status=fail --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+    "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace":
+    "dual-evpn", "hostname": "leaf01", "ifname": "swp3", "state": "up", "peerHostname":
+    "leaf02", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+    1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp4",
+    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp4", "result": "pass",
+    "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname":
+    "leaf02", "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname":
+    "swp3", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+    "ospf-ibgp", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581492},
+    {"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth1", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server103",
+    "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
+    "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname": "",
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server104", "ifname": "eth2", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104",
+    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+    "hostname": "server102", "ifname": "eth2", "state": "up", "peerHostname": "",
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581595},
+    {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth1", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "bond02", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond02", "state":
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp5", "state": "up",
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp6", "state": "up", "peerHostname":
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp5", "state": "up",
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "peerlink",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp6", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
+    "exit01", "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
+    "leaf01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp2",
+    "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582129}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
+    "exit01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp5",
+    "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582129}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
+    "exit02", "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582248}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp4", "state": "up", "peerHostname":
+    "leaf01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp3",
+    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp3", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "swp1",
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp6", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname":
+    "internet", "ifname": "swp2", "state": "up", "peerHostname": "exit02", "peerIfname":
+    "swp6", "result": "pass", "assertReason": "-", "timestamp": 1616681582344}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname":
+    "spine01", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp3", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf03", "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname":
+    "swp3", "result": "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname":
+    "leaf04", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp4",
+    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp4", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname":
+    "swp3", "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname":
+    "spine02", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
+    "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582843}, {"namespace":
+    "ospf-ibgp", "hostname": "spine02", "ifname": "swp4", "state": "up", "peerHostname":
+    "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp3",
+    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582843}, {"namespace":
+    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
+    "leaf02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp6",
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp2", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf01", "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname":
+    "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp3", "state": "up", "peerHostname":
+    "leaf02", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2",
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf01", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582844}]'
+- command: interface assert --result=fail --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "ospf-single", "hostname": "server102", "ifname": "eth0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616352402674}, {"namespace": "ospf-single",
       "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352402674}, {"namespace": "ospf-single", "hostname": "server101", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352402674}, {"namespace": "ospf-single", "hostname": "server104", "ifname":
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
       "ospf-single", "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352402700}, {"namespace": "ospf-single", "hostname": "server101", "ifname":
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
+      "ospf-single", "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352402700}, {"namespace": "ospf-single", "hostname": "server103", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
-      "ospf-single", "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352402700}, {"namespace": "ospf-single", "hostname": "server104", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
-      "ospf-single", "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "ospf-single", "hostname": "server104", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352402700}, {"namespace": "ospf-single", "hostname": "edge01", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402916}, {"namespace":
-      "ospf-single", "hostname": "exit02", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "internet", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname":
-      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "ospf-single", "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
       "ospf-single", "hostname": "spine02", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "exit01", "ifname": "swp6", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "ospf-single", "hostname": "exit02", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname":
+      "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit02", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
-      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf02", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "internet", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
       "ospf-single", "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "leaf04", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
-      "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
-      "dual-evpn", "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
-      "dual-evpn", "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616644822254}, {"namespace": "dual-evpn", "hostname": "server101", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "dual-evpn", "hostname": "server103", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
       "dual-evpn", "hostname": "server103", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
+      "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616644822254}, {"namespace": "dual-evpn", "hostname": "server104", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616644822255}, {"namespace":
       "dual-evpn", "hostname": "server104", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616644822255}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname":
       "spine02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822831},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822831},
       {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
       "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822941},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822941},
       {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
-      "exit02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
       "internet", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823003},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823003},
       {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname":
       "leaf02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823147},
-      {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "fail", "assertReason":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823147},
+      {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "fail", "assertReason":
       ["Speed mismatch"], "timestamp": 1616644822307}, {"namespace": "dual-evpn",
-      "hostname": "edge01", "ifname": "eth2", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp5", "assert": "fail", "assertReason": ["Speed mismatch"],
+      "hostname": "edge01", "ifname": "eth1", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp5", "result": "fail", "assertReason": ["Speed mismatch"],
       "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "spine02",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp2",
-      "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp2", "assert": "fail", "assertReason":
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine02", "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "swp2", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp1", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert": "fail", "assertReason":
+      "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+      "swp2", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname":
-      "swp1", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
-      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "assert": "fail", "assertReason":
+      "spine01", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+      "swp1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
-      "spine01", "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "swp1", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
-      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp1", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp1", "assert": "fail", "assertReason":
+      "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
+      "swp1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp3", "state":
+      "up", "peerHostname": "leaf03", "peerIfname": "swp1", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
-      "exit01", "ifname": "swp5", "state": "up", "peerHostname": "edge01", "peerIfname":
-      "eth1", "assert": "fail", "assertReason": ["Speed mismatch"], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
       "leaf03", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-      "swp3", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822941},
+      "swp3", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp2", "state":
+      "up", "peerHostname": "spine02", "peerIfname": "swp3", "result": "fail", "assertReason":
+      ["MTU mismatch"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+      "exit01", "ifname": "swp5", "state": "up", "peerHostname": "edge01", "peerIfname":
+      "eth1", "result": "fail", "assertReason": ["Speed mismatch"], "timestamp": 1616644822941},
       {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp1", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "fail", "assertReason":
+      "up", "peerHostname": "spine01", "peerIfname": "swp4", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
       "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp4", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822983},
+      "swp4", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822983},
       {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5", "state":
-      "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "fail", "assertReason":
+      "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "fail", "assertReason":
       ["Speed mismatch"], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp":
-      1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "assert": "fail",
+      "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
+      "peerIfname": "swp1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp2",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp1", "result": "fail",
       "assertReason": ["MTU mismatch"], "timestamp": 1616644823051}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp2", "assert": "fail", "assertReason": ["MTU mismatch"],
+      "spine02", "peerIfname": "swp2", "result": "fail", "assertReason": ["MTU mismatch"],
       "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
       "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp2",
-      "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644823147},
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644823147},
       {"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581492}, {"namespace": "ospf-ibgp", "hostname":
       "server101", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581492},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581492},
       {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581509}, {"namespace": "ospf-ibgp", "hostname":
       "server103", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581509},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581509},
       {"namespace": "ospf-ibgp", "hostname": "server104", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
       "server104", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581517},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581517},
       {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
-      "server102", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581595},
-      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "server102", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581595},
+      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname":
       "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582085},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582085},
       {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
       "exit02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582248},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582248},
       {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname":
       "internet", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582344},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582344},
       {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
       "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582523},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582523},
       {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
       "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582844},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582844},
       {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "fail", "assertReason":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "fail", "assertReason":
       ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681581517}, {"namespace":
       "ospf-ibgp", "hostname": "edge01", "ifname": "eth2", "state": "up", "peerHostname":
-      "exit02", "peerIfname": "swp5", "assert": "fail", "assertReason": ["MTU mismatch",
+      "exit02", "peerIfname": "swp5", "result": "fail", "assertReason": ["MTU mismatch",
       "Speed mismatch"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
       "exit01", "ifname": "swp5", "state": "up", "peerHostname": "edge01", "peerIfname":
-      "eth1", "assert": "fail", "assertReason": ["MTU mismatch", "Speed mismatch"],
+      "eth1", "result": "fail", "assertReason": ["MTU mismatch", "Speed mismatch"],
       "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit02",
       "ifname": "swp5", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
-      "assert": "fail", "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp":
+      "result": "fail", "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp":
       1616681582248}]'
   marks: interface assert cumulus
-- command: interface assert --status=all --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface assert --result=all --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   error:
-    error: '[{"namespace": "ospf-single", "hostname": "leaf01", "ifname": "vlan10",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
-      "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+    error: '[{"namespace": "ospf-single", "hostname": "leaf03", "ifname": "vlan10",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04",
+      "ifname": "vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
       "hostname": "leaf02", "ifname": "vlan10", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "vlan10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "dual-evpn", "hostname": "edge01",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "vlan10", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "dual-evpn", "hostname": "edge01",
+      "ifname": "eth2.2", "state": "up", "peerHostname": "exit02", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822307}, {"namespace":
+      "dual-evpn", "hostname": "edge01", "ifname": "eth2.3", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2.4",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822307}, {"namespace": "dual-evpn",
+      "hostname": "edge01", "ifname": "eth1.2", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616644822307},
+      {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1.3", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01",
       "ifname": "eth1.4", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822307}, {"namespace":
-      "dual-evpn", "hostname": "edge01", "ifname": "eth1.3", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth1.2",
-      "state": "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822307}, {"namespace": "dual-evpn",
-      "hostname": "edge01", "ifname": "eth2.2", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616644822307},
-      {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2.4", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "edge01",
-      "ifname": "eth2.3", "state": "up", "peerHostname": "exit02", "peerIfname": "swp5",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822307}, {"namespace":
-      "dual-evpn", "hostname": "exit01", "ifname": "vlan24", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "exit02", "ifname": "vlan24", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn",
-      "hostname": "exit01", "ifname": "vlan13", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan13", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "exit02", "ifname": "vlan13", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan13", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace": "dual-evpn",
-      "hostname": "exit01", "ifname": "swp5.3", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth1", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp5.2", "state":
-      "up", "peerHostname": "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
-      "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822307}, {"namespace":
       "dual-evpn", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
       "dual-evpn", "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-      "dual-evpn", "hostname": "exit02", "ifname": "swp5.2", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5.3",
-      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "exit02", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.4", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
-      "ifname": "eth1.3", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681581517}, {"namespace":
-      "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.2", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "vlan13", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "vlan13", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "ifname": "vlan24", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "vlan24", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "vlan24", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "vlan24", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01",
+      "peerIfname": "eth1", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp5.3", "state":
+      "up", "peerHostname": "edge01", "peerIfname": "eth1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "ifname": "swp5.2", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "exit02", "ifname": "swp5.4", "state": "up", "peerHostname":
+      "edge01", "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5.2",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "swp5.3", "state": "up", "peerHostname": "edge01",
+      "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.2", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+      "ifname": "eth1.4", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681581517}, {"namespace":
+      "ospf-ibgp", "hostname": "edge01", "ifname": "eth1.3", "state": "up", "peerHostname":
+      "exit01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
       1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2.4",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
       "hostname": "edge01", "ifname": "eth2.3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681581517},
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616681581517},
       {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2.2", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "exit01",
-      "ifname": "swp5.3", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
-      "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth1", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.4",
-      "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+      "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+      "ifname": "swp5.4", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
+      "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.3", "state": "up", "peerHostname":
+      "edge01", "peerIfname": "eth1", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth1", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
       "hostname": "exit01", "ifname": "vlan4001", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582085},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582085},
       {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "vlan4001", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
       "hostname": "leaf03", "ifname": "vlan4001", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
       {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan4001", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "vlan4001", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
       "hostname": "exit02", "ifname": "swp5.4", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth2", "assert": "pass", "assertReason": [], "timestamp": 1616681582248},
-      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.2", "state":
-      "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-      "ifname": "swp5.3", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582248}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
-      "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "peerIfname": "eth2", "result": "pass", "assertReason": "-", "timestamp": 1616681582248},
+      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.3", "state":
+      "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+      "ifname": "swp5.2", "state": "up", "peerHostname": "edge01", "peerIfname": "eth2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582248}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325},
+      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf01", "ifname": "vlan24", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844},
+      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "ifname": "vlan13", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523},
+      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan13", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink.4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
-      "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up",
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
+      "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan13", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-      "ifname": "vlan13", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf01", "ifname": "vlan13", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "vlan24", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf04", "ifname": "vlan24", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan24", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-single", "hostname": "server102",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up",
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
+      "timestamp": 1616681582844}, {"namespace": "ospf-single", "hostname": "server102",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
       "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352402674}, {"namespace":
       "ospf-single", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352402674}, {"namespace": "ospf-single", "hostname": "server101", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352402674}, {"namespace": "ospf-single", "hostname": "server104", "ifname":
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
       "ospf-single", "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352402700}, {"namespace": "ospf-single", "hostname": "server101", "ifname":
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
+      "ospf-single", "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352402700}, {"namespace": "ospf-single", "hostname": "server103", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
-      "ospf-single", "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352402700}, {"namespace": "ospf-single", "hostname": "server104", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352402700}, {"namespace":
-      "ospf-single", "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "ospf-single", "hostname": "server104", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352402700}, {"namespace": "ospf-single", "hostname": "edge01", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352402916}, {"namespace":
-      "ospf-single", "hostname": "exit02", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "internet", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "ospf-single", "hostname": "leaf03", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf04", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "spine01", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
       "ospf-single", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname":
-      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine01", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf01",
-      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
-      "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02",
-      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
-      "swp4", "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "exit01", "ifname": "swp3", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp6", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit01",
-      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp6",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616352404640}, {"namespace": "ospf-single", "hostname": "exit02", "ifname":
-      "swp4", "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-      "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "spine01", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
-      "ospf-single", "hostname": "spine01", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-      "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "ospf-single",
-      "hostname": "spine01", "ifname": "swp5", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616352404640},
-      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf03",
-      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace":
+      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "swp6", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
+      "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "internet", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp5", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
+      "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
       "ospf-single", "hostname": "leaf04", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf04", "ifname":
-      "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp4", "assert":
-      "pass", "assertReason": [], "timestamp": 1616352404640}, {"namespace": "dual-evpn",
-      "hostname": "server102", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616644822254}, {"namespace": "dual-evpn", "hostname": "server101", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
-      "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
-      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
-      "dual-evpn", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822254},
-      {"namespace": "dual-evpn", "hostname": "server102", "ifname": "eth2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server103",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
-      "dual-evpn", "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "spine01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
+      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname": "exit02",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
+      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03",
+      "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "spine01", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "spine01",
+      "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
+      "exit01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
+      "swp6", "state": "up", "peerHostname": "exit01", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
+      "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf03", "ifname": "swp1", "state":
+      "up", "peerHostname": "spine01", "peerIfname": "swp3", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit02",
+      "ifname": "swp4", "state": "up", "peerHostname": "exit02", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf03", "ifname":
+      "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp3", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp4", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp3", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "exit01",
+      "ifname": "swp3", "state": "up", "peerHostname": "exit01", "peerIfname": "swp4",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "exit01", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "exit01", "ifname":
+      "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp6", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "ospf-single",
+      "hostname": "exit02", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
+      "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp": 1616352404640},
+      {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp1", "state":
+      "up", "peerHostname": "spine01", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02",
+      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace":
+      "ospf-single", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616352404640}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname":
+      "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616352404640}, {"namespace": "dual-evpn",
+      "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616644822254}, {"namespace": "dual-evpn", "hostname": "server103", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
+      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn",
       "hostname": "server103", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822254}, {"namespace": "dual-evpn", "hostname": "server102", "ifname":
+      "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server103", "ifname": "eth2", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254},
+      {"namespace": "dual-evpn", "hostname": "server102", "ifname": "eth2", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server101",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server102", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616644822254}, {"namespace": "dual-evpn", "hostname": "server101", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822254}, {"namespace": "dual-evpn",
-      "hostname": "server103", "ifname": "eth1", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822254},
+      "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616644822254}, {"namespace":
+      "dual-evpn", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822254},
+      {"namespace": "dual-evpn", "hostname": "server101", "ifname": "eth1", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn", "hostname": "server102",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822254}, {"namespace": "dual-evpn",
+      "hostname": "server104", "ifname": "eth2", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822255},
       {"namespace": "dual-evpn", "hostname": "server104", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616644822255}, {"namespace": "dual-evpn", "hostname":
       "server104", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644822255}, {"namespace":
-      "dual-evpn", "hostname": "server104", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822255},
-      {"namespace": "dual-evpn", "hostname": "server104", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822255}, {"namespace": "dual-evpn", "hostname":
-      "edge01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822307},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822880},
-      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822255}, {"namespace":
+      "dual-evpn", "hostname": "server104", "ifname": "bond0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822255}, {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth0",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname":
+      "spine02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
       "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-      "dual-evpn", "hostname": "leaf03", "ifname": "swp5", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond01", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
-      "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn",
-      "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "leaf04", "ifname": "bond01", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
-      "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "internet", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname":
-      "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823051},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace": "dual-evpn",
-      "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823051},
-      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "bond02", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace": "dual-evpn",
-      "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-      "dual-evpn", "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147},
-      {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "bond02", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823147}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp5", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn",
+      "hostname": "leaf03", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "exit01", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "eth0",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+      "leaf04", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "peerlink", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp6", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond01", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "internet", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616644823003}, {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "bond02",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "ifname": "bond01", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823051},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp5", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616644823051},
+      {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname":
+      "leaf02", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "ifname": "bond01", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616644823147},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147},
       {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "edge01",
-      "ifname": "eth1", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "fail", "assertReason": ["Speed mismatch"], "timestamp": 1616644822307},
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace": "dual-evpn",
+      "hostname": "leaf02", "ifname": "peerlink", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616644823147},
       {"namespace": "dual-evpn", "hostname": "edge01", "ifname": "eth2", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "fail", "assertReason":
+      "up", "peerHostname": "exit02", "peerIfname": "swp5", "result": "fail", "assertReason":
       ["Speed mismatch"], "timestamp": 1616644822307}, {"namespace": "dual-evpn",
-      "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp5", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "swp2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine02",
+      "hostname": "edge01", "ifname": "eth1", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp5", "result": "fail", "assertReason": ["Speed mismatch"],
+      "timestamp": 1616644822307}, {"namespace": "dual-evpn", "hostname": "spine02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result": "fail", "assertReason":
+      ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
+      "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+      "swp2", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp6", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine02",
       "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp2",
-      "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp2", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine02", "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "swp2", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
-      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp1", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname":
-      "spine01", "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616644822880}, {"namespace":
-      "dual-evpn", "hostname": "spine01", "ifname": "swp5", "state": "up", "peerHostname":
-      "exit02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01", "ifname":
-      "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1", "assert":
-      "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880}, {"namespace":
-      "dual-evpn", "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01",
-      "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1",
-      "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
-      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp1", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp1", "assert": "fail", "assertReason":
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822831},
+      {"namespace": "dual-evpn", "hostname": "spine02", "ifname": "swp5", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822831}, {"namespace": "dual-evpn", "hostname": "spine01",
+      "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname":
-      "leaf03", "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
-      "dual-evpn", "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth1", "assert": "fail", "assertReason": ["Speed mismatch"],
+      "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
+      "swp1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822880},
+      {"namespace": "dual-evpn", "hostname": "spine01", "ifname": "swp5", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname": "spine01",
+      "ifname": "swp6", "state": "up", "peerHostname": "exit01", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822880}, {"namespace":
+      "dual-evpn", "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname":
+      "leaf03", "peerIfname": "swp1", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644822880}, {"namespace": "dual-evpn", "hostname": "leaf03",
+      "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp4",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "swp3", "state": "up", "peerHostname":
+      "leaf04", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp3", "result": "fail",
+      "assertReason": ["MTU mismatch"], "timestamp": 1616644822941}, {"namespace":
+      "dual-evpn", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp3", "result": "fail", "assertReason": ["MTU mismatch"],
       "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "ifname": "swp5", "state": "up", "peerHostname": "edge01", "peerIfname": "eth1",
+      "result": "fail", "assertReason": ["Speed mismatch"], "timestamp": 1616644822941},
+      {"namespace": "dual-evpn", "hostname": "exit01", "ifname": "swp6", "state":
+      "up", "peerHostname": "internet", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
       "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp6",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822941}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822941}, {"namespace":
       "dual-evpn", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp4",
-      "state": "up", "peerHostname": "leaf04", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822941}, {"namespace": "dual-evpn",
-      "hostname": "exit01", "ifname": "swp6", "state": "up", "peerHostname": "internet",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
-      "leaf03", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-      "swp3", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822941},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp1", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
-      "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp4", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644822983},
-      {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644822983}, {"namespace":
-      "dual-evpn", "hostname": "exit02", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+      "spine01", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822941}, {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "result": "fail",
+      "assertReason": ["MTU mismatch"], "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp4", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname": "leaf04",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644822983}, {"namespace":
+      "dual-evpn", "hostname": "leaf04", "ifname": "swp4", "state": "up", "peerHostname":
+      "leaf03", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
       1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp5",
-      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "assert": "fail",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "fail",
       "assertReason": ["Speed mismatch"], "timestamp": 1616644822983}, {"namespace":
-      "dual-evpn", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
-      "internet", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1616644822983}, {"namespace": "dual-evpn",
-      "hostname": "internet", "ifname": "swp2", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp": 1616644823003},
-      {"namespace": "dual-evpn", "hostname": "internet", "ifname": "swp1", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp6", "assert": "pass", "assertReason":
-      [], "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
-      "dual-evpn", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644823051}, {"namespace":
+      "dual-evpn", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
+      "spine01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
+      1616644822983}, {"namespace": "dual-evpn", "hostname": "exit02", "ifname": "swp2",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1616644822983}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname": "internet",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616644822983},
+      {"namespace": "dual-evpn", "hostname": "internet", "ifname": "swp2", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823003}, {"namespace": "dual-evpn", "hostname": "internet",
+      "ifname": "swp1", "state": "up", "peerHostname": "exit01", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823003}, {"namespace":
       "dual-evpn", "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp1", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf02",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616644823147}, {"namespace":
-      "dual-evpn", "hostname": "leaf02", "ifname": "swp3", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
+      "spine01", "peerIfname": "swp1", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp1",
+      "result": "fail", "assertReason": ["MTU mismatch"], "timestamp": 1616644823051},
+      {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616644823051}, {"namespace": "dual-evpn", "hostname": "leaf01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823051}, {"namespace":
+      "dual-evpn", "hostname": "leaf02", "ifname": "swp4", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
       1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "swp2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "assert": "fail",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "result": "fail",
       "assertReason": ["MTU mismatch"], "timestamp": 1616644823147}, {"namespace":
       "dual-evpn", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp2", "assert": "fail", "assertReason": ["MTU mismatch"],
-      "timestamp": 1616644823147}, {"namespace": "ospf-ibgp", "hostname": "server101",
-      "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581492}, {"namespace":
-      "ospf-ibgp", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581492},
+      "spine01", "peerIfname": "swp2", "result": "fail", "assertReason": ["MTU mismatch"],
+      "timestamp": 1616644823147}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616644823147}, {"namespace":
+      "ospf-ibgp", "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681581492}, {"namespace": "ospf-ibgp",
+      "hostname": "server101", "ifname": "eth1", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581492},
       {"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581492}, {"namespace": "ospf-ibgp", "hostname":
-      "server101", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681581492}, {"namespace":
-      "ospf-ibgp", "hostname": "server103", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
+      "server103", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581509},
+      {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth2", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
       "hostname": "server103", "ifname": "eth0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
-      "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581509}, {"namespace": "ospf-ibgp",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
       "hostname": "server104", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
-      "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581517},
-      {"namespace": "ospf-ibgp", "hostname": "server104", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
+      "assertReason": ["No Peer Found"], "timestamp": 1616681581517}, {"namespace":
+      "ospf-ibgp", "hostname": "server104", "ifname": "eth1", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681581517},
+      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
-      "edge01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581517},
-      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname":
-      "server102", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681581595}, {"namespace":
-      "ospf-ibgp", "hostname": "server102", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681581595},
-      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname":
-      "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582085},
-      {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname":
-      "exit02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582248},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname":
-      "leaf02", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf02", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-      "ospf-ibgp", "hostname": "internet", "ifname": "eth0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
-      1616681582344}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
-      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582391},
-      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-      "leaf04", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
-      {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
-      ["No Peer Found"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname":
-      "leaf01", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-      "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582844},
+      "server102", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681581595},
+      {"namespace": "ospf-ibgp", "hostname": "server102", "ifname": "eth2", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681581595}, {"namespace": "ospf-ibgp",
+      "hostname": "server102", "ifname": "eth0", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681581595}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "eth0",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
+      "spine01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582129},
+      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "eth0", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
+      ["No Peer Found"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf02", "ifname": "swp6", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp5",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+      "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582325},
+      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "bond01", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "internet",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582344}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf03", "ifname": "eth0", "state": "up", "peerHostname":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
+      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582523},
+      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "ifname": "peerlink", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582523},
+      {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "spine02", "ifname": "eth0", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp6",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "swp5", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "",
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1616681582844},
       {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "bond02", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "edge01",
-      "ifname": "eth1", "state": "up", "peerHostname": "exit01", "peerIfname": "swp5",
-      "assert": "fail", "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp":
-      1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth2",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp5", "assert": "fail",
-      "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681581517},
-      {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp1", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "swp6", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
-      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp6",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1616681582844},
+      {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1", "state":
+      "up", "peerHostname": "exit01", "peerIfname": "swp5", "result": "fail", "assertReason":
+      ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681581517}, {"namespace":
+      "ospf-ibgp", "hostname": "edge01", "ifname": "eth2", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp5", "result": "fail", "assertReason": ["MTU mismatch",
+      "Speed mismatch"], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname":
+      "exit01", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+      "swp6", "result": "pass", "assertReason": "-", "timestamp": 1616681582085},
+      {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "state":
+      "up", "peerHostname": "spine02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+      "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582085}, {"namespace":
       "ospf-ibgp", "hostname": "exit01", "ifname": "swp5", "state": "up", "peerHostname":
-      "edge01", "peerIfname": "eth1", "assert": "fail", "assertReason": ["MTU mismatch",
+      "edge01", "peerIfname": "eth1", "result": "fail", "assertReason": ["MTU mismatch",
       "Speed mismatch"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname":
-      "exit01", "ifname": "swp6", "state": "up", "peerHostname": "internet", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582085}, {"namespace":
-      "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname":
-      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp1", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
-      "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname": "leaf03",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582129},
-      {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-      "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp1",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582129}, {"namespace":
+      "spine01", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
+      "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582129},
+      {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582129}, {"namespace":
       "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582129}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp6",
-      "state": "up", "peerHostname": "internet", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
-      "hostname": "exit02", "ifname": "swp5", "state": "up", "peerHostname": "edge01",
-      "peerIfname": "eth2", "assert": "fail", "assertReason": ["MTU mismatch", "Speed
-      mismatch"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname":
-      "exit02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp5", "assert": "pass", "assertReason": [], "timestamp": 1616681582248}, {"namespace":
-      "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf02", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616681582325},
-      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582325}, {"namespace":
-      "ospf-ibgp", "hostname": "internet", "ifname": "swp1", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582344}, {"namespace": "ospf-ibgp", "hostname": "internet", "ifname":
-      "swp2", "state": "up", "peerHostname": "exit02", "peerIfname": "swp6", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582344}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname": "spine01",
-      "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp": 1616681582391},
-      {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-      "ifname": "swp3", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582391}, {"namespace":
-      "ospf-ibgp", "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1616681582523},
+      "exit01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname":
+      "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+      "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04",
+      "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp": 1616681582129},
+      {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "state":
+      "up", "peerHostname": "spine01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+      "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582248}, {"namespace":
+      "ospf-ibgp", "hostname": "exit02", "ifname": "swp6", "state": "up", "peerHostname":
+      "internet", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5",
+      "state": "up", "peerHostname": "edge01", "peerIfname": "eth2", "result": "fail",
+      "assertReason": ["MTU mismatch", "Speed mismatch"], "timestamp": 1616681582248},
+      {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf01", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582325}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp2", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+      "hostname": "internet", "ifname": "swp1", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp": 1616681582344},
+      {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "swp2", "state":
+      "up", "peerHostname": "exit02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+      "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582391}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp3",
+      "state": "up", "peerHostname": "leaf04", "peerIfname": "swp3", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname": "leaf04",
+      "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp": 1616681582391},
       {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf03", "peerIfname": "swp4", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+      "up", "peerHostname": "leaf03", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
       "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp3",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582523}, {"namespace":
-      "ospf-ibgp", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname":
-      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "assert":
-      "pass", "assertReason": [], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
-      "hostname": "spine02", "ifname": "swp3", "state": "up", "peerHostname": "leaf03",
-      "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp": 1616681582843},
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp4", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+      "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582843},
       {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp4", "state":
-      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-      "ifname": "swp5", "state": "up", "peerHostname": "exit02", "peerIfname": "swp2",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582843}, {"namespace":
-      "ospf-ibgp", "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
-      "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname": "spine02",
-      "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp": 1616681582844},
-      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp3", "state":
-      "up", "peerHostname": "leaf02", "peerIfname": "swp3", "assert": "pass", "assertReason":
-      [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-      "ifname": "swp4", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp4",
-      "assert": "pass", "assertReason": [], "timestamp": 1616681582844}]'
+      "up", "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582843}, {"namespace":
+      "ospf-ibgp", "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname":
+      "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result":
+      "pass", "assertReason": "-", "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+      "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname": "exit01",
+      "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp": 1616681582843},
+      {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp4", "state":
+      "up", "peerHostname": "leaf02", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp3",
+      "result": "pass", "assertReason": "-", "timestamp": 1616681582844}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
+      "spine02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1616681582844}]'
   marks: interface assert cumulus
-- command: interface assert --status=whatever --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: interface assert --result=whatever --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface assert cumulus
   output: '[]'

--- a/tests/integration/sqcmds/cumulus-samples/ospf.yml
+++ b/tests/integration/sqcmds/cumulus-samples/ospf.yml
@@ -232,7 +232,8 @@ tests:
     "spine02", "vrf": "default", "ifname": "swp6", "peerHostname": "exit01", "area":
     "0.0.0.0", "ifState": "up", "nbrCount": 1, "adjState": "full", "peerIP": "10.0.0.101",
     "numChanges": 5.0, "lastChangeTime": 1616681064000.0, "timestamp": 1616681581441}]'
-- command: ospf show --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf show --columns=hostname --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: ospf show
   output: '[{"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"},
@@ -261,14 +262,16 @@ tests:
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
     {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
     "spine01"}, {"hostname": "spine02"}]'
-- command: ospf unique --count=True --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf unique --count=True --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: ospf unique
   output: '[{"hostname": "exit01", "numRows": 6}, {"hostname": "exit02", "numRows":
     6}, {"hostname": "leaf01", "numRows": 7}, {"hostname": "leaf02", "numRows": 7},
     {"hostname": "leaf03", "numRows": 7}, {"hostname": "leaf04", "numRows": 7}, {"hostname":
     "spine01", "numRows": 14}, {"hostname": "spine02", "numRows": 14}]'
-- command: ospf unique --columns=hostname --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf unique --columns=hostname --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: ospf unique
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
@@ -278,333 +281,337 @@ tests:
   data-directory: tests/data/parquet/
   ignore-columns: lastChangeTime timestamp
   marks: ospf assert
-  output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
-    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "spine02", "ifname": "swp3", "vrf": "default", "assert":
+  output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp5", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403216}, {"namespace": "ospf-single", "hostname": "spine02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-    "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
     {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "exit01", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403217}, {"namespace": "ospf-single",
-    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "leaf03",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403217},
+    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "exit01",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp2",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403217},
     {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace":
-    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace":
+    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace": "ospf-single",
-    "hostname": "spine01", "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine01", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403219}, {"namespace": "ospf-single", "hostname": "spine01",
-    "ifname": "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp3", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp3", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp6", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403251},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403251},
     {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
-    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
+    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403440}, {"namespace": "ospf-single",
-    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616352403440}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2", "vrf": "default", "assert":
+    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352403440}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp3", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "exit01", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "vrf": "default", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "ifname": "swp3", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine01", "ifname": "swp4", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "ifname": "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "assert":
+    "ifname": "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "hostname": "exit02", "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "vrf": "default", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581441},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace":
-    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert":
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581441},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace":
+    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-    "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp3",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581441},
+    "ifname": "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp6",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581441},
     {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681582523}]'
 - command: ospf assert --namespace=ospf-single --format=json
   data-directory: tests/data/parquet
   ignore-columns: lastChangeTime timestamp
   marks: ospf assert
   output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
     {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "spine02", "ifname": "swp3", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403216}, {"namespace": "ospf-single", "hostname": "spine02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
     {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "spine02", "ifname": "swp5", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp5", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "leaf03",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403217},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403217},
     {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403217}, {"namespace":
-    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403217}, {"namespace":
+    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace": "ospf-single",
-    "hostname": "exit02", "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "exit02", "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403219}, {"namespace": "ospf-single", "hostname": "spine01",
-    "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp6", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp3", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp3", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403251},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403251},
     {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
-    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
+    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403440}, {"namespace": "ospf-single",
-    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403440}]'
-- command: ospf assert --status=fail --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf assert --result=fail --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   ignore-columns: lastChangeTime timestamp
   marks: ospf assert cumulus
   output: '[]'
-- command: ospf assert --status=pass --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf assert --result=pass --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   ignore-columns: lastChangeTime timestamp
   marks: ospf assert cumulus
-  output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
-    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "spine02", "ifname": "swp3", "vrf": "default", "assert":
+  output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp5", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403216}, {"namespace": "ospf-single", "hostname": "spine02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-    "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
     {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "exit01", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403217}, {"namespace": "ospf-single",
-    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "leaf03",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403217},
+    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "exit01",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp2",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403217},
     {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace":
-    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace":
+    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace": "ospf-single",
-    "hostname": "spine01", "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine01", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403219}, {"namespace": "ospf-single", "hostname": "spine01",
-    "ifname": "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp3", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp3", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp6", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403251},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403251},
     {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
-    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
+    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403440}, {"namespace": "ospf-single",
-    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616352403440}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2", "vrf": "default", "assert":
+    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352403440}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp3", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "exit01", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "vrf": "default", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "ifname": "swp3", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine01", "ifname": "swp4", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "ifname": "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "assert":
+    "ifname": "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "hostname": "exit02", "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "vrf": "default", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581441},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace":
-    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert":
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581441},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace":
+    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-    "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp3",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581441},
+    "ifname": "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp6",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581441},
     {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681582523}]'
-- command: ospf assert --status=all --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf assert --result=all --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   ignore-columns: lastChangeTime timestamp
   marks: ospf assert cumulus
-  output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
-    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "spine02", "ifname": "swp3", "vrf": "default", "assert":
+  output: '[{"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp4",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    {"namespace": "ospf-single", "hostname": "spine02", "ifname": "swp6", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "spine02", "ifname": "swp5", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403216}, {"namespace": "ospf-single", "hostname": "spine02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "spine02", "ifname":
-    "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403216},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403216},
     {"namespace": "ospf-single", "hostname": "leaf01", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
-    "ospf-single", "hostname": "exit01", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403216}, {"namespace":
+    "ospf-single", "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403217}, {"namespace": "ospf-single",
-    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "leaf03",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403217},
+    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352403217}, {"namespace": "ospf-single", "hostname": "exit01",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616352403217}, {"namespace": "ospf-single", "hostname": "exit01", "ifname": "swp2",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403217},
     {"namespace": "ospf-single", "hostname": "exit02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace":
-    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace":
+    "ospf-single", "hostname": "exit02", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403219}, {"namespace": "ospf-single",
-    "hostname": "spine01", "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine01", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616352403219}, {"namespace": "ospf-single", "hostname": "spine01",
-    "ifname": "swp5", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp3", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp3", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "spine01", "ifname":
-    "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "swp6", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616352403219}, {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616352403251},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616352403251},
     {"namespace": "ospf-single", "hostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
-    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616352403251}, {"namespace":
+    "ospf-single", "hostname": "leaf04", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616352403440}, {"namespace": "ospf-single",
-    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616352403440}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp2", "vrf": "default", "assert":
+    "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616352403440}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp3", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "exit01", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "ifname": "swp2", "vrf": "default", "assert":
-    "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "ifname": "swp3", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine01", "ifname": "swp4", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "ifname": "swp4", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "vrf": "default", "assert":
+    "ifname": "swp5", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
-    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "ifname": "swp2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "hostname": "exit02", "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581440},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "vrf": "default", "result":
+    "pass", "assertReason": "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp1", "vrf": "default", "result": "pass", "assertReason":
+    "-", "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1616681581440}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581441},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace":
-    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "vrf": "default", "assert":
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581441},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp1", "vrf": "default",
+    "result": "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace":
+    "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681581441}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "ifname": "swp1", "vrf": "default", "assert": "pass", "assertReason":
+    "hostname": "spine02", "ifname": "swp3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-    "ifname": "swp6", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
-    1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp3",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1616681581441},
+    "ifname": "swp4", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
+    1616681581441}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp6",
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1616681581441},
     {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1616681582523}]'
-- command: ospf assert --status=whatever --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: ospf assert --result=whatever --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
   data-directory: tests/data/parquet/
   ignore-columns: lastChangeTime timestamp
   marks: ospf assert cumulus

--- a/tests/integration/sqcmds/eos-samples/bgp.yml
+++ b/tests/integration/sqcmds/eos-samples/bgp.yml
@@ -602,122 +602,122 @@ tests:
   error:
     error: '[{"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer":
       "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname":
-      "spine02", "assert": "pass", "assertReason": "-", "timestamp": 1623025175569},
+      "spine02", "result": "pass", "assertReason": "-", "timestamp": 1623025175569},
       {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025175569}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025175569}, {"namespace":
       "eos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "asn":
-      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025175571}, {"namespace": "eos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "result":
       "pass", "assertReason": "-", "timestamp": 1623025175571}, {"namespace": "eos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "result":
       "pass", "assertReason": "-", "timestamp": 1623025175571}, {"namespace": "eos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025175571}, {"namespace": "eos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025175571}, {"namespace": "eos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025175571}, {"namespace": "eos",
       "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine01", "assert": "pass",
+      64520, "state": "Established", "peerHostname": "spine01", "result": "pass",
       "assertReason": "-", "timestamp": 1623025175797}, {"namespace": "eos", "hostname":
       "leaf02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520,
-      "state": "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1623025175797}, {"namespace": "eos", "hostname": "leaf04",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176019}, {"namespace": "eos", "hostname": "leaf04",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176019}, {"namespace": "eos", "hostname": "exit02",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02",
       "vrf": "evpn-vrf", "peer": "169.254.253.6", "asn": 65521, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "169.254.253.10", "asn": 65522, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "169.254.127.2", "asn": 65522, "peerAsn": 65534,
-      "state": "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02",
       "vrf": "default", "peer": "169.254.253.2", "asn": 65520, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit01",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "169.254.254.10", "asn": 65522, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01",
       "vrf": "evpn-vrf", "peer": "169.254.254.6", "asn": 65521, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01",
       "vrf": "default", "peer": "169.254.254.2", "asn": 65520, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "169.254.127.0", "asn": 65522, "peerAsn": 65534,
-      "state": "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "leaf02", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf":
       "default", "peer": "10.0.0.13", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf03", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf03", "result": "pass", "assertReason": "-", "timestamp":
       1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf04", "result": "pass", "assertReason": "-", "timestamp":
       1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit01", "result": "pass", "assertReason": "-", "timestamp":
       1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit02", "result": "pass", "assertReason": "-", "timestamp":
       1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf01", "result": "pass", "assertReason": "-", "timestamp":
       1623025176023}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1623025176024}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine01", "result": "pass", "assertReason": "-", "timestamp":
       1623025176024}, {"namespace": "eos", "hostname": "firewall01", "vrf": "default",
       "peer": "eth2.4", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
-      "exit02", "assert": "pass", "assertReason": "-", "timestamp": 1623025176025},
+      "exit02", "result": "pass", "assertReason": "-", "timestamp": 1623025176025},
       {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.3",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025176025}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176025}, {"namespace":
       "eos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "asn":
-      65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02", "assert":
+      65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025176025}, {"namespace": "eos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "asn": 65533,
-      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025176025}, {"namespace": "eos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "asn": 65533,
-      "peerAsn": 65521, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65521, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025176025}, {"namespace": "eos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "asn": 65533,
-      "peerAsn": 65520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025176025}, {"namespace": "eos",
       "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3", "asn": 65534,
-      "peerAsn": 65522, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1623025177989},
       {"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
       "asn": 65534, "peerAsn": 65522, "state": "Established", "peerHostname": "exit01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1623025177989}]'
   marks: bgp assert eos

--- a/tests/integration/sqcmds/eos-samples/evpnVni.yml
+++ b/tests/integration/sqcmds/eos-samples/evpnVni.yml
@@ -77,28 +77,28 @@ tests:
   data-directory: tests/data/parquet/
   marks: evpnVni assert eos
   output: '[{"namespace": "eos", "hostname": "leaf02", "vni": 10, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1623025177153}, {"namespace": "eos", "hostname":
-    "leaf02", "vni": 999, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "-", "result": "pass", "timestamp": 1623025177153}, {"namespace": "eos", "hostname":
+    "leaf02", "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1623025177153}, {"namespace": "eos", "hostname": "leaf02", "vni": 30, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1623025177153}, {"namespace":
-    "eos", "hostname": "leaf03", "vni": 20, "type": "L2", "assertReason": "-", "assert":
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177153}, {"namespace":
+    "eos", "hostname": "leaf03", "vni": 20, "type": "L2", "assertReason": "-", "result":
     "pass", "timestamp": 1623025177155}, {"namespace": "eos", "hostname": "leaf03",
-    "vni": 999, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1623025177155}, {"namespace": "eos", "hostname": "leaf03", "vni": 30, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1623025177155}, {"namespace":
-    "eos", "hostname": "exit02", "vni": 999, "type": "L3", "assertReason": "-", "assert":
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177155}, {"namespace":
+    "eos", "hostname": "exit02", "vni": 999, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1623025177256}, {"namespace": "eos", "hostname": "exit01",
-    "vni": 999, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1623025177350}, {"namespace": "eos", "hostname": "leaf01", "vni": 10, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1623025177459}, {"namespace":
-    "eos", "hostname": "leaf01", "vni": 999, "type": "L3", "assertReason": "-", "assert":
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177459}, {"namespace":
+    "eos", "hostname": "leaf01", "vni": 999, "type": "L3", "assertReason": "-", "result":
     "pass", "timestamp": 1623025177459}, {"namespace": "eos", "hostname": "leaf01",
-    "vni": 30, "type": "L2", "assertReason": "-", "assert": "pass", "timestamp": 1623025177459},
+    "vni": 30, "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177459},
     {"namespace": "eos", "hostname": "leaf04", "vni": 20, "type": "L2", "assertReason":
-    "-", "assert": "pass", "timestamp": 1623025177461}, {"namespace": "eos", "hostname":
-    "leaf04", "vni": 999, "type": "L3", "assertReason": "-", "assert": "pass", "timestamp":
+    "-", "result": "pass", "timestamp": 1623025177461}, {"namespace": "eos", "hostname":
+    "leaf04", "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
     1623025177461}, {"namespace": "eos", "hostname": "leaf04", "vni": 30, "type":
-    "L2", "assertReason": "-", "assert": "pass", "timestamp": 1623025177461}]'
+    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177461}]'
 - command: evpnVni show --priVtepIp='10.0.0.112' --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: evpnVni show eos filter

--- a/tests/integration/sqcmds/eos-samples/interface.yml
+++ b/tests/integration/sqcmds/eos-samples/interface.yml
@@ -638,334 +638,334 @@ tests:
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "eos", "hostname": "firewall01", "ifname": "eth2.4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
-      "ifname": "eth1.4", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025175583}, {"namespace": "eos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+      "ifname": "eth1.4", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1623025175583}, {"namespace": "eos",
       "hostname": "firewall01", "ifname": "eth2.3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175583},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175583},
       {"namespace": "eos", "hostname": "firewall01", "ifname": "eth1.3", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
-      "ifname": "eth2.2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025175583}, {"namespace": "eos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+      "ifname": "eth2.2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1623025175583}, {"namespace": "eos",
       "hostname": "firewall01", "ifname": "eth1.2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175583},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175583},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf04", "ifname":
-      "Vlan4094", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+      "Vlan4094", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
       "exit01", "ifname": "Vlan4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025176020}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025176020}, {"namespace":
       "eos", "hostname": "exit02", "ifname": "Vlan4094", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176020},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan4094", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf01", "ifname":
-      "Vlan4094", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname":
+      "Vlan4094", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025176024}, {"namespace": "eos", "hostname":
       "leaf02", "ifname": "Vlan10", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025175798}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025175798}, {"namespace":
       "eos", "hostname": "leaf01", "ifname": "Vlan10", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176024},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176024},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan1006", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf04", "ifname":
-      "Vlan1006", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+      "Vlan1006", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
       "leaf03", "ifname": "Vlan1006", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
       "eos", "hostname": "leaf01", "ifname": "Vlan1006", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176024},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176024},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf04", "ifname":
-      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
       "leaf03", "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
       "eos", "hostname": "leaf01", "ifname": "Vlan30", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176024},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176024},
       {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan20", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf03", "ifname":
-      "Vlan20", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+      "Vlan20", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
       "exit02", "ifname": "Ethernet3.4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "exit02", "ifname": "Ethernet3.3", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
       "exit02", "ifname": "Ethernet3.2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "exit01", "ifname": "Ethernet3.3", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
       "exit01", "ifname": "Ethernet3.4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "exit01", "ifname": "Ethernet3.2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "lo0.16385", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "jsrv.1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "server302", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175379},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175379},
       {"namespace": "eos", "hostname": "server301", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
       "server301", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025175379}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025175379}, {"namespace":
       "eos", "hostname": "server301", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175379},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175379},
       {"namespace": "eos", "hostname": "server301", "ifname": "bond0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
       "server302", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175379},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175379},
       {"namespace": "eos", "hostname": "server302", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025175379}, {"namespace": "eos", "hostname": "server302", "ifname":
-      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
+      "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
       "server101", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175566},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175566},
       {"namespace": "eos", "hostname": "server101", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025175566}, {"namespace": "eos", "hostname": "server101", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1623025175566}, {"namespace":
       "eos", "hostname": "server101", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175566},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175566},
       {"namespace": "eos", "hostname": "server102", "ifname": "bond0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025175575}, {"namespace": "eos", "hostname":
       "server102", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025175575}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025175575}, {"namespace":
       "eos", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175575},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175575},
       {"namespace": "eos", "hostname": "server102", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025175575}, {"namespace": "eos", "hostname":
       "firewall01", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175583},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175583},
       {"namespace": "eos", "hostname": "firewall01", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025175583}, {"namespace": "eos", "hostname":
       "firewall01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175583},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025175583},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02",
       "ifname": "Port-Channel1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025175798}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025175798}, {"namespace":
       "eos", "hostname": "leaf02", "ifname": "Port-Channel3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175798},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175798},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Management1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025175798}, {"namespace": "eos", "hostname":
       "leaf02", "ifname": "Ethernet3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025175798}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025175798}, {"namespace":
       "eos", "hostname": "leaf02", "ifname": "Ethernet4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025175798},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025175798},
       {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
-      "Ethernet4", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176018}, {"namespace": "eos",
+      "Ethernet4", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1623025176018}, {"namespace": "eos",
       "hostname": "leaf04", "ifname": "Port-Channel3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176018},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176018},
       {"namespace": "eos", "hostname": "leaf04", "ifname": "Port-Channel1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04",
       "ifname": "Port-Channel4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025176018}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025176018}, {"namespace":
       "eos", "hostname": "leaf04", "ifname": "Management1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1623025176018}, {"namespace": "eos", "hostname": "exit02", "ifname": "Ethernet3",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
       "exit01", "ifname": "Ethernet3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "exit01", "ifname": "Management1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
       "exit02", "ifname": "Management1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "spine01", "ifname": "Management1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025176022}, {"namespace": "eos", "hostname":
       "leaf03", "ifname": "Management1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176023},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025176023},
       {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
-      "Ethernet4", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace": "eos",
+      "Ethernet4", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace": "eos",
       "hostname": "leaf03", "ifname": "Port-Channel3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176023},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176023},
       {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03",
       "ifname": "Port-Channel4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
       "eos", "hostname": "spine02", "ifname": "Management1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1623025176023}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Port-Channel1",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01",
       "ifname": "Port-Channel4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025176024}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025176024}, {"namespace":
       "eos", "hostname": "leaf01", "ifname": "Management1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Port-Channel3",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01",
       "ifname": "Ethernet4", "state": "up", "peerHostname": "", "peerIfname": "",
-      "assert": "pass", "assertReason": [], "timestamp": 1623025176024}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176024}, {"namespace":
       "eos", "hostname": "leaf01", "ifname": "Ethernet3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025176024},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025176024},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "em3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "em2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "em4", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "xe-0/0/7", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "lo0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "xe-0/0/10", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/9", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "xe-0/0/8", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "xe-0/0/5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "dcedge01", "ifname": "xe-0/0/3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025179345},
       {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/11", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
       "leaf02", "ifname": "Ethernet2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "Ethernet2", "assert": "pass", "assertReason": [], "timestamp": 1623025175798},
+      "Ethernet2", "result": "pass", "assertReason": "-", "timestamp": 1623025175798},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet1", "state": "up",
-      "peerHostname": "spine01", "peerIfname": "Ethernet2", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02",
+      "peerHostname": "spine01", "peerIfname": "Ethernet2", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02",
       "ifname": "Ethernet5", "state": "up", "peerHostname": "leaf01", "peerIfname":
-      "Ethernet5", "assert": "pass", "assertReason": [], "timestamp": 1623025175798},
+      "Ethernet5", "result": "pass", "assertReason": "-", "timestamp": 1623025175798},
       {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet6", "state": "up",
-      "peerHostname": "leaf01", "peerIfname": "Ethernet6", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf04",
+      "peerHostname": "leaf01", "peerIfname": "Ethernet6", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf04",
       "ifname": "Ethernet2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "Ethernet4", "assert": "pass", "assertReason": [], "timestamp": 1623025176018},
+      "Ethernet4", "result": "pass", "assertReason": "-", "timestamp": 1623025176018},
       {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet1", "state": "up",
-      "peerHostname": "spine01", "peerIfname": "Ethernet4", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04",
+      "peerHostname": "spine01", "peerIfname": "Ethernet4", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04",
       "ifname": "Ethernet5", "state": "up", "peerHostname": "leaf03", "peerIfname":
-      "Ethernet5", "assert": "pass", "assertReason": [], "timestamp": 1623025176018},
+      "Ethernet5", "result": "pass", "assertReason": "-", "timestamp": 1623025176018},
       {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet6", "state": "up",
-      "peerHostname": "leaf03", "peerIfname": "Ethernet6", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "exit01",
+      "peerHostname": "leaf03", "peerIfname": "Ethernet6", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "exit01",
       "ifname": "Ethernet2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "Ethernet5", "assert": "pass", "assertReason": [], "timestamp": 1623025176020},
+      "Ethernet5", "result": "pass", "assertReason": "-", "timestamp": 1623025176020},
       {"namespace": "eos", "hostname": "exit01", "ifname": "Ethernet4", "state": "up",
-      "peerHostname": "dcedge01", "peerIfname": "xe-0/0/0", "assert": "fail", "assertReason":
+      "peerHostname": "dcedge01", "peerIfname": "xe-0/0/0", "result": "fail", "assertReason":
       ["Speed mismatch"], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
       "exit02", "ifname": "Ethernet4", "state": "up", "peerHostname": "dcedge01",
-      "peerIfname": "xe-0/0/1", "assert": "fail", "assertReason": ["Speed mismatch"],
+      "peerIfname": "xe-0/0/1", "result": "fail", "assertReason": ["Speed mismatch"],
       "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname":
       "Ethernet1", "state": "up", "peerHostname": "spine01", "peerIfname": "Ethernet6",
-      "assert": "pass", "assertReason": [], "timestamp": 1623025176020}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176020}, {"namespace":
       "eos", "hostname": "exit01", "ifname": "Ethernet1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "Ethernet5", "assert": "pass", "assertReason": [],
+      "spine01", "peerIfname": "Ethernet5", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname":
       "Ethernet2", "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet6",
-      "assert": "pass", "assertReason": [], "timestamp": 1623025176020}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176020}, {"namespace":
       "eos", "hostname": "spine01", "ifname": "Ethernet2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "Ethernet1", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet3",
-      "state": "up", "peerHostname": "leaf03", "peerIfname": "Ethernet1", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176022}, {"namespace": "eos",
-      "hostname": "spine01", "ifname": "Ethernet6", "state": "up", "peerHostname":
-      "exit02", "peerIfname": "Ethernet1", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet4",
-      "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet1", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176022}, {"namespace": "eos",
-      "hostname": "spine01", "ifname": "Ethernet5", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "Ethernet1", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet1",
-      "state": "up", "peerHostname": "leaf01", "peerIfname": "Ethernet1", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176022}, {"namespace": "eos",
-      "hostname": "leaf03", "ifname": "Ethernet1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "Ethernet3", "assert": "pass", "assertReason": [],
+      "leaf02", "peerIfname": "Ethernet1", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname":
+      "Ethernet3", "state": "up", "peerHostname": "leaf03", "peerIfname": "Ethernet1",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176022}, {"namespace":
+      "eos", "hostname": "spine01", "ifname": "Ethernet6", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "Ethernet1", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname":
+      "Ethernet4", "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet1",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176022}, {"namespace":
+      "eos", "hostname": "spine01", "ifname": "Ethernet5", "state": "up", "peerHostname":
+      "exit01", "peerIfname": "Ethernet1", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname":
+      "Ethernet1", "state": "up", "peerHostname": "leaf01", "peerIfname": "Ethernet1",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176022}, {"namespace":
+      "eos", "hostname": "leaf03", "ifname": "Ethernet1", "state": "up", "peerHostname":
+      "spine01", "peerIfname": "Ethernet3", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
       "Ethernet2", "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet3",
-      "assert": "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
       "eos", "hostname": "spine02", "ifname": "Ethernet5", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "Ethernet2", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet5",
-      "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet5", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace": "eos",
-      "hostname": "spine02", "ifname": "Ethernet4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "Ethernet2", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet6",
-      "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet6", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace": "eos",
-      "hostname": "spine02", "ifname": "Ethernet2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "Ethernet2", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname": "Ethernet3",
-      "state": "up", "peerHostname": "leaf03", "peerIfname": "Ethernet2", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace": "eos",
-      "hostname": "spine02", "ifname": "Ethernet1", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "Ethernet2", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname": "Ethernet6",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "Ethernet2", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176023}, {"namespace": "eos",
-      "hostname": "leaf01", "ifname": "Ethernet5", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "Ethernet5", "assert": "pass", "assertReason": [], "timestamp":
-      1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025176024}, {"namespace": "eos",
-      "hostname": "leaf01", "ifname": "Ethernet1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "Ethernet1", "assert": "pass", "assertReason": [],
+      "exit01", "peerIfname": "Ethernet2", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+      "Ethernet5", "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet5",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
+      "eos", "hostname": "spine02", "ifname": "Ethernet4", "state": "up", "peerHostname":
+      "leaf04", "peerIfname": "Ethernet2", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+      "Ethernet6", "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet6",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
+      "eos", "hostname": "spine02", "ifname": "Ethernet2", "state": "up", "peerHostname":
+      "leaf02", "peerIfname": "Ethernet2", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname":
+      "Ethernet3", "state": "up", "peerHostname": "leaf03", "peerIfname": "Ethernet2",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
+      "eos", "hostname": "spine02", "ifname": "Ethernet1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "Ethernet2", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname":
+      "Ethernet6", "state": "up", "peerHostname": "exit02", "peerIfname": "Ethernet2",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176023}, {"namespace":
+      "eos", "hostname": "leaf01", "ifname": "Ethernet5", "state": "up", "peerHostname":
+      "leaf02", "peerIfname": "Ethernet5", "result": "pass", "assertReason": "-",
+      "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+      "Ethernet2", "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1",
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176024}, {"namespace":
+      "eos", "hostname": "leaf01", "ifname": "Ethernet1", "state": "up", "peerHostname":
+      "spine01", "peerIfname": "Ethernet1", "result": "pass", "assertReason": "-",
       "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
       "Ethernet6", "state": "up", "peerHostname": "leaf02", "peerIfname": "Ethernet6",
-      "assert": "pass", "assertReason": [], "timestamp": 1623025176024}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025176024}, {"namespace":
       "eos", "hostname": "dcedge01", "ifname": "xe-0/0/0", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "Ethernet4", "assert": "fail", "assertReason": ["Speed
+      "exit01", "peerIfname": "Ethernet4", "result": "fail", "assertReason": ["Speed
       mismatch"], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
       "ifname": "xe-0/0/1", "state": "up", "peerHostname": "exit02", "peerIfname":
-      "Ethernet4", "assert": "fail", "assertReason": ["Speed mismatch"], "timestamp":
+      "Ethernet4", "result": "fail", "assertReason": ["Speed mismatch"], "timestamp":
       1623025179345}]'
   marks: interface assert eos
 - command: interface top --what=statusChangeTimestamp --format=json --namespace=eos
@@ -1008,7 +1008,8 @@ tests:
     {"namespace": "eos", "hostname": "leaf01", "ifname": "Vxlan1", "state": "up",
     "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge",
     "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176024}]'
-- command: interface show --type='vrf vlan' --hostname='leaf01 spine01' --format=json --namespace=eos
+- command: interface show --type='vrf vlan' --hostname='leaf01 spine01' --format=json
+    --namespace=eos
   data-directory: tests/data/parquet/
   marks: interface show eos
   output: '[{"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan1006", "state":

--- a/tests/integration/sqcmds/eos-samples/ospf.yml
+++ b/tests/integration/sqcmds/eos-samples/ospf.yml
@@ -177,49 +177,49 @@ tests:
   data-directory: tests/data/parquet/
   marks: ospf assert eos
   output: '[{"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet1", "vrf":
-    "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025177058},
+    "default", "result": "pass", "assertReason": "-", "timestamp": 1623025177058},
     {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet3", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025177058}, {"namespace":
-    "eos", "hostname": "spine01", "ifname": "Ethernet2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1623025177058}, {"namespace":
+    "eos", "hostname": "spine01", "ifname": "Ethernet2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1623025177058}, {"namespace": "eos",
-    "hostname": "spine01", "ifname": "Ethernet6", "vrf": "default", "assert": "pass",
+    "hostname": "spine01", "ifname": "Ethernet6", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1623025177058}, {"namespace": "eos", "hostname":
-    "spine01", "ifname": "Ethernet4", "vrf": "default", "assert": "pass", "assertReason":
+    "spine01", "ifname": "Ethernet4", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1623025177058}, {"namespace": "eos", "hostname": "spine01",
-    "ifname": "Ethernet5", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "Ethernet5", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1623025177058}, {"namespace": "eos", "hostname": "leaf02", "ifname":
-    "Ethernet2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "Ethernet2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1623025177152}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025177152},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1623025177152},
     {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025177253}, {"namespace":
-    "eos", "hostname": "leaf03", "ifname": "Ethernet1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1623025177253}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Ethernet1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1623025177253}, {"namespace": "eos",
-    "hostname": "spine02", "ifname": "Ethernet2", "vrf": "default", "assert": "pass",
+    "hostname": "spine02", "ifname": "Ethernet2", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1623025177290}, {"namespace": "eos", "hostname":
-    "spine02", "ifname": "Ethernet3", "vrf": "default", "assert": "pass", "assertReason":
+    "spine02", "ifname": "Ethernet3", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1623025177290}, {"namespace": "eos", "hostname": "spine02",
-    "ifname": "Ethernet1", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "Ethernet1", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1623025177290}, {"namespace": "eos", "hostname": "spine02", "ifname":
-    "Ethernet6", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "Ethernet6", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1623025177290}, {"namespace": "eos", "hostname": "spine02", "ifname": "Ethernet5",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025177290},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1623025177290},
     {"namespace": "eos", "hostname": "spine02", "ifname": "Ethernet4", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025177290}, {"namespace":
-    "eos", "hostname": "exit02", "ifname": "Ethernet1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1623025177290}, {"namespace":
+    "eos", "hostname": "exit02", "ifname": "Ethernet1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1623025177308}, {"namespace": "eos",
-    "hostname": "exit02", "ifname": "Ethernet2", "vrf": "default", "assert": "pass",
+    "hostname": "exit02", "ifname": "Ethernet2", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1623025177308}, {"namespace": "eos", "hostname":
-    "exit01", "ifname": "Ethernet1", "vrf": "default", "assert": "pass", "assertReason":
+    "exit01", "ifname": "Ethernet1", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1623025177431}, {"namespace": "eos", "hostname": "exit01", "ifname":
-    "Ethernet2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "Ethernet2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1623025177431}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025177614},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1623025177614},
     {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025177614}, {"namespace":
-    "eos", "hostname": "leaf04", "ifname": "Ethernet1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1623025177614}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Ethernet1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1623025177660}, {"namespace": "eos",
-    "hostname": "leaf04", "ifname": "Ethernet2", "vrf": "default", "assert": "pass",
+    "hostname": "leaf04", "ifname": "Ethernet2", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1623025177660}]'
 - command: ospf top --what=numChanges --format=json --namespace=eos
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/junos-samples/bgp.yml
+++ b/tests/integration/sqcmds/junos-samples/bgp.yml
@@ -164,99 +164,99 @@ tests:
   error:
     error: '[{"namespace": "junos", "hostname": "firewall01", "vrf": "default", "peer":
       "eth1.3", "asn": 65533, "peerAsn": 64520, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1623025795301},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1623025795301},
       {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.4",
       "asn": 65533, "peerAsn": 64520, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025795301}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025795301}, {"namespace":
       "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "asn":
-      65533, "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      65533, "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025795301}, {"namespace": "junos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "asn": 65533,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025795301}, {"namespace": "junos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "asn": 65533,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025795301}, {"namespace": "junos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "asn": 65533,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025795301}, {"namespace": "junos",
       "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "pass",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "pass",
       "assertReason": "-", "timestamp": 1623025797432}, {"namespace": "junos", "hostname":
       "leaf01", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
-      "state": "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025797432}, {"namespace": "junos", "hostname": "leaf02",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1623025797434}, {"namespace": "junos", "hostname": "leaf02",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1623025797434}, {"namespace": "junos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1623025797800}, {"namespace": "junos", "hostname": "spine01", "vrf":
       "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit01", "result": "pass", "assertReason": "-", "timestamp":
       1623025797800}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf02", "result": "pass", "assertReason": "-", "timestamp":
       1623025797800}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf01", "result": "pass", "assertReason": "-", "timestamp":
       1623025797800}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
       "peer": "169.254.127.1", "asn": 65534, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1623025798026}, {"namespace": "junos", "hostname": "exit01",
       "vrf": "default", "peer": "169.254.254.2", "asn": 64520, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "fail", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1623025798026}, {"namespace": "junos",
       "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "asn":
       64520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025798026}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025798026}, {"namespace":
       "junos", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "asn":
       64520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1623025798026}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
       "peer": "169.254.127.0", "asn": 64520, "peerAsn": 65534, "state": "Established",
-      "peerHostname": "dcedge01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "dcedge01", "result": "pass", "assertReason": "-", "timestamp":
       1623025798026}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1623025798026}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine01", "result": "pass", "assertReason": "-", "timestamp":
       1623025798026}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
       "peer": "169.254.127.3", "asn": 65534, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1623025798026}, {"namespace": "junos", "hostname": "exit02",
       "vrf": "evpn-vrf", "peer": "169.254.253.6", "asn": 64520, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "fail", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1623025798028}, {"namespace": "junos",
       "hostname": "exit02", "vrf": "default", "peer": "169.254.253.2", "asn": 64520,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1623025798028},
       {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf", "peer":
       "169.254.127.2", "asn": 64520, "peerAsn": 65534, "state": "Established", "peerHostname":
-      "dcedge01", "assert": "pass", "assertReason": "-", "timestamp": 1623025798028},
+      "dcedge01", "result": "pass", "assertReason": "-", "timestamp": 1623025798028},
       {"namespace": "junos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025798028}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025798028}, {"namespace":
       "junos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025798028}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025798028}, {"namespace":
       "junos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
       "asn": 64520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1623025798028}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1623025798028}, {"namespace":
       "junos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "asn":
-      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02", "assert":
+      64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025798030}, {"namespace": "junos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025798030}, {"namespace": "junos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "result":
       "pass", "assertReason": "-", "timestamp": 1623025798030}, {"namespace": "junos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025798030}]'
   marks: bgp assert junos junos

--- a/tests/integration/sqcmds/junos-samples/interface.yml
+++ b/tests/integration/sqcmds/junos-samples/interface.yml
@@ -1190,508 +1190,508 @@ tests:
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "junos", "hostname": "firewall01", "ifname": "eth2.4",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025795928}, {"namespace": "junos", "hostname": "firewall01",
-      "ifname": "eth1.4", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025795928}, {"namespace": "junos",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025795928}, {"namespace": "junos", "hostname": "firewall01",
+      "ifname": "eth1.4", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1623025795928}, {"namespace": "junos",
       "hostname": "exit01", "ifname": "xe-0/0/2.4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1623025801370}, {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/2.4",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "firewall01", "ifname": "eth2.3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025795928}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025795928}, {"namespace":
       "junos", "hostname": "firewall01", "ifname": "eth1.3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025795928},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/2.3", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "xe-0/0/2.3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "firewall01", "ifname": "eth2.2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1623025795928}, {"namespace": "junos", "hostname": "firewall01",
-      "ifname": "eth1.2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1623025795928}, {"namespace": "junos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1623025795928}, {"namespace": "junos", "hostname": "firewall01",
+      "ifname": "eth1.2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1623025795928}, {"namespace": "junos",
       "hostname": "exit01", "ifname": "xe-0/0/2.2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1623025801370}, {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/2.2",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "em4.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "em2.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "em2.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "em4.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "lo0.16385", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "lo0.16385", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "lo0.16385", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "spine02", "ifname": "lo0.16385", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "lo0.16385", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "lo0.16385", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "lo0.16385", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "exit01", "ifname": "lo0.999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "lo0.999", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "exit02", "ifname": "lo0.999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "lo0.999", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "exit01", "ifname": "jsrv.1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "jsrv.1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "exit02", "ifname": "jsrv.1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "jsrv.1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "jsrv.1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "jsrv.1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "jsrv.1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "irb.30", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1623025801371}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1623025801371}, {"namespace":
       "junos", "hostname": "leaf01", "ifname": "irb.30", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1623025803099},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "irb.20", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1623025801371}, {"namespace": "junos", "hostname": "leaf01", "ifname":
-      "irb.10", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+      "irb.10", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "server201", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "server201", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025795928}, {"namespace": "junos", "hostname":
       "server101", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "server202", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025795928}, {"namespace": "junos", "hostname":
       "server202", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "server101", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025795928}, {"namespace": "junos", "hostname":
       "firewall01", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "server102", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025795928}, {"namespace": "junos", "hostname":
       "firewall01", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "firewall01", "ifname": "eth0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025795928}, {"namespace": "junos", "hostname":
       "server102", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025795928},
       {"namespace": "junos", "hostname": "exit01", "ifname": "em6", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "em2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "em4", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "em5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "em3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "lsi", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "lo0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "em1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "xe-0/0/9", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/8", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "xe-0/0/7", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "em0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "xe-0/0/5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "lo0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "lsi", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "em5", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "em4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "em2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "em6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "em3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "xe-0/0/4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "xe-0/0/10", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/9", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "xe-0/0/8", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/7", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "xe-0/0/6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "exit02", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "em2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "em4", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "lo0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "lsi", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "xe-0/0/10", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/11", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "em3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "em5", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "xe-0/0/9", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/8", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "xe-0/0/7", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "xe-0/0/4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "em6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/8", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "xe-0/0/4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "xe-0/0/6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/7", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "xe-0/0/9", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "em2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "em4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "em5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "lo0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "em3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "em6", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "xe-0/0/3", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "xe-0/0/4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "xe-0/0/6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "xe-0/0/7", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "xe-0/0/8", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "xe-0/0/9", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "xe-0/0/10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "bme0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "em0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "em1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "em2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "em4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "lo0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "xe-0/0/2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "xe-0/0/5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "em3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "xe-0/0/4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "xe-0/0/6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/7", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "xe-0/0/8", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/9", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "lo0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "em2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "em4", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "lo0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "em6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "em2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "em3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "em4", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "em5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "xe-0/0/4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "xe-0/0/5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "xe-0/0/6", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "xe-0/0/7", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "xe-0/0/8", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "xe-0/0/9", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "xe-0/0/10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "em5", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "em3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "lsi", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "em6", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "xe-0/0/0", "state": "up", "peerHostname": "spine01", "peerIfname":
-      "xe-0/0/2", "assert": "pass", "assertReason": [], "timestamp": 1623025801370},
+      "xe-0/0/2", "result": "pass", "assertReason": "-", "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/1", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "xe-0/0/2", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "spine02", "peerIfname": "xe-0/0/2", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025801370}, {"namespace": "junos", "hostname":
       "exit01", "ifname": "xe-0/0/3", "state": "up", "peerHostname": "dcedge01", "peerIfname":
-      "xe-0/0/0", "assert": "pass", "assertReason": [], "timestamp": 1623025801370},
+      "xe-0/0/0", "result": "pass", "assertReason": "-", "timestamp": 1623025801370},
       {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/0", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "xe-0/0/1", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "spine01", "peerIfname": "xe-0/0/1", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025801371}, {"namespace": "junos", "hostname":
       "leaf02", "ifname": "xe-0/0/1", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "xe-0/0/1", "assert": "pass", "assertReason": [], "timestamp": 1623025801371},
+      "xe-0/0/1", "result": "pass", "assertReason": "-", "timestamp": 1623025801371},
       {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/3", "state":
-      "up", "peerHostname": "dcedge01", "peerIfname": "xe-0/0/1", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "dcedge01", "peerIfname": "xe-0/0/1", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "exit02", "ifname": "xe-0/0/1", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "xe-0/0/3", "assert": "pass", "assertReason": [], "timestamp": 1623025801614},
+      "xe-0/0/3", "result": "pass", "assertReason": "-", "timestamp": 1623025801614},
       {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/0", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "xe-0/0/3", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "spine01", "peerIfname": "xe-0/0/3", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025801614}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "xe-0/0/2", "state": "up", "peerHostname": "exit01", "peerIfname":
-      "xe-0/0/1", "assert": "pass", "assertReason": [], "timestamp": 1623025801643},
+      "xe-0/0/1", "result": "pass", "assertReason": "-", "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/3", "state":
-      "up", "peerHostname": "exit02", "peerIfname": "xe-0/0/1", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "exit02", "peerIfname": "xe-0/0/1", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "spine02", "ifname": "xe-0/0/1", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "xe-0/0/1", "assert": "pass", "assertReason": [], "timestamp": 1623025801643},
+      "xe-0/0/1", "result": "pass", "assertReason": "-", "timestamp": 1623025801643},
       {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/0", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "xe-0/0/1", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "leaf01", "peerIfname": "xe-0/0/1", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
       "dcedge01", "ifname": "xe-0/0/1", "state": "up", "peerHostname": "exit02", "peerIfname":
-      "xe-0/0/3", "assert": "pass", "assertReason": [], "timestamp": 1623025802054},
+      "xe-0/0/3", "result": "pass", "assertReason": "-", "timestamp": 1623025802054},
       {"namespace": "junos", "hostname": "dcedge01", "ifname": "xe-0/0/0", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "xe-0/0/3", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "exit01", "peerIfname": "xe-0/0/3", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025802054}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "xe-0/0/3", "state": "up", "peerHostname": "exit02", "peerIfname":
-      "xe-0/0/0", "assert": "pass", "assertReason": [], "timestamp": 1623025803099},
+      "xe-0/0/0", "result": "pass", "assertReason": "-", "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/2", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "xe-0/0/0", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "exit01", "peerIfname": "xe-0/0/0", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "spine01", "ifname": "xe-0/0/1", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "xe-0/0/0", "assert": "pass", "assertReason": [], "timestamp": 1623025803099},
+      "xe-0/0/0", "result": "pass", "assertReason": "-", "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/0", "state":
-      "up", "peerHostname": "leaf01", "peerIfname": "xe-0/0/0", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+      "up", "peerHostname": "leaf01", "peerIfname": "xe-0/0/0", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
       "leaf01", "ifname": "xe-0/0/0", "state": "up", "peerHostname": "spine01", "peerIfname":
-      "xe-0/0/0", "assert": "pass", "assertReason": [], "timestamp": 1623025803099},
+      "xe-0/0/0", "result": "pass", "assertReason": "-", "timestamp": 1623025803099},
       {"namespace": "junos", "hostname": "leaf01", "ifname": "xe-0/0/1", "state":
-      "up", "peerHostname": "spine02", "peerIfname": "xe-0/0/0", "assert": "pass",
-      "assertReason": [], "timestamp": 1623025803099}]'
+      "up", "peerHostname": "spine02", "peerIfname": "xe-0/0/0", "result": "pass",
+      "assertReason": "-", "timestamp": 1623025803099}]'
   marks: interface assert junos
 - command: interface top --what=statusChangeTimestamp --format=json --namespace=junos
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/junos-samples/ospf.yml
+++ b/tests/integration/sqcmds/junos-samples/ospf.yml
@@ -116,35 +116,35 @@ tests:
   data-directory: tests/data/parquet/
   marks: ospf assert junos
   output: '[{"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/0.0", "vrf":
-    "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025798026},
+    "default", "result": "pass", "assertReason": "-", "timestamp": 1623025798026},
     {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/1.0", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025798026}, {"namespace":
-    "junos", "hostname": "spine01", "ifname": "xe-0/0/3.0", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1623025798026}, {"namespace":
+    "junos", "hostname": "spine01", "ifname": "xe-0/0/3.0", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1623025798027}, {"namespace": "junos",
-    "hostname": "spine01", "ifname": "xe-0/0/2.0", "vrf": "default", "assert": "pass",
+    "hostname": "spine01", "ifname": "xe-0/0/2.0", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1623025798027}, {"namespace": "junos", "hostname":
-    "spine01", "ifname": "xe-0/0/1.0", "vrf": "default", "assert": "pass", "assertReason":
+    "spine01", "ifname": "xe-0/0/1.0", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1623025798027}, {"namespace": "junos", "hostname": "spine01",
-    "ifname": "xe-0/0/0.0", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1623025798027}, {"namespace": "junos", "hostname": "exit01", "ifname":
-    "xe-0/0/1.0", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "xe-0/0/1.0", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1623025798361}, {"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/0.0",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025798361},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1623025798361},
     {"namespace": "junos", "hostname": "leaf01", "ifname": "xe-0/0/0.0", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025798813}, {"namespace":
-    "junos", "hostname": "leaf01", "ifname": "xe-0/0/1.0", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1623025798813}, {"namespace":
+    "junos", "hostname": "leaf01", "ifname": "xe-0/0/1.0", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1623025798813}, {"namespace": "junos",
-    "hostname": "exit02", "ifname": "xe-0/0/1.0", "vrf": "default", "assert": "pass",
+    "hostname": "exit02", "ifname": "xe-0/0/1.0", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1623025799339}, {"namespace": "junos", "hostname":
-    "exit02", "ifname": "xe-0/0/0.0", "vrf": "default", "assert": "pass", "assertReason":
+    "exit02", "ifname": "xe-0/0/0.0", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1623025799339}, {"namespace": "junos", "hostname": "spine02",
-    "ifname": "xe-0/0/2.0", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "xe-0/0/2.0", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1623025799761}, {"namespace": "junos", "hostname": "spine02", "ifname":
-    "xe-0/0/0.0", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "xe-0/0/0.0", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1623025799761}, {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/1.0",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1623025799761},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1623025799761},
     {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/3.0", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1623025799761}]'
+    "result": "pass", "assertReason": "-", "timestamp": 1623025799761}]'
 - command: ospf top --what=numChanges --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: ospf top junos

--- a/tests/integration/sqcmds/nxos-samples/bgp.yml
+++ b/tests/integration/sqcmds/nxos-samples/bgp.yml
@@ -321,123 +321,123 @@ tests:
   error:
     error: '[{"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "peer":
       "eth2.2", "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname":
-      "exit02", "assert": "pass", "assertReason": "-", "timestamp": 1619275256921},
+      "exit02", "result": "pass", "assertReason": "-", "timestamp": 1619275256921},
       {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.4",
       "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1619275256921}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275256921}, {"namespace":
       "nxos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "asn":
-      65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02", "assert":
+      65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1619275256921}, {"namespace": "nxos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "asn": 65533,
-      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1619275256921}, {"namespace": "nxos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "asn": 65533,
-      "peerAsn": 65521, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65521, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1619275256921}, {"namespace": "nxos",
       "hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "asn": 65533,
-      "peerAsn": 65520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1619275256921}, {"namespace": "nxos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1619275258329}, {"namespace": "nxos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "result":
       "pass", "assertReason": "-", "timestamp": 1619275258329}, {"namespace": "nxos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02", "result":
       "pass", "assertReason": "-", "timestamp": 1619275258329}, {"namespace": "nxos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "result":
       "pass", "assertReason": "-", "timestamp": 1619275258329}, {"namespace": "nxos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "result":
       "pass", "assertReason": "-", "timestamp": 1619275258329}, {"namespace": "nxos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1619275258329}, {"namespace": "nxos",
       "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "pass",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "pass",
       "assertReason": "-", "timestamp": 1619275258347}, {"namespace": "nxos", "hostname":
       "leaf03", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
-      "state": "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258347}, {"namespace": "nxos", "hostname": "leaf01",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258542}, {"namespace": "nxos", "hostname": "leaf01",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258542}, {"namespace": "nxos", "hostname": "exit01",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "exit01",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "exit01",
       "vrf": "default", "peer": "169.254.254.2", "asn": 64520, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "exit01",
       "vrf": "evpn-vrf", "peer": "169.254.254.6", "asn": 64520, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "169.254.127.0", "asn": 64520, "peerAsn": 65534,
-      "state": "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "169.254.254.10", "asn": 64520, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.13", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf03", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "leaf03", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf":
       "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit02", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "exit01", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf04", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf04", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "leaf02", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
       "peer": "169.254.127.1", "asn": 65534, "peerAsn": 65522, "state": "Established",
-      "peerHostname": "exit01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf01", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "leaf01", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
       "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine02", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "pass", "assertReason": "-", "timestamp":
+      "peerHostname": "spine01", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default",
       "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state": "Established",
-      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf02",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "169.254.127.2", "asn": 64520, "peerAsn": 65534,
-      "state": "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259384}, {"namespace": "nxos", "hostname": "exit02",
       "vrf": "evpn-vrf", "peer": "169.254.253.6", "asn": 64520, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259384}, {"namespace": "nxos", "hostname": "exit02",
       "vrf": "default", "peer": "169.254.253.2", "asn": 64520, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259384}, {"namespace": "nxos", "hostname": "exit02",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259384}, {"namespace": "nxos", "hostname": "exit02",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259384}, {"namespace": "nxos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "169.254.253.10", "asn": 64520, "peerAsn": 65533,
-      "state": "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "state": "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1619275259384}]'
   marks: bgp assert nxos
 - command: bgp show --state=NotEstd --format=json --namespace=nxos

--- a/tests/integration/sqcmds/nxos-samples/interface.yml
+++ b/tests/integration/sqcmds/nxos-samples/interface.yml
@@ -2308,7 +2308,8 @@ tests:
     {"namespace": "nxos", "hostname": "exit02", "ifname": "nve1", "state": "up", "adminState":
     "up", "type": "vxlan", "mtu": 9216, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "timestamp": 1619275260177}]'
-- command: interface show --type='vrf vlan' --hostname='leaf01 spine01' --format=json --namespace=nxos
+- command: interface show --type='vrf vlan' --hostname='leaf01 spine01' --format=json
+    --namespace=nxos
   data-directory: tests/data/parquet/
   marks: interface show nxos
   output: '[{"namespace": "nxos", "hostname": "leaf01", "ifname": "default", "state":
@@ -2354,328 +2355,329 @@ tests:
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "nxos", "hostname": "firewall01", "ifname": "eth2.2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275256290}, {"namespace": "nxos", "hostname": "firewall01",
-      "ifname": "eth1.2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275256290}, {"namespace": "nxos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275256290}, {"namespace": "nxos", "hostname": "firewall01",
+      "ifname": "eth1.2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275256290}, {"namespace": "nxos",
       "hostname": "firewall01", "ifname": "eth2.3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275256290},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275256290},
       {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth1.3", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275256290}, {"namespace": "nxos", "hostname": "firewall01",
-      "ifname": "eth2.4", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275256290}, {"namespace": "nxos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275256290}, {"namespace": "nxos", "hostname": "firewall01",
+      "ifname": "eth2.4", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275256290}, {"namespace": "nxos",
       "hostname": "firewall01", "ifname": "eth1.4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275256290},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275256290},
       {"namespace": "nxos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
-      "Vlan20", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+      "Vlan20", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
       "leaf03", "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275258539}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275258539}, {"namespace":
       "nxos", "hostname": "leaf01", "ifname": "Vlan30", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275258762},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275258762},
       {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
-      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
       "leaf03", "ifname": "Vlan999", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275258539}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275258539}, {"namespace":
       "nxos", "hostname": "leaf01", "ifname": "Vlan999", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275258762},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275258762},
       {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
-      "Vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+      "Vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
       "exit01", "ifname": "Vlan999", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275259574}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275259574}, {"namespace":
       "nxos", "hostname": "exit02", "ifname": "Vlan999", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275260177},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275260177},
       {"namespace": "nxos", "hostname": "leaf01", "ifname": "Vlan10", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
-      "Vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+      "Vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "lo0.16385", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "em2.32768", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "em4.32768", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "jsrv.1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "server101", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275256203}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275256203}, {"namespace":
       "nxos", "hostname": "server101", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1619275256203}, {"namespace": "nxos", "hostname": "server101", "ifname": "eth2",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275256203}, {"namespace": "nxos", "hostname": "server101",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275256203}, {"namespace": "nxos", "hostname": "server101",
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
       "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275256203}, {"namespace":
       "nxos", "hostname": "server102", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1619275256204}, {"namespace": "nxos", "hostname": "server102", "ifname": "eth1",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275256204}, {"namespace": "nxos", "hostname": "server102",
-      "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275256204}, {"namespace": "nxos",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275256204}, {"namespace": "nxos", "hostname": "server102",
+      "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275256204}, {"namespace": "nxos",
       "hostname": "server102", "ifname": "eth0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1619275256204}, {"namespace": "nxos", "hostname": "server301", "ifname": "eth0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275256205}, {"namespace": "nxos", "hostname":
       "server301", "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275256205}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275256205}, {"namespace":
       "nxos", "hostname": "server301", "ifname": "eth2", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275256205},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275256205},
       {"namespace": "nxos", "hostname": "server301", "ifname": "bond0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1619275256205}, {"namespace": "nxos", "hostname":
       "firewall01", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275256290},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275256290},
       {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1619275256290}, {"namespace": "nxos", "hostname":
       "firewall01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275256290},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275256290},
       {"namespace": "nxos", "hostname": "server302", "ifname": "eth2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1619275256321}, {"namespace": "nxos", "hostname": "server302",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
       "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275256321}, {"namespace":
       "nxos", "hostname": "server302", "ifname": "bond0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1619275256321}, {"namespace": "nxos", "hostname": "server302", "ifname": "eth1",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275256321}, {"namespace": "nxos", "hostname": "leaf03",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275256321}, {"namespace": "nxos", "hostname": "leaf03",
       "ifname": "Ethernet1/4", "state": "up", "peerHostname": "", "peerIfname": "",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275258539}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275258539}, {"namespace":
       "nxos", "hostname": "leaf03", "ifname": "Ethernet1/3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275258539},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275258539},
       {"namespace": "nxos", "hostname": "leaf03", "ifname": "port-channel1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03",
       "ifname": "port-channel3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275258539}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275258539}, {"namespace":
       "nxos", "hostname": "leaf03", "ifname": "port-channel4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275258539},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275258539},
       {"namespace": "nxos", "hostname": "leaf01", "ifname": "Ethernet1/4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01",
       "ifname": "Ethernet1/3", "state": "up", "peerHostname": "", "peerIfname": "",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275258762}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275258762}, {"namespace":
       "nxos", "hostname": "leaf01", "ifname": "port-channel1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275258762},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275258762},
       {"namespace": "nxos", "hostname": "leaf01", "ifname": "port-channel4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01",
       "ifname": "port-channel3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275258762}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275258762}, {"namespace":
       "nxos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/3",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "xe-0/0/4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/5", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "xe-0/0/6", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/7", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "xe-0/0/8", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/10", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "xe-0/0/11", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "bme0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "em0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "em1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "em2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "em4", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "xe-0/0/2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/9", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
       "dcedge01", "ifname": "em3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275258985},
       {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04",
       "ifname": "port-channel4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "leaf04", "ifname": "port-channel3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275259180},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275259180},
       {"namespace": "nxos", "hostname": "leaf04", "ifname": "port-channel1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04",
       "ifname": "Ethernet1/3", "state": "up", "peerHostname": "", "peerIfname": "",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "leaf02", "ifname": "Ethernet1/3", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275259186},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275259186},
       {"namespace": "nxos", "hostname": "leaf02", "ifname": "Ethernet1/4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02",
       "ifname": "port-channel3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1619275259186}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1619275259186}, {"namespace":
       "nxos", "hostname": "leaf02", "ifname": "port-channel4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1619275259186},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1619275259186},
       {"namespace": "nxos", "hostname": "leaf02", "ifname": "port-channel1", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "exit01",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "exit01",
       "ifname": "Ethernet1/3.3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275259574},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275259574},
       {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/3.2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
       "exit01", "ifname": "Ethernet1/3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275259574},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275259574},
       {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/3.4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
       "exit02", "ifname": "Ethernet1/3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275260177},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275260177},
       {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/3.2", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname":
       "exit02", "ifname": "Ethernet1/3.3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275260177},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1619275260177},
       {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/3.4", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname":
       "leaf03", "ifname": "Ethernet1/6", "state": "up", "peerHostname": "leaf04",
-      "peerIfname": "Ethernet1/6", "assert": "pass", "assertReason": [], "timestamp":
+      "peerIfname": "Ethernet1/6", "result": "pass", "assertReason": "-", "timestamp":
       1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/5",
-      "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet1/5", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275258539}, {"namespace": "nxos",
+      "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet1/5", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275258539}, {"namespace": "nxos",
       "hostname": "leaf03", "ifname": "Ethernet1/2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "Ethernet1/3", "assert": "pass", "assertReason": [],
+      "spine02", "peerIfname": "Ethernet1/3", "result": "pass", "assertReason": "-",
       "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
       "Ethernet1/1", "state": "up", "peerHostname": "spine01", "peerIfname": "Ethernet1/3",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275258539}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275258539}, {"namespace":
       "nxos", "hostname": "leaf03", "ifname": "mgmt0", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "mgmt0", "assert": "pass", "assertReason": [], "timestamp":
+      "spine01", "peerIfname": "mgmt0", "result": "pass", "assertReason": "-", "timestamp":
       1619275258539}, {"namespace": "nxos", "hostname": "leaf01", "ifname": "mgmt0",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "mgmt0", "assert": "fail",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "mgmt0", "result": "fail",
       "assertReason": ["Speed mismatch"], "timestamp": 1619275258762}, {"namespace":
       "nxos", "hostname": "spine02", "ifname": "mgmt0", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "mgmt0", "assert": "pass", "assertReason": [], "timestamp":
+      "spine01", "peerIfname": "mgmt0", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "mgmt0",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "mgmt0", "assert": "pass",
-      "assertReason": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+      "state": "up", "peerHostname": "spine01", "peerIfname": "mgmt0", "result": "pass",
+      "assertReason": "-", "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
       "leaf02", "ifname": "mgmt0", "state": "up", "peerHostname": "spine01", "peerIfname":
-      "mgmt0", "assert": "pass", "assertReason": [], "timestamp": 1619275259186},
+      "mgmt0", "result": "pass", "assertReason": "-", "timestamp": 1619275259186},
       {"namespace": "nxos", "hostname": "exit01", "ifname": "mgmt0", "state": "up",
-      "peerHostname": "spine01", "peerIfname": "mgmt0", "assert": "pass", "assertReason":
-      [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit02",
+      "peerHostname": "spine01", "peerIfname": "mgmt0", "result": "pass", "assertReason":
+      "-", "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit02",
       "ifname": "mgmt0", "state": "up", "peerHostname": "spine01", "peerIfname": "mgmt0",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275260177}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275260177}, {"namespace":
       "nxos", "hostname": "leaf01", "ifname": "Ethernet1/1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "Ethernet1/1", "assert": "pass", "assertReason": [],
+      "spine01", "peerIfname": "Ethernet1/1", "result": "pass", "assertReason": "-",
       "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
       "Ethernet1/6", "state": "up", "peerHostname": "leaf02", "peerIfname": "Ethernet1/6",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275258762}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275258762}, {"namespace":
       "nxos", "hostname": "leaf01", "ifname": "Ethernet1/5", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "Ethernet1/5", "assert": "pass", "assertReason": [],
+      "leaf02", "peerIfname": "Ethernet1/5", "result": "pass", "assertReason": "-",
       "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
       "Ethernet1/2", "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1/1",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275258762}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275258762}, {"namespace":
       "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/1", "state": "up", "peerHostname":
-      "exit02", "peerIfname": "Ethernet1/4", "assert": "fail", "assertReason": ["Speed
+      "exit02", "peerIfname": "Ethernet1/4", "result": "fail", "assertReason": ["Speed
       mismatch"], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
       "ifname": "xe-0/0/0", "state": "up", "peerHostname": "exit01", "peerIfname":
-      "Ethernet1/4", "assert": "fail", "assertReason": ["Speed mismatch"], "timestamp":
+      "Ethernet1/4", "result": "fail", "assertReason": ["Speed mismatch"], "timestamp":
       1619275258985}, {"namespace": "nxos", "hostname": "spine01", "ifname": "Ethernet1/1",
-      "state": "up", "peerHostname": "leaf01", "peerIfname": "Ethernet1/1", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace": "nxos",
+      "state": "up", "peerHostname": "leaf01", "peerIfname": "Ethernet1/1", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace": "nxos",
       "hostname": "leaf04", "ifname": "Ethernet1/6", "state": "up", "peerHostname":
-      "leaf03", "peerIfname": "Ethernet1/6", "assert": "pass", "assertReason": [],
+      "leaf03", "peerIfname": "Ethernet1/6", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
       "Ethernet1/5", "state": "up", "peerHostname": "leaf03", "peerIfname": "Ethernet1/5",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "spine01", "ifname": "mgmt0", "state": "up", "peerHostname":
-      "leaf03", "peerIfname": "mgmt0", "assert": "pass", "assertReason": [], "timestamp":
+      "leaf03", "peerIfname": "mgmt0", "result": "pass", "assertReason": "-", "timestamp":
       1619275259180}, {"namespace": "nxos", "hostname": "spine01", "ifname": "Ethernet1/2",
-      "state": "up", "peerHostname": "leaf02", "peerIfname": "Ethernet1/1", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace": "nxos",
+      "state": "up", "peerHostname": "leaf02", "peerIfname": "Ethernet1/1", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace": "nxos",
       "hostname": "spine01", "ifname": "Ethernet1/3", "state": "up", "peerHostname":
-      "leaf03", "peerIfname": "Ethernet1/1", "assert": "pass", "assertReason": [],
+      "leaf03", "peerIfname": "Ethernet1/1", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01", "ifname":
       "Ethernet1/4", "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet1/1",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "spine01", "ifname": "Ethernet1/5", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "Ethernet1/1", "assert": "pass", "assertReason": [],
+      "exit01", "peerIfname": "Ethernet1/1", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01", "ifname":
       "Ethernet1/6", "state": "up", "peerHostname": "exit02", "peerIfname": "Ethernet1/1",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "spine02", "ifname": "Ethernet1/1", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "Ethernet1/2", "assert": "pass", "assertReason": [],
+      "leaf01", "peerIfname": "Ethernet1/2", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02", "ifname":
       "Ethernet1/2", "state": "up", "peerHostname": "leaf02", "peerIfname": "Ethernet1/2",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "spine02", "ifname": "Ethernet1/3", "state": "up", "peerHostname":
-      "leaf03", "peerIfname": "Ethernet1/2", "assert": "pass", "assertReason": [],
+      "leaf03", "peerIfname": "Ethernet1/2", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02", "ifname":
       "Ethernet1/4", "state": "up", "peerHostname": "leaf04", "peerIfname": "Ethernet1/2",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "spine02", "ifname": "Ethernet1/5", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "Ethernet1/2", "assert": "pass", "assertReason": [],
+      "exit01", "peerIfname": "Ethernet1/2", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02", "ifname":
       "Ethernet1/6", "state": "up", "peerHostname": "exit02", "peerIfname": "Ethernet1/2",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "leaf04", "ifname": "Ethernet1/1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "Ethernet1/4", "assert": "pass", "assertReason": [],
+      "spine01", "peerIfname": "Ethernet1/4", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
       "Ethernet1/2", "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1/4",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259180}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259180}, {"namespace":
       "nxos", "hostname": "leaf02", "ifname": "Ethernet1/1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "Ethernet1/2", "assert": "pass", "assertReason": [],
+      "spine01", "peerIfname": "Ethernet1/2", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
       "Ethernet1/2", "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1/2",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259186}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259186}, {"namespace":
       "nxos", "hostname": "leaf02", "ifname": "Ethernet1/5", "state": "up", "peerHostname":
-      "leaf01", "peerIfname": "Ethernet1/5", "assert": "pass", "assertReason": [],
+      "leaf01", "peerIfname": "Ethernet1/5", "result": "pass", "assertReason": "-",
       "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
       "Ethernet1/6", "state": "up", "peerHostname": "leaf01", "peerIfname": "Ethernet1/6",
-      "assert": "pass", "assertReason": [], "timestamp": 1619275259186}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1619275259186}, {"namespace":
       "nxos", "hostname": "exit01", "ifname": "Ethernet1/4", "state": "up", "peerHostname":
-      "dcedge01", "peerIfname": "xe-0/0/0", "assert": "fail", "assertReason": ["Speed
+      "dcedge01", "peerIfname": "xe-0/0/0", "result": "fail", "assertReason": ["Speed
       mismatch"], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01",
       "ifname": "Ethernet1/2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "Ethernet1/5", "assert": "pass", "assertReason": [], "timestamp": 1619275259574},
+      "Ethernet1/5", "result": "pass", "assertReason": "-", "timestamp": 1619275259574},
       {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/1", "state":
-      "up", "peerHostname": "spine01", "peerIfname": "Ethernet1/5", "assert": "pass",
-      "assertReason": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+      "up", "peerHostname": "spine01", "peerIfname": "Ethernet1/5", "result": "pass",
+      "assertReason": "-", "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
       "exit02", "ifname": "Ethernet1/1", "state": "up", "peerHostname": "spine01",
-      "peerIfname": "Ethernet1/6", "assert": "pass", "assertReason": [], "timestamp":
+      "peerIfname": "Ethernet1/6", "result": "pass", "assertReason": "-", "timestamp":
       1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1/6", "assert":
-      "pass", "assertReason": [], "timestamp": 1619275260177}, {"namespace": "nxos",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "Ethernet1/6", "result":
+      "pass", "assertReason": "-", "timestamp": 1619275260177}, {"namespace": "nxos",
       "hostname": "exit02", "ifname": "Ethernet1/4", "state": "up", "peerHostname":
-      "dcedge01", "peerIfname": "xe-0/0/1", "assert": "fail", "assertReason": ["Speed
+      "dcedge01", "peerIfname": "xe-0/0/1", "result": "fail", "assertReason": ["Speed
       mismatch"], "timestamp": 1619275260177}]'
   marks: interface assert nxos
-- command: interface show --query-str='adminState == "down" and state == "up" ' --format=json --namespace=nxos
+- command: interface show --query-str='adminState == "down" and state == "up" ' --format=json
+    --namespace=nxos
   data-directory: tests/data/parquet/
   marks: interface show nxos
   output: '[]'

--- a/tests/integration/sqcmds/nxos-samples/ospf.yml
+++ b/tests/integration/sqcmds/nxos-samples/ospf.yml
@@ -186,49 +186,49 @@ tests:
   data-directory: tests/data/parquet/
   marks: ospf assert nxos
   output: '[{"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/2", "vrf":
-    "default", "assert": "pass", "assertReason": "-", "timestamp": 1619275260398},
+    "default", "result": "pass", "assertReason": "-", "timestamp": 1619275260398},
     {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1619275260398}, {"namespace":
-    "nxos", "hostname": "spine02", "ifname": "Ethernet1/6", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1619275260398}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/6", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1619275260613}, {"namespace": "nxos",
-    "hostname": "spine02", "ifname": "Ethernet1/5", "vrf": "default", "assert": "pass",
+    "hostname": "spine02", "ifname": "Ethernet1/5", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1619275260613}, {"namespace": "nxos", "hostname":
-    "spine02", "ifname": "Ethernet1/4", "vrf": "default", "assert": "pass", "assertReason":
+    "spine02", "ifname": "Ethernet1/4", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1619275260613}, {"namespace": "nxos", "hostname": "spine02",
-    "ifname": "Ethernet1/3", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "Ethernet1/3", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1619275260613}, {"namespace": "nxos", "hostname": "spine02", "ifname":
-    "Ethernet1/2", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "Ethernet1/2", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1619275260613}, {"namespace": "nxos", "hostname": "spine02", "ifname": "Ethernet1/1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1619275260613},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1619275260613},
     {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/1", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1619275261428}, {"namespace":
-    "nxos", "hostname": "exit01", "ifname": "Ethernet1/2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1619275261428}, {"namespace":
+    "nxos", "hostname": "exit01", "ifname": "Ethernet1/2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1619275261428}, {"namespace": "nxos",
-    "hostname": "leaf01", "ifname": "Ethernet1/2", "vrf": "default", "assert": "pass",
+    "hostname": "leaf01", "ifname": "Ethernet1/2", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1619275261428}, {"namespace": "nxos", "hostname":
-    "leaf01", "ifname": "Ethernet1/1", "vrf": "default", "assert": "pass", "assertReason":
+    "leaf01", "ifname": "Ethernet1/1", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1619275261428}, {"namespace": "nxos", "hostname": "exit02",
-    "ifname": "Ethernet1/2", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "Ethernet1/2", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1619275261836}, {"namespace": "nxos", "hostname": "exit02", "ifname":
-    "Ethernet1/1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "Ethernet1/1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1619275261836}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/1",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1619275262039},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1619275262039},
     {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1619275262039}, {"namespace":
-    "nxos", "hostname": "spine01", "ifname": "Ethernet1/2", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1619275262039}, {"namespace":
+    "nxos", "hostname": "spine01", "ifname": "Ethernet1/2", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1619275262040}, {"namespace": "nxos",
-    "hostname": "spine01", "ifname": "Ethernet1/5", "vrf": "default", "assert": "pass",
+    "hostname": "spine01", "ifname": "Ethernet1/5", "vrf": "default", "result": "pass",
     "assertReason": "-", "timestamp": 1619275262040}, {"namespace": "nxos", "hostname":
-    "spine01", "ifname": "Ethernet1/4", "vrf": "default", "assert": "pass", "assertReason":
+    "spine01", "ifname": "Ethernet1/4", "vrf": "default", "result": "pass", "assertReason":
     "-", "timestamp": 1619275262040}, {"namespace": "nxos", "hostname": "spine01",
-    "ifname": "Ethernet1/3", "vrf": "default", "assert": "pass", "assertReason": "-",
+    "ifname": "Ethernet1/3", "vrf": "default", "result": "pass", "assertReason": "-",
     "timestamp": 1619275262040}, {"namespace": "nxos", "hostname": "spine01", "ifname":
-    "Ethernet1/1", "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp":
+    "Ethernet1/1", "vrf": "default", "result": "pass", "assertReason": "-", "timestamp":
     1619275262040}, {"namespace": "nxos", "hostname": "spine01", "ifname": "Ethernet1/6",
-    "vrf": "default", "assert": "pass", "assertReason": "-", "timestamp": 1619275262040},
+    "vrf": "default", "result": "pass", "assertReason": "-", "timestamp": 1619275262040},
     {"namespace": "nxos", "hostname": "leaf02", "ifname": "Ethernet1/2", "vrf": "default",
-    "assert": "pass", "assertReason": "-", "timestamp": 1619275262652}, {"namespace":
-    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/1", "vrf": "default", "assert":
+    "result": "pass", "assertReason": "-", "timestamp": 1619275262652}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/1", "vrf": "default", "result":
     "pass", "assertReason": "-", "timestamp": 1619275262652}]'
 - command: ospf top --what=numChanges --format=json --namespace=nxos
   data-directory: tests/data/parquet/
@@ -282,7 +282,8 @@ tests:
     "default", "ifname": "Ethernet1/2", "peerHostname": "leaf02", "area": "0.0.0.0",
     "ifState": "up", "nbrCount": 1, "adjState": "full", "peerIP": "10.0.0.12", "numChanges":
     4, "lastChangeTime": 1619014444515, "timestamp": 1619275262040}]'
-- command: ospf show --ifname=Ethernet1/1 --hostname='leaf01 leaf02' --format=json --namespace=nxos
+- command: ospf show --ifname=Ethernet1/1 --hostname='leaf01 leaf02' --format=json
+    --namespace=nxos
   data-directory: tests/data/parquet/
   marks: ospf show nxos filter
   output: '[{"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "ifname":

--- a/tests/integration/sqcmds/panos-samples/bgp.yml
+++ b/tests/integration/sqcmds/panos-samples/bgp.yml
@@ -708,129 +708,129 @@ tests:
   error:
     error: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
       "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1639476253357},
       {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
       "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
       "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
       "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf04", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2",
       "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
       "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01",
       "vrf": "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf":
       "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
       {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "asn": 65534,
-      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "default", "peer": "swp3.2", "asn": 65520, "peerAsn":
-      65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+      65533, "state": "Established", "peerHostname": "firewall01", "result": "pass",
       "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname":
       "exit02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
-      "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace":
       "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf01",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
       "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}]'
   marks: bgp assert panos
 - command: bgp assert --format=json --namespace=panos
@@ -838,394 +838,394 @@ tests:
   error:
     error: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
       "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1639476253357},
       {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
       "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
       "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
       "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf04", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2",
       "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
       "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01",
       "vrf": "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf":
       "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
       {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "asn": 65534,
-      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "default", "peer": "swp3.2", "asn": 65520, "peerAsn":
-      65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+      65533, "state": "Established", "peerHostname": "firewall01", "result": "pass",
       "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname":
       "exit02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
-      "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace":
       "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf01",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
       "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}]'
   marks: bgp assert panos
-- command: bgp assert --status=pass --format=json --namespace=panos
+- command: bgp assert --result=pass --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: bgp assert panos
   output: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
     "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
-    "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+    "exit01", "result": "pass", "assertReason": "-", "timestamp": 1639476253357},
     {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
     "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
     "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
     "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
     "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
     "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
     "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
     "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
     "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
     "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
-    "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
     "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2", "asn": 65520,
-    "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+    "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
     "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace": "panos",
     "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn":
-    65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+    65533, "state": "Established", "peerHostname": "firewall01", "result": "pass",
     "assertReason": "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname":
     "exit01", "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534,
-    "state": "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+    "state": "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
     "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
     "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
-    "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+    "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
     "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
     "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-    "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason": "-",
+    "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason": "-",
     "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01", "vrf":
     "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state": "Established",
-    "peerHostname": "exit02", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "exit02", "result": "pass", "assertReason": "-", "timestamp":
     1639476253948}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "default",
     "peer": "169.254.127.1", "asn": 65534, "peerAsn": 65522, "state": "Established",
-    "peerHostname": "exit01", "assert": "pass", "assertReason": "-", "timestamp":
+    "peerHostname": "exit01", "result": "pass", "assertReason": "-", "timestamp":
     1639476253948}, {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf",
     "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state": "Established", "peerHostname":
-    "firewall01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253948},
+    "firewall01", "result": "pass", "assertReason": "-", "timestamp": 1639476253948},
     {"namespace": "panos", "hostname": "exit02", "vrf": "default", "peer": "swp3.2",
     "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-    "assert": "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace":
     "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
-    "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+    "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
     "pass", "assertReason": "-", "timestamp": 1639476253948}]'
-- command: bgp assert --status=fail --format=json --namespace=panos
+- command: bgp assert --result=fail --format=json --namespace=panos
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "panos", "hostname": "leaf03", "vrf": "default", "peer":
       "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf04", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit02", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit02", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit01", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
       {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.13", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf03", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf03", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf02", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf01", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
       {"namespace": "panos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253948}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "leaf02",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "fail", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
       "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine01", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine01", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf04",
       "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine02", "assert": "fail", "assertReason":
+      "Established", "peerHostname": "spine02", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
       "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine01", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine01", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}]'
   marks: bgp assert panos
-- command: bgp assert --status=all --format=json --namespace=panos
+- command: bgp assert --result=all --format=json --namespace=panos
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer":
       "169.254.254.9", "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname":
-      "exit01", "assert": "pass", "assertReason": "-", "timestamp": 1639476253357},
+      "exit01", "result": "pass", "assertReason": "-", "timestamp": 1639476253357},
       {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1",
       "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
       "asn": 65533, "peerAsn": 65522, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.5",
       "asn": 65533, "peerAsn": 65521, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1",
       "asn": 65533, "peerAsn": 65520, "state": "Established", "peerHostname": "exit02",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253357}, {"namespace":
       "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253942}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.14", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf04", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf04", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf02",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "spine02", "vrf": "default",
       "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "spine02",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253943}, {"namespace": "panos",
       "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253943},
       {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2",
       "asn": 65520, "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01",
-      "assert": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476253943}, {"namespace":
       "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253943}, {"namespace": "panos", "hostname": "exit01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit01",
       "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521, "peerAsn": 65533, "state":
-      "Established", "peerHostname": "firewall01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "firewall01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253943}, {"namespace": "panos", "hostname": "exit02",
       "vrf": "internet-vrf", "peer": "swp4", "asn": 65522, "peerAsn": 65534, "state":
-      "Established", "peerHostname": "dcedge01", "assert": "pass", "assertReason":
+      "Established", "peerHostname": "dcedge01", "result": "pass", "assertReason":
       "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "dcedge01",
       "vrf": "default", "peer": "169.254.127.3", "asn": 65534, "peerAsn": 65522, "state":
-      "Established", "peerHostname": "exit02", "assert": "pass", "assertReason": "-",
+      "Established", "peerHostname": "exit02", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf":
       "default", "peer": "10.0.0.32", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "exit02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "exit02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.31", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "exit01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "exit01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "asn": 64520,
-      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "assert":
+      "peerAsn": 64520, "state": "Established", "peerHostname": "leaf04", "result":
       "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948},
       {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
       "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname": "leaf03",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253948}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
       "peer": "10.0.0.12", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "leaf02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "leaf02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253948}, {"namespace": "panos", "hostname": "spine01",
       "vrf": "default", "peer": "10.0.0.11", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "leaf01", "assert": "fail", "assertReason": "Not
+      "Established", "peerHostname": "leaf01", "result": "fail", "assertReason": "Not
       all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "asn": 65534,
-      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "assert":
+      "peerAsn": 65522, "state": "Established", "peerHostname": "exit01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp3.4", "asn": 65522,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "default", "peer": "swp3.2", "asn": 65520, "peerAsn":
-      65533, "state": "Established", "peerHostname": "firewall01", "assert": "pass",
+      65533, "state": "Established", "peerHostname": "firewall01", "result": "pass",
       "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos", "hostname":
       "exit02", "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520,
-      "state": "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "state": "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253948}, {"namespace":
       "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "asn": 65521,
-      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "assert":
+      "peerAsn": 65533, "state": "Established", "peerHostname": "firewall01", "result":
       "pass", "assertReason": "-", "timestamp": 1639476253948}, {"namespace": "panos",
       "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine02", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}, {"namespace": "panos", "hostname": "leaf01",
       "vrf": "default", "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state":
-      "Established", "peerHostname": "spine01", "assert": "fail", "assertReason":
+      "Established", "peerHostname": "spine01", "result": "fail", "assertReason":
       "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace": "panos",
       "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "asn": 64520, "peerAsn":
-      64520, "state": "Established", "peerHostname": "spine02", "assert": "fail",
+      64520, "state": "Established", "peerHostname": "spine02", "result": "fail",
       "assertReason": "Not all Afi/Safis enabled", "timestamp": 1639476253949}, {"namespace":
       "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "asn":
       64520, "peerAsn": 64520, "state": "Established", "peerHostname": "spine01",
-      "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}]'
   marks: bgp assert panos
-- command: bgp assert --status=whatever --format=json --namespace=panos
+- command: bgp assert --result=whatever --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: bgp assert panos
   output: '[]'
@@ -1234,10 +1234,10 @@ tests:
   error:
     error: '[{"namespace": "panos", "hostname": "leaf01", "vrf": "default", "peer":
       "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}]'
   marks: bgp assert panos
 - command: bgp assert --hostname=leaf01 --namespace=panos --format=json
@@ -1245,10 +1245,10 @@ tests:
   error:
     error: '[{"namespace": "panos", "hostname": "leaf01", "vrf": "default", "peer":
       "10.0.0.22", "asn": 64520, "peerAsn": 64520, "state": "Established", "peerHostname":
-      "spine02", "assert": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
+      "spine02", "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1639476253949}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
       "peer": "10.0.0.21", "asn": 64520, "peerAsn": 64520, "state": "Established",
-      "peerHostname": "spine01", "assert": "fail", "assertReason": "Not all Afi/Safis
+      "peerHostname": "spine01", "result": "fail", "assertReason": "Not all Afi/Safis
       enabled", "timestamp": 1639476253949}]'
   marks: bgp assert panos
 - command: bgp unique --columns=hostname --format=json --namespace=panos

--- a/tests/integration/sqcmds/panos-samples/interface.yml
+++ b/tests/integration/sqcmds/panos-samples/interface.yml
@@ -596,282 +596,284 @@ tests:
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/1.3",
-      "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "firewall01", "ifname": "ethernet1/1.4", "state": "up",
-      "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/1.2", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2.4",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "firewall01", "ifname": "ethernet1/2.2", "state": "up",
-      "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/2.3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.2",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos",
+      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos",
       "hostname": "exit01", "ifname": "swp3.3", "state": "up", "peerHostname": "firewall01",
-      "peerIfname": "ethernet1/1", "assert": "pass", "assertReason": [], "timestamp":
+      "peerIfname": "ethernet1/1", "result": "pass", "assertReason": "-", "timestamp":
       1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.4",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos",
+      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos",
       "hostname": "exit01", "ifname": "vlan999", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "exit02", "ifname": "vlan999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "leaf04", "ifname":
-      "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "vlan999", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "vlan999", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "vlan999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "exit02", "ifname":
       "swp3.2", "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/2",
-      "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace":
       "panos", "hostname": "exit02", "ifname": "swp3.3", "state": "up", "peerHostname":
-      "firewall01", "peerIfname": "ethernet1/2", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
+      "firewall01", "peerIfname": "ethernet1/2", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
       "ifname": "swp3.4", "state": "up", "peerHostname": "firewall01", "peerIfname":
-      "ethernet1/2", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+      "ethernet1/2", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "peerlink.4094", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "peerlink.4094", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf04",
-      "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf04",
+      "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos",
       "hostname": "leaf02", "ifname": "Vlan30", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf01", "ifname":
-      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "Vlan20", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "Vlan10", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf01", "ifname":
-      "Vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "Vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "server102", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769},
       {"namespace": "panos", "hostname": "server102", "ifname": "eth2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253769}, {"namespace": "panos", "hostname": "server102",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
       "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769}, {"namespace":
       "panos", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476253769},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476253769},
       {"namespace": "panos", "hostname": "server301", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476253889}, {"namespace": "panos", "hostname":
       "server301", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476253889}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476253889}, {"namespace":
       "panos", "hostname": "server301", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476253889},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476253889},
       {"namespace": "panos", "hostname": "server301", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476253889}, {"namespace": "panos", "hostname":
       "server302", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253942},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253942},
       {"namespace": "panos", "hostname": "server302", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "server302",
-      "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476253942}, {"namespace": "panos",
+      "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476253942}, {"namespace": "panos",
       "hostname": "server302", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476253942}, {"namespace": "panos", "hostname": "server101", "ifname": "eth2",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "server101",
-      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254006}, {"namespace": "panos",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "server101",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254006}, {"namespace": "panos",
       "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254006}, {"namespace": "panos", "hostname": "server101", "ifname": "bond0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254006}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "Management Interface", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "dcedge01", "ifname": "eth0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
       "exit02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254817},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "exit01", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "swp3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
-      "swp4", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "swp4", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "bond02", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
-      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "swp3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf02", "ifname": "swp4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "bond02", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
-      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254844},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "spine02", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
       "leaf03", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf03", "ifname": "swp3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254844}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "spine01", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
       "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254854},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254854},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "bond02", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname":
-      "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "leaf01", "ifname": "swp4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254854}, {"namespace":
       "panos", "hostname": "leaf01", "ifname": "bond01", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254854},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254854},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/1", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["MTU mismatch"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "dcedge01", "ifname": "swp1", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
+      "exit01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
       1639476254659}, {"namespace": "panos", "hostname": "dcedge01", "ifname": "swp2",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp4", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
       "exit02", "ifname": "swp4", "state": "up", "peerHostname": "dcedge01", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
-      "fail", "assertReason": ["MTU mismatch"], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "exit01", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp6", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
-      "exit02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname":
-      "firewall01", "peerIfname": "ethernet1/2", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
-      "exit01", "ifname": "swp4", "state": "up", "peerHostname": "dcedge01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "leaf04", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "swp2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
-      "leaf04", "ifname": "swp6", "state": "up", "peerHostname": "leaf03", "peerIfname":
-      "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
+      {"namespace": "panos", "hostname": "exit01", "ifname": "swp1", "state": "up",
+      "peerHostname": "spine01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01",
+      "ifname": "swp3", "state": "up", "peerHostname": "firewall01", "peerIfname":
+      "ethernet1/1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp2",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+      "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+      "swp6", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
+      {"namespace": "panos", "hostname": "exit02", "ifname": "swp2", "state": "up",
+      "peerHostname": "spine02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
+      "ifname": "swp3", "state": "up", "peerHostname": "firewall01", "peerIfname":
+      "ethernet1/2", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp4",
+      "state": "up", "peerHostname": "dcedge01", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+      "leaf04", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+      "swp4", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
+      {"namespace": "panos", "hostname": "leaf04", "ifname": "swp2", "state": "up",
+      "peerHostname": "spine02", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04",
+      "ifname": "swp6", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
-      "leaf03", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+      "leaf03", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
       1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp6",
-      "state": "up", "peerHostname": "leaf01", "peerIfname": "swp6", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "state": "up", "peerHostname": "leaf01", "peerIfname": "swp6", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
-      "panos", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp5",
-      "state": "up", "peerHostname": "leaf01", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
-      "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
-      "panos", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp3",
-      "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
-      "spine02", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
-      "panos", "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp6",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
-      "leaf03", "ifname": "swp5", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp5", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
-      "panos", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp3", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
-      "leaf03", "ifname": "swp6", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+      "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
+      {"namespace": "panos", "hostname": "leaf02", "ifname": "swp1", "state": "up",
+      "peerHostname": "spine01", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+      "ifname": "swp5", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
+      "panos", "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp2",
+      "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+      "spine02", "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname":
+      "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
+      {"namespace": "panos", "hostname": "spine02", "ifname": "swp4", "state": "up",
+      "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "spine02",
+      "ifname": "swp5", "state": "up", "peerHostname": "exit01", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
+      "panos", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp5",
+      "state": "up", "peerHostname": "leaf04", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+      "leaf03", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
+      "swp3", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
+      {"namespace": "panos", "hostname": "leaf03", "ifname": "swp1", "state": "up",
+      "peerHostname": "spine01", "peerIfname": "swp3", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
+      "ifname": "swp6", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
       "panos", "hostname": "spine01", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
+      "leaf02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
       1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp6",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
       "spine01", "ifname": "swp5", "state": "up", "peerHostname": "exit01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254852}, {"namespace":
-      "panos", "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp3",
-      "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
-      "spine01", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254852}, {"namespace":
-      "panos", "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
-      "leaf01", "ifname": "swp5", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "swp5", "assert": "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace":
-      "panos", "hostname": "leaf01", "ifname": "swp6", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254854}]'
+      "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254852},
+      {"namespace": "panos", "hostname": "spine01", "ifname": "swp4", "state": "up",
+      "peerHostname": "leaf04", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254852}, {"namespace": "panos", "hostname": "spine01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254852}, {"namespace":
+      "panos", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1639476254852}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "leaf01", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
+      "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254854},
+      {"namespace": "panos", "hostname": "leaf01", "ifname": "swp5", "state": "up",
+      "peerHostname": "leaf02", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01",
+      "ifname": "swp6", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254854}]'
   marks: interface assert panos
 - command: interface top --what='statusChangeTimestamp' --format=json --namespace=panos
   data-directory: tests/data/parquet/
@@ -893,570 +895,572 @@ tests:
     "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
     "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
     1639466736510, "timestamp": 1639476254854}]'
-- command: interface assert --status=pass --format=json --namespace=panos
+- command: interface assert --result=pass --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: interface assert panos
   output: '[{"namespace": "panos", "hostname": "exit01", "ifname": "swp3.2", "state":
-    "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+    "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
     "exit01", "ifname": "swp3.3", "state": "up", "peerHostname": "firewall01", "peerIfname":
-    "ethernet1/1", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+    "ethernet1/1", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
     {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.4", "state": "up",
-    "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01",
-    "ifname": "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos",
+    "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01",
+    "ifname": "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos",
     "hostname": "exit02", "ifname": "vlan999", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
     {"namespace": "panos", "hostname": "leaf04", "ifname": "vlan999", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "vlan999",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf03",
-    "ifname": "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf03",
+    "ifname": "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos",
     "hostname": "leaf01", "ifname": "vlan999", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254854},
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254854},
     {"namespace": "panos", "hostname": "exit02", "ifname": "swp3.2", "state": "up",
-    "peerHostname": "firewall01", "peerIfname": "ethernet1/2", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
+    "peerHostname": "firewall01", "peerIfname": "ethernet1/2", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
     "ifname": "swp3.3", "state": "up", "peerHostname": "firewall01", "peerIfname":
-    "ethernet1/2", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+    "ethernet1/2", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
     {"namespace": "panos", "hostname": "exit02", "ifname": "swp3.4", "state": "up",
-    "peerHostname": "firewall01", "peerIfname": "ethernet1/2", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "leaf04",
+    "peerHostname": "firewall01", "peerIfname": "ethernet1/2", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "leaf04",
     "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname": "",
-    "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf02", "ifname": "peerlink.4094", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
     {"namespace": "panos", "hostname": "leaf03", "ifname": "peerlink.4094", "state":
-    "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf01",
+    "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf01",
     "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname": "",
-    "assert": "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476254854}, {"namespace":
     "panos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
     {"namespace": "panos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "leaf03", "ifname": "Vlan30",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf01",
-    "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf01",
+    "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos",
     "hostname": "leaf04", "ifname": "Vlan20", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
     {"namespace": "panos", "hostname": "leaf02", "ifname": "Vlan10", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "leaf01", "ifname": "Vlan10",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "server102",
-    "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476253769}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "server102",
+    "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476253769}, {"namespace": "panos",
     "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476253769},
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476253769},
     {"namespace": "panos", "hostname": "server301", "ifname": "eth2", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476253889}, {"namespace": "panos", "hostname": "server301", "ifname": "eth1",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476253889}, {"namespace": "panos", "hostname": "server302",
-    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476253942}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476253889}, {"namespace": "panos", "hostname": "server302",
+    "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476253942}, {"namespace": "panos",
     "hostname": "server302", "ifname": "eth2", "state": "up", "peerHostname": "",
-    "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476253942},
+    "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476253942},
     {"namespace": "panos", "hostname": "server101", "ifname": "eth2", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254006}, {"namespace": "panos", "hostname": "server101", "ifname": "eth1",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "leaf04",
-    "ifname": "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "leaf04",
+    "ifname": "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos",
     "hostname": "leaf04", "ifname": "swp4", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf04", "ifname": "bond02", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
     {"namespace": "panos", "hostname": "leaf04", "ifname": "bond01", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp3",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
-    "ifname": "swp4", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+    "ifname": "swp4", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos",
     "hostname": "leaf02", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf02", "ifname": "bond01", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
     {"namespace": "panos", "hostname": "leaf03", "ifname": "bond01", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp4",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
-    "ifname": "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
+    "ifname": "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos",
     "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname": "", "peerIfname":
-    "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+    "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
     "panos", "hostname": "leaf01", "ifname": "bond02", "state": "up", "peerHostname":
-    "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254854},
+    "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254854},
     {"namespace": "panos", "hostname": "leaf01", "ifname": "swp3", "state": "up",
-    "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp":
+    "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp":
     1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp4",
-    "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01",
-    "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-    "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos",
+    "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01",
+    "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+    "pass", "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos",
     "hostname": "dcedge01", "ifname": "swp1", "state": "up", "peerHostname": "exit01",
-    "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp": 1639476254659},
+    "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp": 1639476254659},
     {"namespace": "panos", "hostname": "dcedge01", "ifname": "swp2", "state": "up",
-    "peerHostname": "exit02", "peerIfname": "swp4", "assert": "pass", "assertReason":
-    [], "timestamp": 1639476254659}, {"namespace": "panos", "hostname": "exit02",
+    "peerHostname": "exit02", "peerIfname": "swp4", "result": "pass", "assertReason":
+    "-", "timestamp": 1639476254659}, {"namespace": "panos", "hostname": "exit02",
     "ifname": "swp4", "state": "up", "peerHostname": "dcedge01", "peerIfname": "swp2",
-    "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
+    "result": "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace":
     "panos", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+    "spine01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
     1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp2",
-    "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
     "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
+    "swp6", "result": "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace":
     "panos", "hostname": "exit02", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
+    "spine02", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
     1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp4",
-    "state": "up", "peerHostname": "dcedge01", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "dcedge01", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
     "leaf04", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp4", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "swp4", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf04", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
+    "spine02", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "swp6",
-    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp6", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf03", "peerIfname": "swp6", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
     "leaf04", "ifname": "swp5", "state": "up", "peerHostname": "leaf03", "peerIfname":
-    "swp5", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "swp5", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf02", "ifname": "swp6", "state": "up", "peerHostname":
-    "leaf01", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
+    "leaf01", "peerIfname": "swp6", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp2",
-    "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "spine02", "peerIfname": "swp2", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
     "leaf02", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
     "panos", "hostname": "leaf02", "ifname": "swp5", "state": "up", "peerHostname":
-    "leaf01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+    "leaf01", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
     1639476254836}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp1",
-    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp2", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
     "spine02", "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname":
-    "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
     "panos", "hostname": "spine02", "ifname": "swp3", "state": "up", "peerHostname":
-    "leaf03", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
+    "leaf03", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
     1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp4",
-    "state": "up", "peerHostname": "leaf04", "peerIfname": "swp2", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
     "spine02", "ifname": "swp5", "state": "up", "peerHostname": "exit01", "peerIfname":
-    "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+    "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
     "panos", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
-    "exit02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
+    "exit02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
     1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp5",
-    "state": "up", "peerHostname": "leaf04", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf04", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
     "leaf03", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-    "swp3", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+    "swp3", "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
     "panos", "hostname": "leaf03", "ifname": "swp1", "state": "up", "peerHostname":
-    "spine01", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
+    "spine01", "peerIfname": "swp3", "result": "pass", "assertReason": "-", "timestamp":
     1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp6",
-    "state": "up", "peerHostname": "leaf04", "peerIfname": "swp6", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf04", "peerIfname": "swp6", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
     "spine01", "ifname": "swp2", "state": "up", "peerHostname": "leaf02", "peerIfname":
-    "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254852}, {"namespace":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254852}, {"namespace":
     "panos", "hostname": "spine01", "ifname": "swp6", "state": "up", "peerHostname":
-    "exit02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
+    "exit02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
     1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp5",
-    "state": "up", "peerHostname": "exit01", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "exit01", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
     "spine01", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
-    "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254852}, {"namespace":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254852}, {"namespace":
     "panos", "hostname": "spine01", "ifname": "swp3", "state": "up", "peerHostname":
-    "leaf03", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
+    "leaf03", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
     1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp1",
-    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf01", "peerIfname": "swp1", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
     "leaf01", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
-    "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace":
+    "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254854}, {"namespace":
     "panos", "hostname": "leaf01", "ifname": "swp2", "state": "up", "peerHostname":
-    "spine02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
+    "spine02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
     1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp5",
-    "state": "up", "peerHostname": "leaf02", "peerIfname": "swp5", "assert": "pass",
-    "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+    "state": "up", "peerHostname": "leaf02", "peerIfname": "swp5", "result": "pass",
+    "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
     "leaf01", "ifname": "swp6", "state": "up", "peerHostname": "leaf02", "peerIfname":
-    "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254854}]'
-- command: interface assert --status=fail --format=json --namespace=panos
+    "swp6", "result": "pass", "assertReason": "-", "timestamp": 1639476254854}]'
+- command: interface assert --result=fail --format=json --namespace=panos
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/1.3",
-      "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "firewall01", "ifname": "ethernet1/1.4", "state": "up",
-      "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/1.2", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2.4",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "firewall01", "ifname": "ethernet1/2.2", "state": "up",
-      "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/2.3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "server102", "ifname": "bond0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476253769}, {"namespace": "panos", "hostname":
       "server102", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769},
       {"namespace": "panos", "hostname": "server301", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476253889}, {"namespace": "panos", "hostname":
       "server301", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253889},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253889},
       {"namespace": "panos", "hostname": "server302", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476253942}, {"namespace": "panos", "hostname":
       "server302", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253942},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253942},
       {"namespace": "panos", "hostname": "server101", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254006}, {"namespace": "panos", "hostname":
       "server101", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254006},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254006},
       {"namespace": "panos", "hostname": "firewall01", "ifname": "Management Interface",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "dcedge01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254659},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254659},
       {"namespace": "panos", "hostname": "exit02", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
       "exit01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254817},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf03", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
       "spine02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254844},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf03", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
       "spine01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254852},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254852},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "leaf01", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254854},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254854},
       {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/1", "state":
-      "up", "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "up", "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/2", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
+      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result":
       "fail", "assertReason": ["MTU mismatch"], "timestamp": 1639476254817}, {"namespace":
       "panos", "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname":
-      "firewall01", "peerIfname": "ethernet1/2", "assert": "fail", "assertReason":
+      "firewall01", "peerIfname": "ethernet1/2", "result": "fail", "assertReason":
       ["MTU mismatch"], "timestamp": 1639476254817}]'
   marks: interface assert panos
-- command: interface assert --status=all --format=json --namespace=panos
+- command: interface assert --result=all --format=json --namespace=panos
   data-directory: tests/data/parquet/
   error:
     error: '[{"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/1.3",
-      "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "firewall01", "ifname": "ethernet1/1.4", "state": "up",
-      "peerHostname": "exit01", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "peerHostname": "exit01", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/1.2", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2.4",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "firewall01", "ifname": "ethernet1/2.2", "state": "up",
-      "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail", "assertReason":
+      "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254171}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/2.3", "state": "up", "peerHostname": "exit02",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.2",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos",
+      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos",
       "hostname": "exit01", "ifname": "swp3.3", "state": "up", "peerHostname": "firewall01",
-      "peerIfname": "ethernet1/1", "assert": "pass", "assertReason": [], "timestamp":
+      "peerIfname": "ethernet1/1", "result": "pass", "assertReason": "-", "timestamp":
       1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3.4",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos",
+      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos",
       "hostname": "exit01", "ifname": "vlan999", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "exit02", "ifname": "vlan999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "leaf04", "ifname":
-      "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "vlan999", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "vlan999", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "vlan999", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "vlan999", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "exit02", "ifname":
       "swp3.2", "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/2",
-      "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254817}, {"namespace":
       "panos", "hostname": "exit02", "ifname": "swp3.3", "state": "up", "peerHostname":
-      "firewall01", "peerIfname": "ethernet1/2", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
+      "firewall01", "peerIfname": "ethernet1/2", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
       "ifname": "swp3.4", "state": "up", "peerHostname": "firewall01", "peerIfname":
-      "ethernet1/2", "assert": "pass", "assertReason": [], "timestamp": 1639476254817},
+      "ethernet1/2", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "peerlink.4094", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
       "ifname": "peerlink.4094", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "peerlink.4094", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf04",
-      "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos",
+      "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf04",
+      "ifname": "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos",
       "hostname": "leaf02", "ifname": "Vlan30", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+      "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf01", "ifname":
-      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "Vlan30", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "Vlan20", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "Vlan10", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf01", "ifname":
-      "Vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "Vlan10", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "server102", "ifname": "bond0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769},
       {"namespace": "panos", "hostname": "server102", "ifname": "eth2", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253769}, {"namespace": "panos", "hostname": "server102",
-      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
+      "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result":
       "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253769}, {"namespace":
       "panos", "hostname": "server102", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476253769},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476253769},
       {"namespace": "panos", "hostname": "server301", "ifname": "bond0", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476253889}, {"namespace": "panos", "hostname":
       "server301", "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476253889}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476253889}, {"namespace":
       "panos", "hostname": "server301", "ifname": "eth1", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476253889},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476253889},
       {"namespace": "panos", "hostname": "server301", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476253889}, {"namespace": "panos", "hostname":
       "server302", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253942},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476253942},
       {"namespace": "panos", "hostname": "server302", "ifname": "eth1", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476253942}, {"namespace": "panos", "hostname": "server302",
-      "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476253942}, {"namespace": "panos",
+      "ifname": "eth2", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476253942}, {"namespace": "panos",
       "hostname": "server302", "ifname": "bond0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476253942}, {"namespace": "panos", "hostname": "server101", "ifname": "eth2",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason":
-      [], "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "server101",
-      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "assert":
-      "pass", "assertReason": [], "timestamp": 1639476254006}, {"namespace": "panos",
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254006}, {"namespace": "panos", "hostname": "server101",
+      "ifname": "eth1", "state": "up", "peerHostname": "", "peerIfname": "", "result":
+      "pass", "assertReason": "-", "timestamp": 1639476254006}, {"namespace": "panos",
       "hostname": "server101", "ifname": "eth0", "state": "up", "peerHostname": "",
-      "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254006}, {"namespace": "panos", "hostname": "server101", "ifname": "bond0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254006}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "Management Interface", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp":
+      "", "peerIfname": "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "dcedge01", "ifname": "eth0",
-      "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
       "exit02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254817},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254817},
       {"namespace": "panos", "hostname": "exit01", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "swp3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
-      "swp4", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "swp4", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf04", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf04", "ifname": "bond02", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname":
-      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "eth0", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "peerlink", "state":
-      "up", "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason":
+      "up", "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason":
       ["No Peer Found"], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "swp3", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf02", "ifname": "swp4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254836},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
       {"namespace": "panos", "hostname": "leaf02", "ifname": "bond02", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname":
-      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "bond01", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf03", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254844},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "spine02", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
       "leaf03", "ifname": "bond01", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "swp4", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "leaf03", "ifname": "swp3", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname":
-      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "fail",
+      "eth0", "state": "up", "peerHostname": "", "peerIfname": "", "result": "fail",
       "assertReason": ["No Peer Found"], "timestamp": 1639476254844}, {"namespace":
       "panos", "hostname": "leaf03", "ifname": "bond02", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254844},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
       {"namespace": "panos", "hostname": "spine01", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
       "leaf01", "ifname": "peerlink", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254854},
+      "", "result": "fail", "assertReason": ["No Peer Found"], "timestamp": 1639476254854},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "bond02", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "pass", "assertReason": [],
+      "peerHostname": "", "peerIfname": "", "result": "pass", "assertReason": "-",
       "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname":
-      "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "swp3", "state": "up", "peerHostname": "", "peerIfname": "", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "leaf01", "ifname": "swp4", "state": "up", "peerHostname": "", "peerIfname":
-      "", "assert": "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace":
+      "", "result": "pass", "assertReason": "-", "timestamp": 1639476254854}, {"namespace":
       "panos", "hostname": "leaf01", "ifname": "bond01", "state": "up", "peerHostname":
-      "", "peerIfname": "", "assert": "pass", "assertReason": [], "timestamp": 1639476254854},
+      "", "peerIfname": "", "result": "pass", "assertReason": "-", "timestamp": 1639476254854},
       {"namespace": "panos", "hostname": "leaf01", "ifname": "eth0", "state": "up",
-      "peerHostname": "", "peerIfname": "", "assert": "fail", "assertReason": ["No
+      "peerHostname": "", "peerIfname": "", "result": "fail", "assertReason": ["No
       Peer Found"], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
       "firewall01", "ifname": "ethernet1/1", "state": "up", "peerHostname": "exit01",
-      "peerIfname": "swp3", "assert": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      "peerIfname": "swp3", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
       1639476254171}, {"namespace": "panos", "hostname": "firewall01", "ifname": "ethernet1/2",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "assert": "fail",
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp3", "result": "fail",
       "assertReason": ["MTU mismatch"], "timestamp": 1639476254171}, {"namespace":
       "panos", "hostname": "dcedge01", "ifname": "swp1", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
+      "exit01", "peerIfname": "swp4", "result": "pass", "assertReason": "-", "timestamp":
       1639476254659}, {"namespace": "panos", "hostname": "dcedge01", "ifname": "swp2",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp4", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254659}, {"namespace": "panos", "hostname":
       "exit02", "ifname": "swp4", "state": "up", "peerHostname": "dcedge01", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "exit01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp3",
-      "state": "up", "peerHostname": "firewall01", "peerIfname": "ethernet1/1", "assert":
-      "fail", "assertReason": ["MTU mismatch"], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "exit01", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254817}, {"namespace": "panos", "hostname": "exit02", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp6", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
-      "exit02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "exit02", "ifname": "swp3", "state": "up", "peerHostname":
-      "firewall01", "peerIfname": "ethernet1/2", "assert": "fail", "assertReason":
-      ["MTU mismatch"], "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
-      "exit01", "ifname": "swp4", "state": "up", "peerHostname": "dcedge01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254817}, {"namespace":
-      "panos", "hostname": "leaf04", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp4", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254836}, {"namespace": "panos", "hostname": "leaf04", "ifname": "swp2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "swp4", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
-      "leaf04", "ifname": "swp6", "state": "up", "peerHostname": "leaf03", "peerIfname":
-      "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
+      "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
+      {"namespace": "panos", "hostname": "exit01", "ifname": "swp1", "state": "up",
+      "peerHostname": "spine01", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit01",
+      "ifname": "swp3", "state": "up", "peerHostname": "firewall01", "peerIfname":
+      "ethernet1/1", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp2",
+      "state": "up", "peerHostname": "spine02", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+      "exit02", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+      "swp6", "result": "pass", "assertReason": "-", "timestamp": 1639476254817},
+      {"namespace": "panos", "hostname": "exit02", "ifname": "swp2", "state": "up",
+      "peerHostname": "spine02", "peerIfname": "swp6", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname": "exit02",
+      "ifname": "swp3", "state": "up", "peerHostname": "firewall01", "peerIfname":
+      "ethernet1/2", "result": "fail", "assertReason": ["MTU mismatch"], "timestamp":
+      1639476254817}, {"namespace": "panos", "hostname": "exit01", "ifname": "swp4",
+      "state": "up", "peerHostname": "dcedge01", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254817}, {"namespace": "panos", "hostname":
+      "leaf04", "ifname": "swp1", "state": "up", "peerHostname": "spine01", "peerIfname":
+      "swp4", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
+      {"namespace": "panos", "hostname": "leaf04", "ifname": "swp2", "state": "up",
+      "peerHostname": "spine02", "peerIfname": "swp4", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf04",
+      "ifname": "swp6", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
       "panos", "hostname": "leaf04", "ifname": "swp5", "state": "up", "peerHostname":
-      "leaf03", "peerIfname": "swp5", "assert": "pass", "assertReason": [], "timestamp":
+      "leaf03", "peerIfname": "swp5", "result": "pass", "assertReason": "-", "timestamp":
       1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp6",
-      "state": "up", "peerHostname": "leaf01", "peerIfname": "swp6", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
+      "state": "up", "peerHostname": "leaf01", "peerIfname": "swp6", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
       "leaf02", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254836}, {"namespace":
-      "panos", "hostname": "leaf02", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254836}, {"namespace": "panos", "hostname": "leaf02", "ifname": "swp5",
-      "state": "up", "peerHostname": "leaf01", "peerIfname": "swp5", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254836}, {"namespace": "panos", "hostname":
-      "spine02", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
-      "panos", "hostname": "spine02", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp3",
-      "state": "up", "peerHostname": "leaf03", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
-      "spine02", "ifname": "swp4", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp2", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
-      "panos", "hostname": "spine02", "ifname": "swp5", "state": "up", "peerHostname":
-      "exit01", "peerIfname": "swp2", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp6",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp2", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
-      "leaf03", "ifname": "swp5", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp5", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
-      "panos", "hostname": "leaf03", "ifname": "swp2", "state": "up", "peerHostname":
-      "spine02", "peerIfname": "swp3", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp1",
-      "state": "up", "peerHostname": "spine01", "peerIfname": "swp3", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
-      "leaf03", "ifname": "swp6", "state": "up", "peerHostname": "leaf04", "peerIfname":
-      "swp6", "assert": "pass", "assertReason": [], "timestamp": 1639476254844}, {"namespace":
+      "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254836},
+      {"namespace": "panos", "hostname": "leaf02", "ifname": "swp1", "state": "up",
+      "peerHostname": "spine01", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254836}, {"namespace": "panos", "hostname": "leaf02",
+      "ifname": "swp5", "state": "up", "peerHostname": "leaf01", "peerIfname": "swp5",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254836}, {"namespace":
+      "panos", "hostname": "spine02", "ifname": "swp1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1639476254844}, {"namespace": "panos", "hostname": "spine02", "ifname": "swp2",
+      "state": "up", "peerHostname": "leaf02", "peerIfname": "swp2", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+      "spine02", "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname":
+      "swp2", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
+      {"namespace": "panos", "hostname": "spine02", "ifname": "swp4", "state": "up",
+      "peerHostname": "leaf04", "peerIfname": "swp2", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "spine02",
+      "ifname": "swp5", "state": "up", "peerHostname": "exit01", "peerIfname": "swp2",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
+      "panos", "hostname": "spine02", "ifname": "swp6", "state": "up", "peerHostname":
+      "exit02", "peerIfname": "swp2", "result": "pass", "assertReason": "-", "timestamp":
+      1639476254844}, {"namespace": "panos", "hostname": "leaf03", "ifname": "swp5",
+      "state": "up", "peerHostname": "leaf04", "peerIfname": "swp5", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname":
+      "leaf03", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
+      "swp3", "result": "pass", "assertReason": "-", "timestamp": 1639476254844},
+      {"namespace": "panos", "hostname": "leaf03", "ifname": "swp1", "state": "up",
+      "peerHostname": "spine01", "peerIfname": "swp3", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254844}, {"namespace": "panos", "hostname": "leaf03",
+      "ifname": "swp6", "state": "up", "peerHostname": "leaf04", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254844}, {"namespace":
       "panos", "hostname": "spine01", "ifname": "swp2", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
+      "leaf02", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
       1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp6",
-      "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
+      "state": "up", "peerHostname": "exit02", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
       "spine01", "ifname": "swp5", "state": "up", "peerHostname": "exit01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254852}, {"namespace":
-      "panos", "hostname": "spine01", "ifname": "swp4", "state": "up", "peerHostname":
-      "leaf04", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254852}, {"namespace": "panos", "hostname": "spine01", "ifname": "swp3",
-      "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254852}, {"namespace": "panos", "hostname":
-      "spine01", "ifname": "swp1", "state": "up", "peerHostname": "leaf01", "peerIfname":
-      "swp1", "assert": "pass", "assertReason": [], "timestamp": 1639476254852}, {"namespace":
-      "panos", "hostname": "leaf01", "ifname": "swp1", "state": "up", "peerHostname":
-      "spine01", "peerIfname": "swp1", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254854}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp2",
-      "state": "up", "peerHostname": "spine02", "peerIfname": "swp1", "assert": "pass",
-      "assertReason": [], "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
-      "leaf01", "ifname": "swp5", "state": "up", "peerHostname": "leaf02", "peerIfname":
-      "swp5", "assert": "pass", "assertReason": [], "timestamp": 1639476254854}, {"namespace":
-      "panos", "hostname": "leaf01", "ifname": "swp6", "state": "up", "peerHostname":
-      "leaf02", "peerIfname": "swp6", "assert": "pass", "assertReason": [], "timestamp":
-      1639476254854}]'
+      "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254852},
+      {"namespace": "panos", "hostname": "spine01", "ifname": "swp4", "state": "up",
+      "peerHostname": "leaf04", "peerIfname": "swp1", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254852}, {"namespace": "panos", "hostname": "spine01",
+      "ifname": "swp3", "state": "up", "peerHostname": "leaf03", "peerIfname": "swp1",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254852}, {"namespace":
+      "panos", "hostname": "spine01", "ifname": "swp1", "state": "up", "peerHostname":
+      "leaf01", "peerIfname": "swp1", "result": "pass", "assertReason": "-", "timestamp":
+      1639476254852}, {"namespace": "panos", "hostname": "leaf01", "ifname": "swp1",
+      "state": "up", "peerHostname": "spine01", "peerIfname": "swp1", "result": "pass",
+      "assertReason": "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname":
+      "leaf01", "ifname": "swp2", "state": "up", "peerHostname": "spine02", "peerIfname":
+      "swp1", "result": "pass", "assertReason": "-", "timestamp": 1639476254854},
+      {"namespace": "panos", "hostname": "leaf01", "ifname": "swp5", "state": "up",
+      "peerHostname": "leaf02", "peerIfname": "swp5", "result": "pass", "assertReason":
+      "-", "timestamp": 1639476254854}, {"namespace": "panos", "hostname": "leaf01",
+      "ifname": "swp6", "state": "up", "peerHostname": "leaf02", "peerIfname": "swp6",
+      "result": "pass", "assertReason": "-", "timestamp": 1639476254854}]'
   marks: interface assert panos
-- command: interface assert --status=whatever --format=json --namespace=panos
+- command: interface assert --result=whatever --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: interface assert panos
   output: '[]'

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -73,9 +73,9 @@ FILTERS = ['',  # for vanilla commands without any filter
            'polled=True',
            'usedPercent=8',
            'column=prefixlen',
-           'status=pass',
-           'status=fail',
-           'status=all',
+           'result=pass',
+           'result=fail',
+           'result=all',
            'status=whatever',
            'vlanName=vlan13',
            'status=alive',
@@ -164,11 +164,11 @@ GOOD_FILTERS_FOR_SERVICE_VERB = {
                     'ospf/assert', 'ospf/show',
                     'route/show', 'route/summarize',
                     ],
-    'status=pass': ['bgp/assert', 'evpnVni/assert', 'interfaces/assert',
+    'result=pass': ['bgp/assert', 'evpnVni/assert', 'interfaces/assert',
                     'ospf/assert', 'sqpoller/show'],
-    'status=fail': ['bgp/assert', 'evpnVni/assert', 'interfaces/assert',
+    'result=fail': ['bgp/assert', 'evpnVni/assert', 'interfaces/assert',
                     'ospf/assert'],
-    'status=all': ['bgp/assert', 'evpnVni/assert', 'interfaces/assert',
+    'result=all': ['bgp/assert', 'evpnVni/assert', 'interfaces/assert',
                    'ospf/assert'],
     'status=alive': ['device/show'],
     'status=dead': ['device/show'],
@@ -197,8 +197,8 @@ GOOD_FILTERS_FOR_SERVICE_VERB = {
 
 GOOD_FILTER_EMPTY_RESULT_FILTER = [
     'sqPoller/show?status=fail',
-    'ospf/assert?status=fail',
-    'evpnVni/assert?status=fail',
+    'ospf/assert?result=fail',
+    'evpnVni/assert?result=fail',
     'device/show?status=neverpoll',
     'device/show?status=dead',
     'vlan/unique?state=notConnected',
@@ -482,8 +482,8 @@ def test_rest_arg_consistency(service, verb):
                 f"{arg} missing from {fn} arguments for verb {verb}"
 
         for arg in rest_args:
-            if arg not in valid_args and arg != "status":
-                # status is usually part of assert keyword and so ignore
+            if arg not in valid_args and arg != "result":
+                # result is usually part of assert keyword and so ignore
                 if found_service_rest_fn:
                     assert False, \
                         f"{arg} not in {service} sqobj {verb} arguments"


### PR DESCRIPTION
This PR contains:
- [x] Rename the `status` subcommand of `assert` command to `result`.
- [x] Change the column name of assertion results from `assert` to `result`
- [x] update REST server commands
- [x] Update tests

