### PR TITLE
4B ASN support

### DIFF
--- a/suzieq/config/schema/bgp.avsc
+++ b/suzieq/config/schema/bgp.avsc
@@ -226,6 +226,12 @@
             "description": "This devices' ASN"
         },
         {
+            "name": "asndot",
+            "type": "string",
+	    "depends": "asn",
+            "description": "This devices' ASN displayed in asdot format"
+        },
+        {
             "name": "notificnReason",
             "type": "string",
             "description": "Last BGP notification reason"
@@ -250,6 +256,12 @@
             "type": "long",
             "display": 9,
             "description": "Peer device's ASN"
+        },
+        {
+            "name": "peerAsndot",
+            "type": "string",
+	    "depends": "peerAsn",
+            "description": "Peer device's ASN displayed in asdot format"
         },
         {
             "name": "peerIP",

--- a/suzieq/config/textfsm_templates/eos_show_bgp_nbr.tfsm
+++ b/suzieq/config/textfsm_templates/eos_show_bgp_nbr.tfsm
@@ -1,6 +1,6 @@
 Value peer (\S+)
-Value peerAsn (\d+)
-Value asn (\d+)
+Value peerAsn ([0-9.]+)
+Value asn ([0-9.]+)
 Value vrf (\S+)
 Value description (.+?)
 Value peerRouterId ([0-9.]+)
@@ -67,7 +67,8 @@ Start
 
 PrefixStats
   ^\s+${afi}\s+${safi}:\s+${pfxTx}\s+${pfxRx}\s+${pfxBestRx}.*$$
-  ^\s+${afi}\s+${safi}:\s+${pfxTx}\s+${pfxRx}\s*$$  
+  ^\s+${afi}\s+${safi}:\s+${pfxTx}\s+${pfxRx}\s*$$
+  ^\s+${afi}\s*:\s+${pfxTx}\s+${pfxRx}\s+${pfxBestRx}.*$$  
   ^\s+${afi}:\s+${pfxTx}\s+${pfxRx}\s*$$
   ^\s+Configured\s+maximum\s+total\s+number\s+of\s+routes\s+is\s+${pfxMaxRx}\s*$$
   ^\s+Inbound\s+route\s+map\s+for\s+${iMapafisafi}\s+is\s+${ingressRmap}\s*$$

--- a/suzieq/engines/pandas/bgp.py
+++ b/suzieq/engines/pandas/bgp.py
@@ -28,6 +28,10 @@ class BgpObj(SqPandasEngine):
         sch = self.schema
         fields = sch.get_display_fields(columns)
 
+        if columns == ['*']:
+            fields.remove('sqvers')
+            fields.remove('origPeer')
+
         for col in ['peerIP', 'updateSource', 'state', 'namespace', 'vrf',
                     'peer', 'hostname']:
             if col not in fields:
@@ -55,6 +59,13 @@ class BgpObj(SqPandasEngine):
             df['peer'] = np.where(df['origPeer'] != "",
                                   df['origPeer'], df['peer'])
 
+        if 'asndot' in fields:
+            df['asndot'] = df.asn.apply(lambda x: f'{int(x/65536)}.{x%65536}')
+
+        if 'peerAsndot' in fields:
+            df['peerAsndot'] = df.peerAsn.apply(
+                lambda x: f'{int(x/65536)}.{x%65536}')
+
         # Convert old data into new 2.0 data format
         if 'peerHostname' in df.columns:
             mdf = self._get_peer_matched_df(df)
@@ -67,9 +78,9 @@ class BgpObj(SqPandasEngine):
 
         if query_str:
             return mdf.query(query_str).drop(columns=drop_cols,
-                                             errors='ignore')
+                                             errors='ignore')[fields]
         else:
-            return mdf.drop(columns=drop_cols, errors='ignore')
+            return mdf.drop(columns=drop_cols, errors='ignore')[fields]
 
     def summarize(self, **kwargs) -> pd.DataFrame:
         """Summarize key information about BGP"""
@@ -263,19 +274,23 @@ class BgpObj(SqPandasEngine):
                      x['reason'] != "No error"))
                 else [], axis=1)
 
+            failed_df['result'] = 'fail'
+
         # Get list of peer IP addresses for peer not in Established state
         # Returning to performing checks even if we didn't get LLDP/Intf info
 
-        passed_df['assertReason'] += passed_df.apply(
-            lambda x: ['Not all Afi/Safis enabled']
-            if x['afisAdvOnly'].any() or x['afisRcvOnly'].any() else [],
-            axis=1)
+        if not passed_df.empty:
+            passed_df['assertReason'] += passed_df.apply(
+                lambda x: ['Not all Afi/Safis enabled']
+                if x['afisAdvOnly'].any() or x['afisRcvOnly'].any() else [],
+                axis=1)
+
+            passed_df['result'] = passed_df.apply(
+                lambda x: 'pass'
+                if len(x.assertReason) == 0 else 'fail',
+                axis=1)
 
         df = pd.concat([failed_df, passed_df])
-
-        df['result'] = df.apply(lambda x: 'pass'
-                                if len(x.assertReason) == 0 else 'fail',
-                                axis=1)
 
         result_df = df[['namespace', 'hostname', 'vrf', 'peer', 'asn',
                         'peerAsn', 'state', 'peerHostname', 'result',

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -772,6 +772,27 @@ def get_sleep_time(period: str) -> int:
     return (nextrun-now).seconds
 
 
+def convert_asndot_to_asn(asn: str) -> int:
+    """Convert BGP ASN into asdot format
+
+    Convert BGP ASN if a single integer to asdot(<asn_hi>.<asn_lo>)
+    format. If input ASN is in asdot format already, it returns it as is.
+    If input ASN is < 65535, returns it as is.
+
+    Args:
+        asn: ASN to convert
+
+    Returns:
+        BGP ASN as 32b integer
+    """
+
+    if isinstance(asn, int) or '.' not in asn:
+        return asn
+
+    s_asn = asn.split('.')
+    return int(s_asn[0])*65536+int(s_asn[1])
+
+
 def print_version():
     '''Print the suzieq version and return'''
     print(SUZIEQ_VERSION)

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -56,44 +56,47 @@ tests:
     only we advertised"}, {"name": "afisRcvOnly", "type": {"type": "array", "items":
     {"name": "weight", "type": "string"}}, "key": "", "display": "", "description":
     "The list of AFIs only our peer advertised"}, {"name": "asn", "type": "long",
-    "key": "", "display": 8, "description": "This devices'' ASN"}, {"name": "bfdStatus",
-    "type": "string", "key": "", "display": "", "description": "BFD status"}, {"name":
-    "communityTypes", "type": {"type": "array", "items": {"name": "weight", "type":
-    "string"}}, "key": "", "display": "", "description": "List of types of communities
-    advertised for AFI/SAFI to peer"}, {"name": "defOriginate", "type": "boolean",
-    "key": "", "display": "", "description": "True if advertising default route for
-    this AFI/SAFI to peer"}, {"name": "egressRmap", "type": "string", "key": "", "display":
-    "", "description": "Route map name associated with egress for AFI/SAFI"}, {"name":
-    "estdTime", "type": "timedelta64[s]", "key": "", "display": 13, "description":
-    "Session uptime"}, {"name": "extnhAdvertised", "type": "boolean", "key": "", "display":
-    "", "description": "Extended NextHop capability sent"}, {"name": "extnhEnabled",
+    "key": "", "display": 8, "description": "This devices'' ASN"}, {"name": "asndot",
+    "type": "string", "key": "", "display": "", "description": "This devices'' ASN
+    displayed in asdot format"}, {"name": "bfdStatus", "type": "string", "key": "",
+    "display": "", "description": "BFD status"}, {"name": "communityTypes", "type":
+    {"type": "array", "items": {"name": "weight", "type": "string"}}, "key": "", "display":
+    "", "description": "List of types of communities advertised for AFI/SAFI to peer"},
+    {"name": "defOriginate", "type": "boolean", "key": "", "display": "", "description":
+    "True if advertising default route for this AFI/SAFI to peer"}, {"name": "egressRmap",
+    "type": "string", "key": "", "display": "", "description": "Route map name associated
+    with egress for AFI/SAFI"}, {"name": "estdTime", "type": "timedelta64[s]", "key":
+    "", "display": 13, "description": "Session uptime"}, {"name": "extnhAdvertised",
     "type": "boolean", "key": "", "display": "", "description": "Extended NextHop
-    capability enabled on session"}, {"name": "extnhReceived", "type": "boolean",
-    "key": "", "display": "", "description": "Extended NextHop capability rcvd"},
-    {"name": "holdTime", "type": "long", "key": "", "display": "", "description":
-    "BGP hold time"}, {"name": "hopsMax", "type": "long", "key": "", "display": "",
-    "description": "Maximum #hops this peer can be"}, {"name": "hostname", "type":
-    "string", "key": 1, "display": 1, "description": "Hostname associated with this
-    record"}, {"name": "ifname", "type": "string", "key": "", "display": "", "description":
-    "Interface name associated with session"}, {"name": "ingressRmap", "type": "string",
-    "key": "", "display": "", "description": "Route map name associated with ingress
-    for AFI/SAFI"}, {"name": "keepaliveTime", "type": "long", "key": "", "display":
-    "", "description": "BGP peer keepalive time in secs"}, {"name": "lastDownTime",
-    "type": "timestamp", "key": "", "display": "", "description": "Unix epoch indicating
-    when session was last down"}, {"name": "mrai", "type": "long", "key": "", "display":
-    "", "description": "Min Route Adv Interval, in secs"}, {"name": "namespace", "type":
-    "string", "key": 0, "display": 0, "description": "Namespace associated with this
-    record"}, {"name": "nhSelf", "type": "boolean", "key": "", "display": "", "description":
-    "True if set nexthop self is configured for iBGP peer"}, {"name": "nhUnchanged",
-    "type": "boolean", "key": "", "display": "", "description": "True if set nexthop
-    unchanged is configured for eBGP peer"}, {"name": "notificnReason", "type": "string",
-    "key": "", "display": "", "description": "Last BGP notification reason"}, {"name":
-    "numChanges", "type": "long", "key": "", "display": 12, "description": "Count
-    of changes in BGP session state"}, {"name": "origPeer", "type": "string", "key":
-    "", "display": "", "description": "internal field, not selectable"}, {"name":
-    "peer", "type": "string", "key": 3, "display": 3, "description": "IP address or
-    ifname of BGP peer"}, {"name": "peerAsn", "type": "long", "key": "", "display":
-    9, "description": "Peer device''s ASN"}, {"name": "peerHostname", "type": "string",
+    capability sent"}, {"name": "extnhEnabled", "type": "boolean", "key": "", "display":
+    "", "description": "Extended NextHop capability enabled on session"}, {"name":
+    "extnhReceived", "type": "boolean", "key": "", "display": "", "description": "Extended
+    NextHop capability rcvd"}, {"name": "holdTime", "type": "long", "key": "", "display":
+    "", "description": "BGP hold time"}, {"name": "hopsMax", "type": "long", "key":
+    "", "display": "", "description": "Maximum #hops this peer can be"}, {"name":
+    "hostname", "type": "string", "key": 1, "display": 1, "description": "Hostname
+    associated with this record"}, {"name": "ifname", "type": "string", "key": "",
+    "display": "", "description": "Interface name associated with session"}, {"name":
+    "ingressRmap", "type": "string", "key": "", "display": "", "description": "Route
+    map name associated with ingress for AFI/SAFI"}, {"name": "keepaliveTime", "type":
+    "long", "key": "", "display": "", "description": "BGP peer keepalive time in secs"},
+    {"name": "lastDownTime", "type": "timestamp", "key": "", "display": "", "description":
+    "Unix epoch indicating when session was last down"}, {"name": "mrai", "type":
+    "long", "key": "", "display": "", "description": "Min Route Adv Interval, in secs"},
+    {"name": "namespace", "type": "string", "key": 0, "display": 0, "description":
+    "Namespace associated with this record"}, {"name": "nhSelf", "type": "boolean",
+    "key": "", "display": "", "description": "True if set nexthop self is configured
+    for iBGP peer"}, {"name": "nhUnchanged", "type": "boolean", "key": "", "display":
+    "", "description": "True if set nexthop unchanged is configured for eBGP peer"},
+    {"name": "notificnReason", "type": "string", "key": "", "display": "", "description":
+    "Last BGP notification reason"}, {"name": "numChanges", "type": "long", "key":
+    "", "display": 12, "description": "Count of changes in BGP session state"}, {"name":
+    "origPeer", "type": "string", "key": "", "display": "", "description": "internal
+    field, not selectable"}, {"name": "peer", "type": "string", "key": 3, "display":
+    3, "description": "IP address or ifname of BGP peer"}, {"name": "peerAsn", "type":
+    "long", "key": "", "display": 9, "description": "Peer device''s ASN"}, {"name":
+    "peerAsndot", "type": "string", "key": "", "display": "", "description": "Peer
+    device''s ASN displayed in asdot format"}, {"name": "peerHostname", "type": "string",
     "key": "", "display": 4, "description": "Hostname of BGP peer"}, {"name": "peerIP",
     "type": "string", "key": "", "display": "", "description": "Peering IP address,
     if any"}, {"name": "peerRouterId", "type": "string", "key": "", "display": "",

--- a/tests/integration/sqcmds/cumulus-samples/all.yml
+++ b/tests/integration/sqcmds/cumulus-samples/all.yml
@@ -1132,88 +1132,92 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime":
     9, "updatesRx": 13, "updatesTx": 17, "peerRouterId": "10.0.0.101", "routerId":
     "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.1", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 554000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "edge01",
-    "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65000, "pfxRx": 2,
-    "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp": 1616681582563,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    "rrclient": "False", "asndot": "0.65530", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65000",
+    "peerIP": "169.254.254.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 554000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.3",
+    "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65530, "peerAsn": 65000, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.6", "holdTime": 9, "updatesRx":
+    6, "updatesTx": 17, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65530", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65000", "peerIP": "169.254.254.5", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 554000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "edge01", "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65001,
+    "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
+    1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.254.6", "holdTime": 9, "updatesRx": 6, "updatesTx": 17, "peerRouterId":
+    "169.254.254.10", "holdTime": 9, "updatesRx": 11, "updatesTx": 17, "peerRouterId":
     "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.254.5",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 554000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp",
-    "hostname": "edge01", "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65001, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
-    11, "updatesTx": 17, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65000, "pfxRx": 10, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime": 9, "updatesRx":
-    13, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.3", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65000, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65530", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65001", "peerIP": "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 554000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer":
+    "eth2.2", "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65530, "peerAsn": 65000, "pfxRx": 10, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681582563, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime":
+    9, "updatesRx": 13, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId":
+    "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65530", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65000",
+    "peerIP": "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 554000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.3",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65530, "peerAsn": 65000, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime": 9, "updatesRx":
     6, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.5", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65001, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
-    11, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "peerHostname":
-    "internet", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001,
-    "peerAsn": 25253, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681048000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.127.1", "holdTime": 9, "updatesRx":
-    11, "updatesTx": 11, "peerRouterId": "10.0.0.253", "routerId": "10.0.0.101", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65530", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65000", "peerIP": "169.254.253.5", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 554000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "edge01", "vrf": "default", "peer": "eth2.4", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65001,
+    "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
+    1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.253.10", "holdTime": 9, "updatesRx": 11, "updatesTx": 17, "peerRouterId":
+    "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65530", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65001", "peerIP": "169.254.253.9", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 554000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf",
+    "peer": "swp6", "peerHostname": "internet", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65001, "peerAsn": 25253, "pfxRx": 3, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616681048000.0, "timestamp": 1616681582980, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.127.1", "holdTime":
+    9, "updatesRx": 11, "updatesTx": 11, "peerRouterId": "10.0.0.253", "routerId":
+    "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65001", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.25253", "peerIP":
     "169.254.127.0", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
+    534000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
     "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
     "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001,
     "peerAsn": 65530, "pfxRx": 13, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681049000.0,
@@ -1223,117 +1227,94 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx":
     17, "updatesTx": 11, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
-    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.10", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname":
-    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65530, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.5", "holdTime": 9, "updatesRx":
-    17, "updatesTx": 6, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.6", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2", "peerHostname":
-    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65530, "pfxRx": 4, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65001", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP": "169.254.254.10", "mrai":
+    0, "reason": "Waiting for peer OPEN", "lastDownTime": 534000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530, "pfxRx": 4,
+    "pfxTx": 6, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681582980,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.254.5", "holdTime": 9, "updatesRx": 17, "updatesTx": 6, "peerRouterId":
+    "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65530", "peerIP": "169.254.254.6", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 534000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
+    "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65530, "pfxRx": 4, "pfxTx": 14, "numChanges": 1, "estdTime":
+    1616681049000.0, "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime": 9, "updatesRx":
     17, "updatesTx": 13, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.2", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "peerHostname":
-    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 32, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fe28:db32", "holdTime": 9, "updatesRx": 40,
-    "updatesTx": 17, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.101", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe5d:daac", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "peerHostname":
-    "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 0, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP": "169.254.254.2", "mrai":
+    0, "reason": "Waiting for peer OPEN", "lastDownTime": 534000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 32, "pfxTx":
+    6, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681582980, "afisAdvOnly":
+    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
+    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe28:db32",
+    "holdTime": 9, "updatesRx": 40, "updatesTx": 17, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.101", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe5d:daac", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 534000, "ifname": "", "afiSafi": "l2vpn evpn", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 0, "pfxTx": 13, "numChanges": 1, "estdTime":
+    1616681049000.0, "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe28:db32", "holdTime":
     9, "updatesRx": 40, "updatesTx": 17, "peerRouterId": "10.0.0.21", "routerId":
     "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe5d:daac", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 534000, "ifname": "", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf":
-    "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 38, "pfxTx":
-    6, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681582980, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feff:73be",
-    "holdTime": 9, "updatesRx": 47, "updatesTx": 17, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.101", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "OPEN Message Error/Unsupported Capability",
-    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe83:94bc", "mrai": 0, "reason": "BGP Notification send", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fe5d:daac", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    534000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
     "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp1", "peerHostname":
-    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 1, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681050000.0,
+    "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
+    "peerAsn": 65000, "pfxRx": 38, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681050000.0,
     "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "fe80::5054:ff:feff:73be", "holdTime": 9, "updatesRx": 47,
+    "updatesTx": 17, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.101", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.65000",
+    "notificnReason": "OPEN Message Error/Unsupported Capability", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe83:94bc", "mrai": 0, "reason": "BGP Notification send",
+    "lastDownTime": 534000, "ifname": "", "afiSafi": "l2vpn evpn", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 1, "pfxTx": 13, "numChanges": 1, "estdTime":
+    1616681050000.0, "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feff:73be", "holdTime":
     9, "updatesRx": 47, "updatesTx": 17, "peerRouterId": "10.0.0.22", "routerId":
     "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "OPEN Message Error/Unsupported Capability", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe83:94bc",
-    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 534000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp":
-    1616681583091, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fea1:a5be", "holdTime": 10, "updatesRx": 30,
-    "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe25:b05b", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    533000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "vrf": "default", "peer": "swp1", "peerHostname":
-    "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681050000.0,
-    "timestamp": 1616681583091, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fedb:8ed", "holdTime":
-    10, "updatesRx": 35, "updatesTx": 7, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.13", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feb0:3559", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 533000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "False", "asndot": "0.65000", "notificnReason": "OPEN Message Error/Unsupported
+    Capability", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe83:94bc", "mrai": 0,
+    "reason": "BGP Notification send", "lastDownTime": 534000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
     "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx":
     8, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583091, "afisAdvOnly":
@@ -1341,105 +1322,138 @@ tests:
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "fe80::5054:ff:fea1:a5be", "holdTime": 10, "updatesRx": 30, "updatesTx": 7, "peerRouterId":
+    "10.0.0.21", "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": true,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fe25:b05b", "mrai": 0, "reason": "Waiting
+    for peer OPEN", "lastDownTime": 533000, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681050000.0, "timestamp": 1616681583091, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "fe80::5054:ff:fedb:8ed", "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": true,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:feb0:3559", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 533000, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681050000.0, "timestamp": 1616681583091, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "fe80::5054:ff:fec7:a486", "holdTime": 10, "updatesRx": 30, "updatesTx": 7, "peerRouterId":
     "10.0.0.21", "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fed1:da",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 534000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681583091, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fed1:da", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 534000, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681049000.0, "timestamp": 1616681583091, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "fe80::5054:ff:fed5:33ac", "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": true,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:feeb:d477", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 534000, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "swp6", "peerHostname": "internet", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65001, "peerAsn": 25253, "pfxRx": 3, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681583200, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.127.3", "holdTime":
+    9, "updatesRx": 11, "updatesTx": 11, "peerRouterId": "10.0.0.253", "routerId":
+    "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65001", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.25253", "peerIP":
+    "169.254.127.2", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    536000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer": "swp1", "peerHostname":
+    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65000, "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681047000.0,
+    "timestamp": 1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed5:33ac", "holdTime":
-    10, "updatesRx": 35, "updatesTx": 7, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.12", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feeb:d477", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 534000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65001, "peerAsn": 25253, "pfxRx": 3,
-    "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp": 1616681583200,
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe93:9e21", "holdTime":
+    10, "updatesRx": 49, "updatesTx": 17, "peerRouterId": "10.0.0.22", "routerId":
+    "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fecf:3b50", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    536000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65530, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681048000.0,
+    "timestamp": 1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime": 9, "updatesRx":
+    17, "updatesTx": 6, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP": "169.254.253.6", "mrai":
+    0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "vrf": "default", "peer": "swp5.2", "peerHostname": "edge01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530, "pfxRx": 4,
+    "pfxTx": 14, "numChanges": 1, "estdTime": 1616681048000.0, "timestamp": 1616681583200,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.127.3", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
-    "10.0.0.253", "routerId": "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.2",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe93:9e21", "holdTime": 10, "updatesRx": 49, "updatesTx": 17, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fecf:3b50",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530,
-    "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681048000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.5", "holdTime": 9, "updatesRx": 17, "updatesTx": 6, "peerRouterId":
-    "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.6",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp5.2", "peerHostname": "edge01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530,
-    "pfxRx": 4, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681048000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "169.254.253.1", "holdTime": 9, "updatesRx": 17, "updatesTx": 13, "peerRouterId":
     "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.2",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 38, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe93:9e21", "holdTime": 10, "updatesRx": 49, "updatesTx": 17, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.102", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fecf:3b50",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp2", "peerHostname": "", "state": "NotEstd",
-    "afi": "", "safi": "", "asn": 65000, "peerAsn": 0, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    0, "estdTime": 0.0, "timestamp": 1616681583200, "afisAdvOnly": [], "afisRcvOnly":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65530", "peerIP": "169.254.253.2", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 536000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 6, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681583200, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": [], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "", "holdTime": 10, "updatesRx": 0, "updatesTx": 0, "peerRouterId":
-    "0.0.0.0", "routerId": "10.0.0.102", "bfdStatus": "Unknown", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "", "notificnReason": "", "extnhAdvertised": false,
-    "extnhReceived": false, "extnhEnabled": false, "peerIP": "", "mrai": 0, "reason":
-    "Waiting for Peer IPv6 LLA", "lastDownTime": 536000, "ifname": "", "active": true,
-    "afiSafi": " "}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "internet-vrf",
-    "peer": "swp5.4", "peerHostname": "edge01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65001, "peerAsn": 65530, "pfxRx": 13, "pfxTx": 16, "numChanges":
+    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe93:9e21", "holdTime":
+    10, "updatesRx": 49, "updatesTx": 17, "peerRouterId": "10.0.0.22", "routerId":
+    "10.0.0.102", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fecf:3b50", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    536000, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer": "swp2", "peerHostname":
+    "", "state": "NotEstd", "afi": "", "safi": "", "asn": 65000, "peerAsn": 0, "pfxRx":
+    0, "pfxTx": 0, "numChanges": 0, "estdTime": 0.0, "timestamp": 1616681583200, "afisAdvOnly":
+    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
+    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": [], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "", "holdTime": 10, "updatesRx": 0,
+    "updatesTx": 0, "peerRouterId": "0.0.0.0", "routerId": "10.0.0.102", "bfdStatus":
+    "Unknown", "nhUnchanged": false, "nhSelf": false, "rrclient": "", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.0", "peerIP": "", "mrai": 0, "reason": "Waiting for Peer
+    IPv6 LLA", "lastDownTime": 536000, "ifname": "", "afiSafi": " ", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "internet-vrf", "peer":
+    "swp5.4", "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65001, "peerAsn": 65530, "pfxRx": 13, "pfxTx": 16, "numChanges":
     1, "estdTime": 1616681048000.0, "timestamp": 1616681583200, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
@@ -1447,236 +1461,245 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.9", "holdTime":
     9, "updatesRx": 17, "updatesTx": 11, "peerRouterId": "10.0.0.100", "routerId":
     "10.0.0.102", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.10", "mrai": 0, "reason": "Waiting
-    for peer OPEN", "lastDownTime": 536000, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
-    "peer": "swp6", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 44, "numChanges":
-    1, "estdTime": 1616681050000.0, "timestamp": 1616681583330, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe83:94bc",
-    "holdTime": 9, "updatesRx": 17, "updatesTx": 47, "peerRouterId": "10.0.0.101",
-    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:feff:73be", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 537000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 13,
-    "pfxTx": 14, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe83:94bc", "holdTime": 9, "updatesRx": 17, "updatesTx": 47, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:feff:73be",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 537000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "vrf": "default", "peer": "swp5", "peerHostname": "exit02",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 6, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681047000.0,
+    "False", "asndot": "0.65001", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP":
+    "169.254.253.10", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    536000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp6", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
+    "peerAsn": 65000, "pfxRx": 6, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681050000.0,
     "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
     false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fecf:3b50", "holdTime": 10, "updatesRx": 17,
-    "updatesTx": 49, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe93:9e21", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
-    "lastDownTime": 537000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp5",
-    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 13, "pfxTx": 14, "numChanges": 1, "estdTime":
-    1616681047000.0, "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fecf:3b50", "holdTime":
-    10, "updatesRx": 17, "updatesTx": 49, "peerRouterId": "10.0.0.102", "routerId":
-    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe93:9e21", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 537000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    3, "updateSource": "fe80::5054:ff:fe83:94bc", "holdTime": 9, "updatesRx": 17,
+    "updatesTx": 47, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.22", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:feff:73be", "mrai": 0,
+    "reason": "No AFI/SAFI activated for peer", "lastDownTime": 537000, "ifname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 13, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp":
+    1616681583330, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:feb0:3559", "holdTime": 10, "updatesRx": 7, "updatesTx": 35, "peerRouterId":
-    "10.0.0.13", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fedb:8ed",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "spine01", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp":
-    1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fe7a:b002", "holdTime": 10, "updatesRx": 7,
-    "updatesTx": 35, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe13:2a2c", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    537000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp2", "peerHostname":
-    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feeb:d477", "holdTime":
-    10, "updatesRx": 7, "updatesTx": 35, "peerRouterId": "10.0.0.12", "routerId":
-    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fed5:33ac", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 537000, "ifname": "", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "internet", "vrf":
-    "default", "peer": "swp2", "peerHostname": "exit02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65001, "pfxRx": 13, "pfxTx":
-    15, "numChanges": 1, "estdTime": 1616681046000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
-    "169.254.127.2", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
-    "10.0.0.102", "routerId": "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.3",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp":
-    1616681583330, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fee6:5037", "holdTime": 10, "updatesRx": 30,
-    "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe54:3d39", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
-    "lastDownTime": 533000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1616681050000.0, "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly":
-    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    "fe80::5054:ff:fe83:94bc", "holdTime": 9, "updatesRx": 17, "updatesTx": 47, "peerRouterId":
+    "10.0.0.101", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "True", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:feff:73be", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 537000, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
+    "peer": "swp5", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 44, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681583330, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fee6:f5c",
-    "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe51:eb3d", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 533000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "internet",
-    "vrf": "default", "peer": "swp1", "peerHostname": "exit01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65001, "pfxRx": 13,
-    "pfxTx": 15, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
-    "169.254.127.0", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.1",
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fecf:3b50",
+    "holdTime": 10, "updatesRx": 17, "updatesTx": 49, "peerRouterId": "10.0.0.102",
+    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe93:9e21", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 537000, "ifname": "", "afiSafi": "l2vpn evpn", "active":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer":
+    "swp5", "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 13, "pfxTx": 14, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681583330, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fecf:3b50",
+    "holdTime": 10, "updatesRx": 17, "updatesTx": 49, "peerRouterId": "10.0.0.102",
+    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe93:9e21", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 537000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer":
+    "swp3", "peerHostname": "leaf03", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 44, "numChanges":
+    1, "estdTime": 1616681049000.0, "timestamp": 1616681583330, "afisAdvOnly": ["ipv4Unicast"],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feb0:3559",
+    "holdTime": 10, "updatesRx": 7, "updatesTx": 35, "peerRouterId": "10.0.0.13",
+    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fedb:8ed", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 537000, "ifname": "", "afiSafi": "l2vpn evpn", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp4",
+    "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime":
+    1616681050000.0, "timestamp": 1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe7a:b002", "holdTime":
+    10, "updatesRx": 7, "updatesTx": 35, "peerRouterId": "10.0.0.14", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe13:2a2c",
     "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "spine01", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02", "state":
     "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
     "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
     1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
     false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fe51:eb3d", "holdTime": 10, "updatesRx": 7,
-    "updatesTx": 35, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fee6:f5c", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    537000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf04", "vrf": "default", "peer": "swp2", "peerHostname":
-    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681052000.0,
-    "timestamp": 1616681583393, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feb5:4a7b", "holdTime":
-    10, "updatesRx": 30, "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.14", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fea7:ba2d", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 532000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp": 1616681583393, "afisAdvOnly":
-    [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    3, "updateSource": "fe80::5054:ff:feeb:d477", "holdTime": 10, "updatesRx": 7,
+    "updatesTx": 35, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.22", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fed5:33ac", "mrai": 0,
+    "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname": "internet",
+    "vrf": "default", "peer": "swp2", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65001, "pfxRx": 13,
+    "pfxTx": 15, "numChanges": 1, "estdTime": 1616681046000.0, "timestamp": 1616681583330,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
+    "169.254.127.2", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
+    "10.0.0.102", "routerId": "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.25253", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65001", "peerIP": "169.254.127.3", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 537000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1616681051000.0, "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fee6:5037",
+    "holdTime": 10, "updatesRx": 30, "updatesTx": 7, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe54:3d39", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 533000, "ifname": "", "afiSafi": "l2vpn evpn", "active":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer":
+    "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681050000.0, "timestamp": 1616681583330, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe13:2a2c", "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.14", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe7a:b002",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 532000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681583504, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "fe80::5054:ff:fee6:f5c", "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": true,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fe51:eb3d", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 533000, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "internet", "vrf": "default",
+    "peer": "swp1", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 25253, "peerAsn": 65001, "pfxRx": 13, "pfxTx": 15, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681583330, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": true, "keepaliveTime": 3, "updateSource": "169.254.127.0", "holdTime":
+    9, "updatesRx": 11, "updatesTx": 11, "peerRouterId": "10.0.0.101", "routerId":
+    "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.25253", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65001", "peerIP":
+    "169.254.127.1", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    537000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp1", "peerHostname":
+    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
+    "peerAsn": 65000, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0,
+    "timestamp": 1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe5d:daac", "holdTime":
-    9, "updatesRx": 17, "updatesTx": 40, "peerRouterId": "10.0.0.101", "routerId":
-    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe28:db32", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 535000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-    "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx":
-    38, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583504,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe54:3d39", "holdTime": 10, "updatesRx": 7, "updatesTx": 30, "peerRouterId":
-    "10.0.0.11", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fee6:5037",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 535000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02", "state":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe51:eb3d", "holdTime":
+    10, "updatesRx": 7, "updatesTx": 35, "peerRouterId": "10.0.0.11", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fee6:f5c",
+    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
     "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp":
-    1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx":
+    "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681052000.0, "timestamp":
+    1616681583393, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
     false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fed1:da", "holdTime": 10, "updatesRx": 7, "updatesTx":
-    30, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged":
-    true, "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fec7:a486",
+    3, "updateSource": "fe80::5054:ff:feb5:4a7b", "holdTime": 10, "updatesRx": 30,
+    "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.14", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fea7:ba2d", "mrai": 0,
+    "reason": "No AFI/SAFI activated for peer", "lastDownTime": 532000, "ifname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp":
+    1616681583393, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "fe80::5054:ff:fe13:2a2c", "holdTime": 10, "updatesRx": 35,
+    "updatesTx": 7, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.14", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe7a:b002", "mrai": 0,
+    "reason": "No AFI/SAFI activated for peer", "lastDownTime": 532000, "ifname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
+    1616681583504, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "fe80::5054:ff:fe5d:daac", "holdTime": 9, "updatesRx": 17, "updatesTx": 40, "peerRouterId":
+    "10.0.0.101", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "True", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fe28:db32", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 535000, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681050000.0, "timestamp": 1616681583504, "afisAdvOnly": ["ipv4Unicast"],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe54:3d39",
+    "holdTime": 10, "updatesRx": 7, "updatesTx": 30, "peerRouterId": "10.0.0.11",
+    "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fee6:5037", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 535000, "ifname": "", "afiSafi": "l2vpn evpn", "active": true},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
+    "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime":
+    1616681050000.0, "timestamp": 1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed1:da", "holdTime":
+    10, "updatesRx": 7, "updatesTx": 30, "peerRouterId": "10.0.0.12", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fec7:a486",
     "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 535000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
     "spine02", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state":
     "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
     "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
@@ -1686,26 +1709,27 @@ tests:
     false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
     3, "updateSource": "fe80::5054:ff:fe25:b05b", "holdTime": 10, "updatesRx": 7,
     "updatesTx": 30, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.21", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fea1:a5be", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
-    "lastDownTime": 535000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer": "swp4",
-    "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime":
-    1616681051000.0, "timestamp": 1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fea7:ba2d", "holdTime":
-    10, "updatesRx": 7, "updatesTx": 30, "peerRouterId": "10.0.0.14", "routerId":
-    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feb5:4a7b", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 535000, "ifname": "", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf":
-    "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fea1:a5be", "mrai": 0,
+    "reason": "No AFI/SAFI activated for peer", "lastDownTime": 535000, "ifname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp":
+    1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "fe80::5054:ff:fea7:ba2d", "holdTime": 10, "updatesRx": 7,
+    "updatesTx": 30, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:feb5:4a7b", "mrai": 0,
+    "reason": "Waiting for peer OPEN", "lastDownTime": 535000, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx":
     38, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681583504,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
@@ -1713,10 +1737,11 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "fe80::5054:ff:fe5d:daac", "holdTime": 9, "updatesRx": 17, "updatesTx": 40, "peerRouterId":
     "10.0.0.101", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe28:db32",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 535000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}]'
+    "nhSelf": false, "rrclient": "True", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fe28:db32", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 535000, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}]'
 - command: device show --columns='*' --namespace=ospf-ibgp --format=json
   data-directory: tests/data/parquet/
   marks: device show cumulus all

--- a/tests/integration/sqcmds/cumulus-samples/bgp.yml
+++ b/tests/integration/sqcmds/cumulus-samples/bgp.yml
@@ -430,1422 +430,734 @@ tests:
     {"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "spine02"}, {"hostname":
     "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"}, {"hostname": "spine02"},
     {"hostname": "spine02"}]'
-- command: bgp show --columns='*' --format=json --namespace='ospf-single dual-evpn
-    ospf-ibgp'
+- command: bgp show --columns='*' --format=json --namespace='dual-bgp'
   data-directory: tests/data/parquet/
   marks: bgp show filter
-  output: '[{"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer":
+  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
     "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000.0, "timestamp": 1616644822492, "afisAdvOnly": [],
+    "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 12, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638156000.0, "timestamp": 1616638469998, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime":
-    9, "updatesRx": 16, "updatesTx": 15, "peerRouterId": "10.0.0.101", "routerId":
+    9, "updatesRx": 10, "updatesTx": 13, "peerRouterId": "10.0.0.101", "routerId":
     "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.1", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 221000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn", "hostname": "edge01",
-    "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 3,
-    "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822492,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.254.6", "holdTime": 9, "updatesRx": 14, "updatesTx": 15, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.254.5",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 221000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn",
-    "hostname": "edge01", "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65201, "pfxRx": 4, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644822492, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    "rrclient": "False", "asndot": "0.65530", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65201",
+    "peerIP": "169.254.254.1", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    314000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
+    "peerAsn": 65201, "pfxRx": 5, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638156000.0,
+    "timestamp": 1616638469998, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
-    16, "updatesTx": 15, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    221000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "dual-evpn", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65202, "pfxRx": 9, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644822492, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime": 9, "updatesRx":
-    15, "updatesTx": 15, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    221000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "dual-evpn", "hostname": "edge01", "vrf": "default", "peer": "eth2.3", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65202, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644822492, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime": 9, "updatesRx":
-    15, "updatesTx": 15, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.5", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    221000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "dual-evpn", "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65202, "pfxRx": 4, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644822492, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    11, "updatesTx": 13, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65530", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65201", "peerIP": "169.254.254.9", "mrai":
+    0, "reason": "Waiting for peer OPEN", "lastDownTime": 314000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname": "edge01",
+    "vrf": "default", "peer": "eth2.2", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65202, "pfxRx": 12,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616638156000.0, "timestamp": 1616638469998,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.253.2", "holdTime": 9, "updatesRx": 12, "updatesTx": 13, "peerRouterId":
+    "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65530", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65202", "peerIP": "169.254.253.1", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 314000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.4",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65530, "peerAsn": 65202, "pfxRx": 5, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616638156000.0, "timestamp": 1616638469998, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
-    15, "updatesTx": 15, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    221000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname":
-    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65102, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
-    "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe05:3cc9", "holdTime":
-    9, "updatesRx": 51, "updatesTx": 55, "peerRouterId": "10.0.0.12", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:18", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine02", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65103, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822793, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe69:1c7c", "holdTime": 9, "updatesRx": 48, "updatesTx": 55, "peerRouterId":
-    "10.0.0.13", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:1f", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp3",
-    "peerHostname": "leaf03", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65103, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe69:1c7c", "holdTime":
-    9, "updatesRx": 48, "updatesTx": 55, "peerRouterId": "10.0.0.13", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:1f", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65104, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822793, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:feeb:ee99", "holdTime": 9, "updatesRx": 51, "updatesTx": 55, "peerRouterId":
-    "10.0.0.14", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:2c", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp5",
-    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65202, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe10:4e5b", "holdTime":
-    9, "updatesRx": 53, "updatesTx": 55, "peerRouterId": "10.0.0.102", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:feba:e37b", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine02", "vrf": "default", "peer": "swp5", "peerHostname": "exit02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65202, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822793, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe10:4e5b", "holdTime": 9, "updatesRx": 53, "updatesTx": 55, "peerRouterId":
-    "10.0.0.102", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:feba:e37b", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp1",
-    "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe4f:3fa3", "holdTime":
-    9, "updatesRx": 49, "updatesTx": 55, "peerRouterId": "10.0.0.11", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:14", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65201, "pfxRx": 7, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822793, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe76:adfa", "holdTime": 9, "updatesRx": 54, "updatesTx": 55, "peerRouterId":
-    "10.0.0.101", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe6d:8402", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp6",
-    "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe76:adfa", "holdTime":
-    9, "updatesRx": 54, "updatesTx": 55, "peerRouterId": "10.0.0.101", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe6d:8402", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65104, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822793, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:feeb:ee99", "holdTime": 9, "updatesRx": 51, "updatesTx": 55, "peerRouterId":
-    "10.0.0.14", "routerId": "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:2c", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp1",
-    "peerHostname": "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65000, "peerAsn": 65101, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe4f:3fa3", "holdTime":
-    9, "updatesRx": 49, "updatesTx": 55, "peerRouterId": "10.0.0.11", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:14", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp2",
-    "peerHostname": "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65000, "peerAsn": 65102, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644607000.0, "timestamp": 1616644822793, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe05:3cc9", "holdTime":
-    9, "updatesRx": 51, "updatesTx": 55, "peerRouterId": "10.0.0.12", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:18", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer": "swp1",
-    "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644609000.0, "timestamp": 1616644822861, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe06:b23b", "holdTime":
-    9, "updatesRx": 49, "updatesTx": 55, "peerRouterId": "10.0.0.11", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:3", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine01", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65102, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822861, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe3d:424d", "holdTime": 9, "updatesRx": 51, "updatesTx": 55, "peerRouterId":
-    "10.0.0.12", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:15", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer": "swp2",
-    "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65102, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822861, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe3d:424d", "holdTime":
-    9, "updatesRx": 51, "updatesTx": 55, "peerRouterId": "10.0.0.12", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:15", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine01", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65103, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822861, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fecb:bbee", "holdTime": 9, "updatesRx": 48, "updatesTx": 55, "peerRouterId":
-    "10.0.0.13", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:23", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer": "swp3",
-    "peerHostname": "leaf03", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65103, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822861, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fecb:bbee", "holdTime":
-    9, "updatesRx": 48, "updatesTx": 55, "peerRouterId": "10.0.0.13", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:23", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine01", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65104, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822861, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe5a:ee0b", "holdTime": 9, "updatesRx": 51, "updatesTx": 55, "peerRouterId":
-    "10.0.0.14", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:5c", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer": "swp4",
-    "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65104, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822861, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe5a:ee0b", "holdTime":
-    9, "updatesRx": 51, "updatesTx": 55, "peerRouterId": "10.0.0.14", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::4638:39ff:fe00:5c", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine01", "vrf": "default", "peer": "swp5", "peerHostname": "exit02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65202, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822861, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe37:41a3", "holdTime": 9, "updatesRx": 53, "updatesTx": 55, "peerRouterId":
-    "10.0.0.102", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:feb6:af3d", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer": "swp5",
-    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65202, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822861, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe37:41a3", "holdTime":
-    9, "updatesRx": 53, "updatesTx": 55, "peerRouterId": "10.0.0.102", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:feb6:af3d", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine01", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65201, "pfxRx": 7, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644822861, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe04:101b", "holdTime": 9, "updatesRx": 54, "updatesTx": 55, "peerRouterId":
-    "10.0.0.101", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe98:11d3", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer": "swp6",
-    "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822861, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe04:101b", "holdTime":
-    9, "updatesRx": 54, "updatesTx": 55, "peerRouterId": "10.0.0.101", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe98:11d3", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "spine01", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65101, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644609000.0, "timestamp":
-    1616644822861, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe06:b23b", "holdTime": 9, "updatesRx": 49, "updatesTx": 55, "peerRouterId":
-    "10.0.0.11", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::4638:39ff:fe00:3", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65201, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822941, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe98:11d3", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 54, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe04:101b", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "internet-vrf", "peer":
-    "swp6", "peerHostname": "internet", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65201, "peerAsn": 25253, "pfxRx": 4, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1616644608000.0, "timestamp": 1616644822941, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.127.1", "holdTime":
-    9, "updatesRx": 16, "updatesTx": 16, "peerRouterId": "10.0.0.253", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.127.0", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
-    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201,
-    "peerAsn": 65530, "pfxRx": 16, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644822941, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx":
-    15, "updatesTx": 16, "peerRouterId": "10.0.0.100", "routerId": "None", "bfdStatus":
-    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.10", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 65530, "pfxRx": 16,
-    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822941,
+    11, "updatesTx": 13, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65530", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65202", "peerIP": "169.254.253.9", "mrai":
+    0, "reason": "Waiting for peer OPEN", "lastDownTime": 314000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname": "spine02",
+    "vrf": "default", "peer": "swp4", "peerHostname": "leaf04", "state": "Established",
+    "afi": "ipv6", "safi": "unicast", "asn": 65000, "peerAsn": 65104, "pfxRx": 1,
+    "pfxTx": 7, "numChanges": 1, "estdTime": 1616638096000.0, "timestamp": 1616638470426,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.254.5", "holdTime": 9, "updatesRx": 15, "updatesTx": 14, "peerRouterId":
-    "10.0.0.100", "routerId": "None", "bfdStatus": "down", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.6", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
-    "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65201, "peerAsn": 65530, "pfxRx": 16, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822941, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime": 9, "updatesRx":
-    15, "updatesTx": 16, "peerRouterId": "10.0.0.100", "routerId": "None", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.2", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65201, "peerAsn": 65000, "pfxRx": 38, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822941, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe6d:8402",
-    "holdTime": 9, "updatesRx": 55, "updatesTx": 54, "peerRouterId": "10.0.0.22",
-    "routerId": "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe76:adfa", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65201, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822941, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe6d:8402", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 54, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe76:adfa", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65201, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822941, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe98:11d3", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 54, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe04:101b", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn":
-    65000, "pfxRx": 12, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
-    "timestamp": 1616644822972, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feb6:af3d", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 53, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe37:41a3", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65202, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644607000.0, "timestamp": 1616644822972, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feba:e37b", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 53, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe10:4e5b", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65202, "peerAsn":
-    65000, "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
-    "timestamp": 1616644822972, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:feb6:af3d", "holdTime": 9, "updatesRx": 55,
-    "updatesTx": 53, "peerRouterId": "10.0.0.21", "routerId": "None", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe37:41a3", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn", "hostname":
-    "exit02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 65000,
-    "pfxRx": 12, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp":
-    1616644822972, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:feba:e37b", "holdTime": 9, "updatesRx": 55, "updatesTx": 53, "peerRouterId":
-    "10.0.0.22", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe10:4e5b", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default", "peer": "swp5.2",
-    "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65202, "peerAsn": 65530, "pfxRx": 16, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644607000.0, "timestamp": 1616644822972, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime": 9, "updatesRx":
-    15, "updatesTx": 15, "peerRouterId": "10.0.0.100", "routerId": "None", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.2", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn", "hostname": "exit02",
-    "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 65530, "pfxRx": 16,
-    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp": 1616644822972,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.5", "holdTime": 9, "updatesRx": 15, "updatesTx": 15, "peerRouterId":
-    "10.0.0.100", "routerId": "None", "bfdStatus": "down", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.6", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "internet-vrf", "peer":
-    "swp5.4", "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65202, "peerAsn": 65530, "pfxRx": 16, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1616644607000.0, "timestamp": 1616644822972, "afisAdvOnly": [],
+    "fe80::5054:ff:fedc:803b", "holdTime": 9, "updatesRx": 38, "updatesTx": 36, "peerRouterId":
+    "10.0.0.14", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65000", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65104", "peerIP": "fe80::5054:ff:fe33:c73d", "mrai": 0, "reason": "Waiting
+    for peer OPEN", "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv6 unicast",
+    "active": true}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp4", "peerHostname": "leaf04", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65104, "pfxRx": 3, "pfxTx": 15, "numChanges":
+    1, "estdTime": 1616638096000.0, "timestamp": 1616638470426, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.9", "holdTime":
-    9, "updatesRx": 15, "updatesTx": 15, "peerRouterId": "10.0.0.100", "routerId":
-    "None", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.10", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn":
-    25253, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
-    "timestamp": 1616644822972, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.127.3", "holdTime": 9, "updatesRx":
-    16, "updatesTx": 15, "peerRouterId": "10.0.0.253", "routerId": "None", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.127.2", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65103, "peerAsn": 65000, "pfxRx": 36, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822983, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:1f",
-    "holdTime": 9, "updatesRx": 55, "updatesTx": 48, "peerRouterId": "10.0.0.22",
-    "routerId": "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe69:1c7c", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65103, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822983, "afisAdvOnly": [], "afisRcvOnly":
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fedc:803b",
+    "holdTime": 9, "updatesRx": 38, "updatesTx": 36, "peerRouterId": "10.0.0.14",
+    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65104",
+    "peerIP": "fe80::5054:ff:fe33:c73d", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp3",
+    "peerHostname": "leaf03", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65103, "pfxRx": 3, "pfxTx": 7, "numChanges": 1, "estdTime":
+    1616638096000.0, "timestamp": 1616638470426, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:1f", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 48, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe69:1c7c", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65103, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644822983, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:23", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 48, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fecb:bbee", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65103, "peerAsn":
-    65000, "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644822983, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed6:9480", "holdTime":
+    9, "updatesRx": 40, "updatesTx": 36, "peerRouterId": "10.0.0.13", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65103", "peerIP":
+    "fe80::5054:ff:fec6:7cc6", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp3", "peerHostname":
+    "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65103, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638096000.0,
+    "timestamp": 1616638470426, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:23", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 48, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fecb:bbee", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "internet", "vrf": "default", "peer": "swp1",
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed6:9480", "holdTime":
+    9, "updatesRx": 40, "updatesTx": 36, "peerRouterId": "10.0.0.13", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65103", "peerIP":
+    "fe80::5054:ff:fec6:7cc6", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname":
+    "leaf02", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65102, "pfxRx": 3, "pfxTx": 7, "numChanges": 1, "estdTime": 1616638096000.0,
+    "timestamp": 1616638470426, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fea1:3072", "holdTime":
+    9, "updatesRx": 39, "updatesTx": 36, "peerRouterId": "10.0.0.12", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65102", "peerIP":
+    "fe80::5054:ff:fe8c:5b4d", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname":
+    "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65102, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638096000.0,
+    "timestamp": 1616638470426, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fea1:3072", "holdTime":
+    9, "updatesRx": 39, "updatesTx": 36, "peerRouterId": "10.0.0.12", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65102", "peerIP":
+    "fe80::5054:ff:fe8c:5b4d", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "peerHostname":
+    "leaf01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65101, "pfxRx": 1, "pfxTx": 7, "numChanges": 1, "estdTime": 1616638096000.0,
+    "timestamp": 1616638470426, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe38:a329", "holdTime":
+    9, "updatesRx": 37, "updatesTx": 36, "peerRouterId": "10.0.0.11", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65101", "peerIP":
+    "fe80::5054:ff:fe6b:7941", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp1", "peerHostname":
+    "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65101, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638096000.0,
+    "timestamp": 1616638470426, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe38:a329", "holdTime":
+    9, "updatesRx": 37, "updatesTx": 36, "peerRouterId": "10.0.0.11", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65101", "peerIP":
+    "fe80::5054:ff:fe6b:7941", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp5", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65202, "pfxRx": 5, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638094000.0,
+    "timestamp": 1616638470426, "afisAdvOnly": ["ipv6Unicast"], "afisRcvOnly": [],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe14:981", "holdTime":
+    9, "updatesRx": 25, "updatesTx": 25, "peerRouterId": "10.0.0.102", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65202", "peerIP":
+    "fe80::5054:ff:fe8d:590", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp6",
     "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 25253, "peerAsn": 65201, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644607000.0, "timestamp": 1616644822996, "afisAdvOnly": [], "afisRcvOnly":
+    "asn": 65000, "peerAsn": 65201, "pfxRx": 2, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638094000.0, "timestamp": 1616638470426, "afisAdvOnly": ["ipv6Unicast"], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed3:cd00", "holdTime":
+    9, "updatesRx": 17, "updatesTx": 25, "peerRouterId": "10.0.0.101", "routerId":
+    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65201", "peerIP":
+    "fe80::5054:ff:fed6:1238", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default", "peer": "swp1",
+    "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 25253, "peerAsn": 65201, "pfxRx": 12, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638094000.0, "timestamp": 1616638470550, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 3, "updateSource": "169.254.127.0", "holdTime": 9, "updatesRx":
-    16, "updatesTx": 16, "peerRouterId": "10.0.0.101", "routerId": "None", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.127.1", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "dual-evpn", "hostname": "internet",
-    "vrf": "default", "peer": "swp2", "peerHostname": "exit02", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65202, "pfxRx": 13,
-    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp": 1616644822996,
+    25, "updatesTx": 24, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.253", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.25253",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65201", "peerIP": "169.254.127.1", "mrai": 0, "reason":
+    "Waiting for peer OPEN", "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4
+    unicast", "active": true}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "peer": "swp5.4", "peerHostname": "edge01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 65530, "pfxRx": 16,
+    "pfxTx": 16, "numChanges": 3, "estdTime": 1616638156000.0, "timestamp": 1616638470550,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
-    "169.254.127.2", "holdTime": 9, "updatesRx": 15, "updatesTx": 16, "peerRouterId":
-    "10.0.0.102", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.127.3", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65101, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644823039, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.253.9", "holdTime": 9, "updatesRx": 30, "updatesTx": 30, "peerRouterId":
+    "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus": "down", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65202", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65530", "peerIP": "169.254.253.10", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 315000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "swp6", "peerHostname": "internet", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65202, "peerAsn": 25253, "pfxRx": 15, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638094000.0, "timestamp": 1616638470550, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.127.3", "holdTime":
+    9, "updatesRx": 24, "updatesTx": 33, "peerRouterId": "10.0.0.253", "routerId":
+    "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65202", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.25253", "peerIP":
+    "169.254.127.2", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    376000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "peer": "swp2", "peerHostname":
+    "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202,
+    "peerAsn": 65000, "pfxRx": 11, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638094000.0,
+    "timestamp": 1616638470550, "afisAdvOnly": [], "afisRcvOnly": ["ipv6Unicast"],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:3", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 49, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "OPEN Message Error/Unsupported Capability", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe06:b23b",
-    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 216000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn", "hostname":
-    "leaf01", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65101, "peerAsn": 65000,
-    "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
-    1616644823039, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe8d:590", "holdTime":
+    9, "updatesRx": 25, "updatesTx": 25, "peerRouterId": "10.0.0.22", "routerId":
+    "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65202", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fe14:981", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    376000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "peer": "swp1", "peerHostname":
+    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202,
+    "peerAsn": 65000, "pfxRx": 11, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638094000.0,
+    "timestamp": 1616638470550, "afisAdvOnly": [], "afisRcvOnly": ["ipv6Unicast"],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fea1:d86a", "holdTime":
+    9, "updatesRx": 25, "updatesTx": 25, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65202", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fef6:f05d", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    376000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202,
+    "peerAsn": 65530, "pfxRx": 15, "pfxTx": 16, "numChanges": 3, "estdTime": 1616638156000.0,
+    "timestamp": 1616638470550, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime": 9, "updatesRx":
+    30, "updatesTx": 31, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus":
+    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65202", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP": "169.254.253.2", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 315000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
+    "internet", "vrf": "default", "peer": "swp2", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65202,
+    "pfxRx": 12, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp":
+    1616638470550, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
     false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::4638:39ff:fe00:3", "holdTime": 9, "updatesRx": 55, "updatesTx": 49, "peerRouterId":
-    "10.0.0.21", "routerId": "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "OPEN Message Error/Unsupported
-    Capability", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe06:b23b", "mrai": 0, "reason": "BGP Notification
-    send", "lastDownTime": 216000, "ifname": "", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default",
-    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 65101, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1616644607000.0, "timestamp": 1616644823039, "afisAdvOnly": [],
+    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
+    "169.254.127.2", "holdTime": 9, "updatesRx": 33, "updatesTx": 24, "peerRouterId":
+    "10.0.0.102", "routerId": "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.25253", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65202", "peerIP": "169.254.127.3", "mrai": 0, "reason": "Waiting for peer OPEN",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "peer":
+    "swp6", "peerHostname": "internet", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65201, "peerAsn": 25253, "pfxRx": 4, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638094000.0, "timestamp": 1616638470555, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:14",
-    "holdTime": 9, "updatesRx": 55, "updatesTx": 49, "peerRouterId": "10.0.0.22",
-    "routerId": "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe4f:3fa3", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65101, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644607000.0, "timestamp": 1616644823039, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:14", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 49, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe4f:3fa3", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65104, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644823113, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:2c", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:feeb:ee99", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "leaf04", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65104, "peerAsn":
-    65000, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644823113, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:2c", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feeb:ee99", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65104, "peerAsn": 65000, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644823113, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:5c", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe5a:ee0b", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65104, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644823113, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:5c", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe5a:ee0b", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "leaf02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65102, "peerAsn":
-    65000, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644823117, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:15", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe3d:424d", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65102, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644823117, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:15", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.21", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe3d:424d", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "dual-evpn",
-    "hostname": "leaf02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65102, "peerAsn":
-    65000, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
-    "timestamp": 1616644823117, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:18", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe05:3cc9", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65102, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000.0, "timestamp": 1616644823117, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::4638:39ff:fe00:18", "holdTime":
-    9, "updatesRx": 55, "updatesTx": 51, "peerRouterId": "10.0.0.22", "routerId":
-    "None", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "fe80::5054:ff:fe05:3cc9", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp",
-    "hostname": "edge01", "vrf": "default", "peer": "eth1.2", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65000, "pfxRx": 10, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime": 9, "updatesRx":
-    13, "updatesTx": 17, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.3", "peerHostname":
-    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65000, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.6", "holdTime": 9, "updatesRx":
-    6, "updatesTx": 17, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.5", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth1.4", "peerHostname":
-    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65001, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
-    11, "updatesTx": 17, "peerRouterId": "10.0.0.101", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65000, "pfxRx": 10, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime": 9, "updatesRx":
-    13, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.3", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65000, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime": 9, "updatesRx":
-    6, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.5", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530,
-    "peerAsn": 65001, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681582563, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
-    11, "updatesTx": 17, "peerRouterId": "10.0.0.102", "routerId": "10.0.0.100", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    554000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
-    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001,
-    "peerAsn": 65530, "pfxRx": 13, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx":
-    17, "updatesTx": 11, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
-    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.10", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "peerHostname":
-    "internet", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001,
-    "peerAsn": 25253, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681048000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.127.1", "holdTime": 9, "updatesRx":
-    11, "updatesTx": 11, "peerRouterId": "10.0.0.253", "routerId": "10.0.0.101", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.127.1", "holdTime":
+    9, "updatesRx": 24, "updatesTx": 25, "peerRouterId": "10.0.0.253", "routerId":
+    "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65201", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.25253", "peerIP":
     "169.254.127.0", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2", "peerHostname":
-    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65530, "pfxRx": 4, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    376000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201,
+    "peerAsn": 65530, "pfxRx": 2, "pfxTx": 13, "numChanges": 3, "estdTime": 1616638156000.0,
+    "timestamp": 1616638470555, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime": 9, "updatesRx":
-    17, "updatesTx": 13, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.2", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname":
-    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65530, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.5", "holdTime": 9, "updatesRx":
-    17, "updatesTx": 6, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.6", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp2", "peerHostname":
-    "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 0, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe28:db32", "holdTime":
-    9, "updatesRx": 40, "updatesTx": 17, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe5d:daac", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 534000, "ifname": "", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf":
-    "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 38, "pfxTx":
-    6, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681582980, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feff:73be",
-    "holdTime": 9, "updatesRx": 47, "updatesTx": 17, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.101", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "OPEN Message Error/Unsupported Capability",
-    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe83:94bc", "mrai": 0, "reason": "BGP Notification send", "lastDownTime":
-    534000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer": "swp1", "peerHostname":
-    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 1, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681050000.0,
-    "timestamp": 1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feff:73be", "holdTime":
-    9, "updatesRx": 47, "updatesTx": 17, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "OPEN Message Error/Unsupported Capability", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe83:94bc",
-    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 534000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
+    30, "updatesTx": 25, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
+    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65201", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP": "169.254.254.2", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 315000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
     "exit01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 32, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
-    1616681582980, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe28:db32", "holdTime": 9, "updatesRx": 40, "updatesTx": 17, "peerRouterId":
-    "10.0.0.21", "routerId": "10.0.0.101", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe5d:daac",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 534000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp":
-    1616681583091, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 65000,
+    "pfxRx": 10, "pfxTx": 13, "numChanges": 1, "estdTime": 1616638095000.0, "timestamp":
+    1616638470555, "afisAdvOnly": [], "afisRcvOnly": ["ipv6Unicast"], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fea1:a5be", "holdTime": 10, "updatesRx": 30,
-    "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe25:b05b", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    533000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf02", "vrf": "default", "peer": "swp2", "peerHostname":
-    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681050000.0,
-    "timestamp": 1616681583091, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fec7:a486", "holdTime":
-    10, "updatesRx": 30, "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.12", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fed1:da", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 534000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed6:1238", "holdTime":
+    9, "updatesRx": 25, "updatesTx": 17, "peerRouterId": "10.0.0.22", "routerId":
+    "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65201", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fed3:cd00", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    376000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp1", "peerHostname":
+    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201,
+    "peerAsn": 65000, "pfxRx": 10, "pfxTx": 13, "numChanges": 1, "estdTime": 1616638094000.0,
+    "timestamp": 1616638470555, "afisAdvOnly": [], "afisRcvOnly": ["ipv6Unicast"],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fed7:1317", "holdTime":
+    9, "updatesRx": 25, "updatesTx": 17, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.101", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65201", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fe5f:e8d4", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
+    376000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "dual-bgp", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201,
+    "peerAsn": 65530, "pfxRx": 16, "pfxTx": 16, "numChanges": 3, "estdTime": 1616638156000.0,
+    "timestamp": 1616638470555, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx":
+    30, "updatesTx": 28, "peerRouterId": "10.0.0.100", "routerId": "10.0.0.101", "bfdStatus":
+    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65201", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65530", "peerIP": "169.254.254.10", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 315000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65201,
+    "pfxRx": 2, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp":
+    1616638470647, "afisAdvOnly": ["ipv6Unicast"], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe5f:e8d4", "holdTime":
+    9, "updatesRx": 17, "updatesTx": 25, "peerRouterId": "10.0.0.101", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65201", "peerIP":
+    "fe80::5054:ff:fed7:1317", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp5",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65202, "pfxRx": 5, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638094000.0, "timestamp": 1616638470647, "afisAdvOnly": ["ipv6Unicast"], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fef6:f05d", "holdTime":
+    9, "updatesRx": 25, "updatesTx": 25, "peerRouterId": "10.0.0.102", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65202", "peerIP":
+    "fe80::5054:ff:fea1:d86a", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp4",
+    "peerHostname": "leaf04", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65104, "pfxRx": 1, "pfxTx": 7, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe8d:ffce", "holdTime":
+    9, "updatesRx": 38, "updatesTx": 36, "peerRouterId": "10.0.0.14", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65104", "peerIP":
+    "fe80::5054:ff:fe7e:5a82", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp4",
+    "peerHostname": "leaf04", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65104, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe8d:ffce", "holdTime":
+    9, "updatesRx": 38, "updatesTx": 36, "peerRouterId": "10.0.0.14", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65104", "peerIP":
+    "fe80::5054:ff:fe7e:5a82", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp3",
+    "peerHostname": "leaf03", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65103, "pfxRx": 3, "pfxTx": 7, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fedb:b08e", "holdTime":
+    9, "updatesRx": 40, "updatesTx": 36, "peerRouterId": "10.0.0.13", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65103", "peerIP":
+    "fe80::5054:ff:fe79:485e", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp3",
+    "peerHostname": "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65103, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fedb:b08e", "holdTime":
+    9, "updatesRx": 40, "updatesTx": 36, "peerRouterId": "10.0.0.13", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65103", "peerIP":
+    "fe80::5054:ff:fe79:485e", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2",
+    "peerHostname": "leaf02", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65102, "pfxRx": 3, "pfxTx": 7, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe6c:9df3", "holdTime":
+    9, "updatesRx": 39, "updatesTx": 36, "peerRouterId": "10.0.0.12", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65102", "peerIP":
+    "fe80::5054:ff:fe40:386", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp2",
+    "peerHostname": "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65102, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe6c:9df3", "holdTime":
+    9, "updatesRx": 39, "updatesTx": 36, "peerRouterId": "10.0.0.12", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65102", "peerIP":
+    "fe80::5054:ff:fe40:386", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp1",
+    "peerHostname": "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65101, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fef1:8d28", "holdTime":
+    9, "updatesRx": 37, "updatesTx": 36, "peerRouterId": "10.0.0.11", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65101", "peerIP":
+    "fe80::5054:ff:fea1:d20b", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp1",
+    "peerHostname": "leaf01", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65101, "pfxRx": 1, "pfxTx": 7, "numChanges": 1, "estdTime":
+    1616638097000.0, "timestamp": 1616638470647, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fef1:8d28", "holdTime":
+    9, "updatesRx": 37, "updatesTx": 36, "peerRouterId": "10.0.0.11", "routerId":
+    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65101", "peerIP":
+    "fe80::5054:ff:fea1:d20b", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 377000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65104, "peerAsn": 65000, "pfxRx": 7, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1616638095000.0, "timestamp": 1616638471112, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe33:c73d", "holdTime":
+    9, "updatesRx": 36, "updatesTx": 38, "peerRouterId": "10.0.0.22", "routerId":
+    "10.0.0.14", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65104", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP":
+    "fe80::5054:ff:fedc:803b", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 376000, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65102, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616638096000.0, "timestamp": 1616638471112, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe40:386", "holdTime":
+    9, "updatesRx": 36, "updatesTx": 39, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.12", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65102", "notificnReason": "OPEN Message Error/Unsupported
+    Capability", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe6c:9df3", "mrai": 0,
+    "reason": "BGP Notification send", "lastDownTime": 376000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname": "leaf02",
     "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681583091, "afisAdvOnly":
-    [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fed5:33ac", "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:feeb:d477",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 534000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681050000.0,
-    "timestamp": 1616681583091, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fedb:8ed", "holdTime":
-    10, "updatesRx": 35, "updatesTx": 7, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.13", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feb0:3559", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 533000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "exit02",
-    "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530, "pfxRx": 4,
-    "pfxTx": 6, "numChanges": 1, "estdTime": 1616681048000.0, "timestamp": 1616681583200,
+    "afi": "ipv6", "safi": "unicast", "asn": 65102, "peerAsn": 65000, "pfxRx": 4,
+    "pfxTx": 8, "numChanges": 1, "estdTime": 1616638096000.0, "timestamp": 1616638471112,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.5", "holdTime": 9, "updatesRx": 17, "updatesTx": 6, "peerRouterId":
-    "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.6",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname": "edge01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001, "peerAsn": 65530,
-    "pfxRx": 13, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681048000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    "fe80::5054:ff:fe40:386", "holdTime": 9, "updatesRx": 36, "updatesTx": 39, "peerRouterId":
+    "10.0.0.21", "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65102", "notificnReason": "OPEN
+    Message Error/Unsupported Capability", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe6c:9df3",
+    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 376000, "ifname":
+    "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
+    "leaf02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv6", "safi": "unicast", "asn": 65102, "peerAsn": 65000,
+    "pfxRx": 4, "pfxTx": 8, "numChanges": 1, "estdTime": 1616638095000.0, "timestamp":
+    1616638471112, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
     false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.9", "holdTime": 9, "updatesRx": 17, "updatesTx": 11, "peerRouterId":
-    "10.0.0.100", "routerId": "10.0.0.102", "bfdStatus": "down", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.10",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001, "peerAsn": 25253,
-    "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.127.3", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
-    "10.0.0.253", "routerId": "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.2",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 38, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe93:9e21", "holdTime": 10, "updatesRx": 49, "updatesTx": 17, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.102", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fecf:3b50",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
-    1616681583200, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe93:9e21", "holdTime": 10, "updatesRx": 49, "updatesTx": 17, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.102", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fecf:3b50",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 536000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "exit02", "vrf": "default", "peer": "swp2", "peerHostname": "", "state": "NotEstd",
-    "afi": "", "safi": "", "asn": 65000, "peerAsn": 0, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    0, "estdTime": 0.0, "timestamp": 1616681583200, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": [], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "", "holdTime": 10, "updatesRx": 0, "updatesTx": 0, "peerRouterId":
-    "0.0.0.0", "routerId": "10.0.0.102", "bfdStatus": "Unknown", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "", "notificnReason": "", "extnhAdvertised": false,
-    "extnhReceived": false, "extnhEnabled": false, "peerIP": "", "mrai": 0, "reason":
-    "Waiting for Peer IPv6 LLA", "lastDownTime": 536000, "ifname": "", "active": true,
-    "afiSafi": " "}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "default",
-    "peer": "swp5.2", "peerHostname": "edge01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65000, "peerAsn": 65530, "pfxRx": 4, "pfxTx": 14, "numChanges":
-    1, "estdTime": 1616681048000.0, "timestamp": 1616681583200, "afisAdvOnly": [],
+    "fe80::5054:ff:fe8c:5b4d", "holdTime": 9, "updatesRx": 36, "updatesTx": 39, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65102", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fea1:3072", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 376000, "ifname": "", "afiSafi": "ipv6 unicast",
+    "active": true}, {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65102, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638095000.0, "timestamp": 1616638471112, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime":
-    9, "updatesRx": 17, "updatesTx": 13, "peerRouterId": "10.0.0.100", "routerId":
-    "10.0.0.102", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.2", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 536000, "ifname": "", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe83:94bc", "holdTime": 9, "updatesRx": 17, "updatesTx": 47, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:feff:73be",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 537000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 13, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681050000.0,
-    "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe83:94bc", "holdTime":
-    9, "updatesRx": 17, "updatesTx": 47, "peerRouterId": "10.0.0.101", "routerId":
-    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feff:73be", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 537000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "vrf": "default", "peer": "swp5", "peerHostname": "exit02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fecf:3b50", "holdTime": 10, "updatesRx": 17, "updatesTx": 49, "peerRouterId":
-    "10.0.0.102", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe93:9e21",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 537000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "vrf": "default", "peer": "swp5", "peerHostname": "exit02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 13, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681047000.0,
-    "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fecf:3b50", "holdTime":
-    10, "updatesRx": 17, "updatesTx": 49, "peerRouterId": "10.0.0.102", "routerId":
-    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe93:9e21", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 537000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "vrf": "default", "peer": "swp4", "peerHostname": "leaf04", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe7a:b002", "holdTime": 10, "updatesRx": 7, "updatesTx": 35, "peerRouterId":
-    "10.0.0.14", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe13:2a2c",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "spine01", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
-    1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:feb0:3559", "holdTime": 10, "updatesRx": 7,
-    "updatesTx": 35, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fedb:8ed", "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime":
-    537000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp2", "peerHostname":
-    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000,
-    "peerAsn": 65000, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0,
-    "timestamp": 1616681583330, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feeb:d477", "holdTime":
-    10, "updatesRx": 7, "updatesTx": 35, "peerRouterId": "10.0.0.12", "routerId":
-    "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fed5:33ac", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 537000, "ifname": "", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf":
-    "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681583330,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe51:eb3d", "holdTime": 10, "updatesRx": 7, "updatesTx": 35, "peerRouterId":
-    "10.0.0.11", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fee6:f5c",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp":
-    1616681583330, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fee6:5037", "holdTime": 10, "updatesRx": 30,
-    "updatesTx": 7, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe54:3d39", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
-    "lastDownTime": 533000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1616681050000.0, "timestamp": 1616681583330, "afisAdvOnly": [], "afisRcvOnly":
-    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe8c:5b4d",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 39, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65102", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fea1:3072", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 376000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default", "peer":
+    "swp1", "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65104, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638096000.0, "timestamp": 1616638471112, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fee6:f5c",
-    "holdTime": 10, "updatesRx": 35, "updatesTx": 7, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe51:eb3d", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 533000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "internet",
-    "vrf": "default", "peer": "swp2", "peerHostname": "exit02", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65001, "pfxRx": 13,
-    "pfxTx": 15, "numChanges": 1, "estdTime": 1616681046000.0, "timestamp": 1616681583330,
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe7e:5a82",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 38, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.14", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65104", "notificnReason": "OPEN Message Error/Unsupported
+    Capability", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe8d:ffce", "mrai": 0,
+    "reason": "BGP Notification send", "lastDownTime": 376000, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname": "leaf04",
+    "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
+    "afi": "ipv6", "safi": "unicast", "asn": 65104, "peerAsn": 65000, "pfxRx": 7,
+    "pfxTx": 8, "numChanges": 1, "estdTime": 1616638096000.0, "timestamp": 1616638471112,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
-    "169.254.127.2", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
-    "10.0.0.102", "routerId": "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.3",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "internet", "vrf": "default", "peer": "swp1", "peerHostname": "exit01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65001,
-    "pfxRx": 13, "pfxTx": 15, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
-    1616681583330, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "fe80::5054:ff:fe7e:5a82", "holdTime": 9, "updatesRx": 36, "updatesTx": 38, "peerRouterId":
+    "10.0.0.21", "routerId": "10.0.0.14", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65104", "notificnReason": "OPEN
+    Message Error/Unsupported Capability", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fe8d:ffce",
+    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 376000, "ifname":
+    "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
+    "leaf04", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65104, "peerAsn": 65000,
+    "pfxRx": 14, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638095000.0, "timestamp":
+    1616638471112, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
     false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 3, "updateSource":
-    "169.254.127.0", "holdTime": 9, "updatesRx": 11, "updatesTx": 11, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.253", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.1",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 537000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf04", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp":
-    1616681583393, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fe13:2a2c", "holdTime": 10, "updatesRx": 35,
-    "updatesTx": 7, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.14", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fe7a:b002", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
-    "lastDownTime": 532000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default", "peer": "swp2",
-    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1616681052000.0, "timestamp": 1616681583393, "afisAdvOnly": [], "afisRcvOnly":
-    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "fe80::5054:ff:fe33:c73d", "holdTime": 9, "updatesRx": 36, "updatesTx": 38, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.14", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65104", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fedc:803b", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 376000, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv6",
+    "safi": "unicast", "asn": 65101, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616638095000.0, "timestamp": 1616638471143, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:feb5:4a7b",
-    "holdTime": 10, "updatesRx": 30, "updatesTx": 7, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.14", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fea7:ba2d", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 532000, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "spine02",
-    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 13,
-    "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681583504,
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe6b:7941",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 37, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65101", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe38:a329", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 376000, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "peer":
+    "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65101, "peerAsn": 65000, "pfxRx": 12, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638095000.0, "timestamp": 1616638471143, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe6b:7941",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 37, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65101", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fe38:a329", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 376000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "peer":
+    "swp1", "peerHostname": "spine01", "state": "Established", "afi": "ipv6", "safi":
+    "unicast", "asn": 65101, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616638096000.0, "timestamp": 1616638471143, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fea1:d20b",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 37, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65101", "notificnReason": "OPEN Message Error/Unsupported
+    Capability", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fef1:8d28", "mrai": 0,
+    "reason": "BGP Notification send", "lastDownTime": 376000, "ifname": "", "afiSafi":
+    "ipv6 unicast", "active": true}, {"namespace": "dual-bgp", "hostname": "leaf01",
+    "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65101, "peerAsn": 65000, "pfxRx": 12,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616638096000.0, "timestamp": 1616638471143,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe5d:daac", "holdTime": 9, "updatesRx": 17, "updatesTx": 40, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe28:db32",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 535000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681050000.0,
-    "timestamp": 1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe54:3d39", "holdTime":
-    10, "updatesRx": 7, "updatesTx": 30, "peerRouterId": "10.0.0.11", "routerId":
-    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:fee6:5037", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 535000, "ifname": "", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf":
-    "default", "peer": "swp2", "peerHostname": "leaf02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx":
-    38, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583504,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    "fe80::5054:ff:fea1:d20b", "holdTime": 9, "updatesRx": 36, "updatesTx": 37, "peerRouterId":
+    "10.0.0.21", "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65101", "notificnReason": "OPEN
+    Message Error/Unsupported Capability", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fef1:8d28",
+    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 376000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
+    "leaf03", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65103, "peerAsn": 65000,
+    "pfxRx": 12, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638098000.0, "timestamp":
+    1616638471475, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    true, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fed1:da", "holdTime": 10, "updatesRx": 7, "updatesTx": 30, "peerRouterId":
-    "10.0.0.12", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fec7:a486",
-    "mrai": 0, "reason": "Waiting for peer OPEN", "lastDownTime": 535000, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
-    1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
-    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "fe80::5054:ff:fe25:b05b", "holdTime": 10, "updatesRx": 7,
-    "updatesTx": 30, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.21", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerIP":
-    "fe80::5054:ff:fea1:a5be", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
-    "lastDownTime": 535000, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer": "swp4",
-    "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime":
-    1616681051000.0, "timestamp": 1616681583504, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fea7:ba2d", "holdTime":
-    10, "updatesRx": 7, "updatesTx": 30, "peerRouterId": "10.0.0.14", "routerId":
-    "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": true, "peerIP": "fe80::5054:ff:feb5:4a7b", "mrai": 0, "reason":
-    "Waiting for peer OPEN", "lastDownTime": 535000, "ifname": "", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf":
-    "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx":
-    38, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681583504,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    "fe80::5054:ff:fe79:485e", "holdTime": 9, "updatesRx": 36, "updatesTx": 40, "peerRouterId":
+    "10.0.0.21", "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65103", "notificnReason": "OPEN
+    Message Error/Unsupported Capability", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fedb:b08e",
+    "mrai": 0, "reason": "BGP Notification send", "lastDownTime": 375000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "dual-bgp", "hostname":
+    "leaf03", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv6", "safi": "unicast", "asn": 65103, "peerAsn": 65000,
+    "pfxRx": 5, "pfxTx": 8, "numChanges": 1, "estdTime": 1616638097000.0, "timestamp":
+    1616638471475, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "fe80::5054:ff:fe5d:daac", "holdTime": 9, "updatesRx": 17, "updatesTx": 40, "peerRouterId":
-    "10.0.0.101", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "fe80::5054:ff:fe28:db32",
-    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 535000,
-    "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}]'
+    "fe80::5054:ff:fec6:7cc6", "holdTime": 9, "updatesRx": 36, "updatesTx": 40, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65103", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot":
+    "0.65000", "peerIP": "fe80::5054:ff:fed6:9480", "mrai": 0, "reason": "No AFI/SAFI
+    activated for peer", "lastDownTime": 375000, "ifname": "", "afiSafi": "ipv6 unicast",
+    "active": true}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65103, "peerAsn": 65000, "pfxRx": 12, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638097000.0, "timestamp": 1616638471475, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fec6:7cc6",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 40, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65103", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": true, "peerAsndot": "0.65000",
+    "peerIP": "fe80::5054:ff:fed6:9480", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 375000, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default", "peer":
+    "swp1", "peerHostname": "spine01", "state": "Established", "afi": "ipv6", "safi":
+    "unicast", "asn": 65103, "peerAsn": 65000, "pfxRx": 5, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616638098000.0, "timestamp": 1616638471475, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "fe80::5054:ff:fe79:485e",
+    "holdTime": 9, "updatesRx": 36, "updatesTx": 40, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65103", "notificnReason": "OPEN Message Error/Unsupported
+    Capability", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    true, "peerAsndot": "0.65000", "peerIP": "fe80::5054:ff:fedb:b08e", "mrai": 0,
+    "reason": "BGP Notification send", "lastDownTime": 375000, "ifname": "", "afiSafi":
+    "ipv6 unicast", "active": true}]'
 - command: bgp summarize --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp summarize

--- a/tests/integration/sqcmds/cumulus-samples/bgpunique.yml
+++ b/tests/integration/sqcmds/cumulus-samples/bgpunique.yml
@@ -1,6 +1,7 @@
 description: Testing unique values for BGP
 tests:
-- command: bgp unique --count=True --format=json --columns=hostname --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=hostname --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"hostname": "internet", "numRows": 4}, {"hostname": "leaf01", "numRows":
@@ -8,17 +9,20 @@ tests:
     {"hostname": "leaf04", "numRows": 6}, {"hostname": "edge01", "numRows": 12}, {"hostname":
     "exit02", "numRows": 15}, {"hostname": "exit01", "numRows": 16}, {"hostname":
     "spine02", "numRows": 18}, {"hostname": "spine01", "numRows": 20}]'
-- command: bgp unique --count=True --format=json --columns=afiSafi --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=afiSafi --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"afiSafi": " ", "numRows": 1}, {"afiSafi": "l2vpn evpn", "numRows": 46},
     {"afiSafi": "ipv4 unicast", "numRows": 62}]'
-- command: bgp unique --count=True --format=json --columns=state --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=state --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"state": "NotEstd", "numRows": 1}, {"state": "Established", "numRows":
     108}]'
-- command: bgp unique --count=True --format=json --columns=peer --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=peer --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"peer": "eth1.2", "numRows": 2}, {"peer": "eth1.3", "numRows": 2}, {"peer":
@@ -28,55 +32,66 @@ tests:
     "swp3", "numRows": 6}, {"peer": "swp4", "numRows": 6}, {"peer": "swp5", "numRows":
     6}, {"peer": "swp6", "numRows": 12}, {"peer": "swp2", "numRows": 27}, {"peer":
     "swp1", "numRows": 28}]'
-- command: bgp unique --count=True --format=json --columns=softReconfig --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=softReconfig --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"softReconfig": false, "numRows": 109}]'
-- command: bgp unique --count=True --format=json --columns=communityTypes --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=communityTypes --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"communityTypes": "extended", "numRows": 108}, {"communityTypes": "standard",
     "numRows": 108}]'
-- command: bgp unique --count=True --format=json --columns=defOriginate --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=defOriginate --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"defOriginate": true, "numRows": 4}, {"defOriginate": false, "numRows":
     105}]'
-- command: bgp unique --count=True --format=json --columns=keepaliveTime --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=keepaliveTime --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"keepaliveTime": 3, "numRows": 109}]'
-- command: bgp unique --count=True --format=json --columns=holdTime --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=holdTime --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"holdTime": 10, "numRows": 21}, {"holdTime": 9, "numRows": 88}]'
-- command: bgp unique --count=True --format=json --columns=vrf --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=vrf --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"vrf": "evpn-vrf", "numRows": 4}, {"vrf": "internet-vrf", "numRows":
     8}, {"vrf": "default", "numRows": 97}]'
-- command: bgp unique --count=True --format=json --columns=nhUnchanged --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=nhUnchanged --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"nhUnchanged": true, "numRows": 46}, {"nhUnchanged": false, "numRows":
     63}]'
-- command: bgp unique --count=True --format=json --columns=nhSelf --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=nhSelf --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"nhSelf": false, "numRows": 109}]'
-- command: bgp unique --count=True --format=json --columns=rrclient --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=rrclient --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"rrclient": "", "numRows": 1}, {"rrclient": "True", "numRows": 14}, {"rrclient":
     "False", "numRows": 94}]'
-- command: bgp unique --count=True --format=json --columns=asn --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=asn --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"asn": 25253, "numRows": 4}, {"asn": 65001, "numRows": 4}, {"asn": 65101,
     "numRows": 4}, {"asn": 65102, "numRows": 4}, {"asn": 65103, "numRows": 4}, {"asn":
     65104, "numRows": 4}, {"asn": 65201, "numRows": 8}, {"asn": 65202, "numRows":
     8}, {"asn": 65530, "numRows": 12}, {"asn": 65000, "numRows": 57}]'
-- command: bgp unique --count=True --format=json --columns=peerAsn --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=peerAsn --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"peerAsn": 0, "numRows": 1}, {"peerAsn": 25253, "numRows": 4}, {"peerAsn":
@@ -84,7 +99,8 @@ tests:
     4}, {"peerAsn": 65103, "numRows": 4}, {"peerAsn": 65104, "numRows": 4}, {"peerAsn":
     65201, "numRows": 8}, {"peerAsn": 65202, "numRows": 8}, {"peerAsn": 65530, "numRows":
     12}, {"peerAsn": 65000, "numRows": 56}]'
-- command: bgp unique --count=True --format=json --columns=routerId --namespace='ospf-single dual-evpn ospf-ibgp'
+- command: bgp unique --count=True --format=json --columns=routerId --namespace='ospf-single
+    dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp unique cumulus
   output: '[{"routerId": "10.0.0.11", "numRows": 2}, {"routerId": "10.0.0.12", "numRows":
@@ -93,3 +109,24 @@ tests:
     6}, {"routerId": "10.0.0.102", "numRows": 7}, {"routerId": "10.0.0.101", "numRows":
     8}, {"routerId": "10.0.0.22", "numRows": 8}, {"routerId": "10.0.0.100", "numRows":
     12}, {"routerId": "None", "numRows": 58}]'
+- command: bgp unique --count=True --format=json --namespace=dual-bgp --columns=peerAsndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique cumulus
+  output: '[{"peerAsndot": "0.25253", "numRows": 2}, {"peerAsndot": "0.65101", "numRows":
+    4}, {"peerAsndot": "0.65102", "numRows": 4}, {"peerAsndot": "0.65103", "numRows":
+    4}, {"peerAsndot": "0.65104", "numRows": 4}, {"peerAsndot": "0.65530", "numRows":
+    4}, {"peerAsndot": "0.65201", "numRows": 5}, {"peerAsndot": "0.65202", "numRows":
+    5}, {"peerAsndot": "0.65000", "numRows": 20}]'
+- command: bgp unique --count=True --format=json --namespace=dual-bgp --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique cumulus
+  output: '[{"asndot": "0.25253", "numRows": 2}, {"asndot": "0.65101", "numRows":
+    4}, {"asndot": "0.65102", "numRows": 4}, {"asndot": "0.65103", "numRows": 4},
+    {"asndot": "0.65104", "numRows": 4}, {"asndot": "0.65530", "numRows": 4}, {"asndot":
+    "0.65201", "numRows": 5}, {"asndot": "0.65202", "numRows": 5}, {"asndot": "0.65000",
+    "numRows": 20}]'
+- command: bgp unique --format=json --namespace=ospf-ibgp --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique cumulus
+  output: '[{"asndot": "0.25253"}, {"asndot": "0.65000"}, {"asndot": "0.65001"}, {"asndot":
+    "0.65530"}]'

--- a/tests/integration/sqcmds/eos-samples/all.yml
+++ b/tests/integration/sqcmds/eos-samples/all.yml
@@ -891,503 +891,534 @@ tests:
     false, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
     26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.13",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network
-    is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer":
-    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677975569.0, "timestamp": 1623025175569, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime":
-    180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp": 1623025175569, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp":
+    1623025175569, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.13",
     "holdTime": 180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22",
     "routerId": "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp": 1623025175569, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677975569.0, "timestamp": 1623025175569, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.13",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677975569.0,
+    "timestamp": 1623025175569, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Invalid argument)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp":
+    1623025175569, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.13",
     "holdTime": 180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Invalid argument)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677975569.0, "timestamp": 1623025175569, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime":
-    180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Invalid argument)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp": 1623025175569, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.13",
-    "holdTime": 180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Invalid argument)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
-    42, "numChanges": 2, "estdTime": 1622920775571.0, "timestamp": 1623025175571,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 6022, "updatesTx": 25269, "peerRouterId": "10.0.0.31",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    2, "estdTime": 1622920775571.0, "timestamp": 1623025175571, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 6022, "updatesTx": 25269, "peerRouterId": "10.0.0.31", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 2, "estdTime": 1622920775571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 6022, "updatesTx": 25269, "peerRouterId": "10.0.0.31",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.14", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.14", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.14", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges":
-    1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges":
-    1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
-    "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Invalid argument)",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace":
+    "eos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
+    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975569.0,
+    "timestamp": 1623025175569, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Invalid argument)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 2, "estdTime": 1622920775571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    6022, "updatesTx": 25269, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 2, "estdTime": 1622920775571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    6022, "updatesTx": 25269, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 2, "estdTime": 1622920775571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    6022, "updatesTx": 25269, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0,
+    "timestamp": 1623025175571, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp":
+    1623025175797, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.12",
     "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.12",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp":
+    1623025175797, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.12",
     "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22",
     "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.12",
-    "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.12",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp":
+    1623025175797, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.12",
     "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime":
-    180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.12",
-    "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer":
-    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges":
-    1, "estdTime": 1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime":
-    180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer":
-    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime":
-    180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1620677975797.0, "timestamp": 1623025175797, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.12",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677976019.0,
+    "timestamp": 1623025176019, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.14",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp":
+    1623025176019, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.14",
     "holdTime": 180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22",
     "routerId": "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.14",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677976019.0,
+    "timestamp": 1623025176019, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.14",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp":
+    1623025176019, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.14",
     "holdTime": 180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime":
-    180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.14",
-    "holdTime": 180, "updatesRx": 26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "exit02", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
-    10, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32",
-    "holdTime": 180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf", "peer":
-    "169.254.253.6", "peerHostname": "firewall01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 65521, "peerAsn": 65533, "pfxRx": 7, "pfxTx":
-    3, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.5",
-    "holdTime": 9, "updatesRx": 76, "updatesTx": 73, "peerRouterId": "10.0.0.200",
-    "routerId": "169.254.253.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.6", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
-    "peerHostname": "firewall01", "state": "Established", "afi": "ipv6", "safi": "unicast",
-    "asn": 65522, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976019.0, "timestamp": 1623025176019, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
+    26522, "updatesTx": 4802, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.14",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1620677976020.0,
+    "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime": 180, "updatesRx":
+    25292, "updatesTx": 6032, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.32",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65521, "peerAsn": 65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime":
     1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.9", "holdTime":
-    9, "updatesRx": 76, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId":
-    "169.254.253.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.10", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv6 unicast"},
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime":
+    9, "updatesRx": 76, "updatesTx": 73, "peerRouterId": "10.0.0.200", "routerId":
+    "169.254.253.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65521", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.253.6", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 65522, "peerAsn":
+    65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
+    1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254,
+    "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "169.254.253.9", "holdTime": 9, "updatesRx": 76, "updatesTx":
+    2, "peerRouterId": "10.0.0.200", "routerId": "169.254.253.9", "bfdStatus": "disabled",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.253.10", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
     {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
     "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
     "asn": 65522, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime":
@@ -1398,51 +1429,26 @@ tests:
     "defOriginate": false, "keepaliveTime": 30, "updateSource": "169.254.127.3", "holdTime":
     90, "updatesRx": 3, "updatesTx": 70, "peerRouterId": "10.0.0.41", "routerId":
     "169.254.253.9", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.127.2", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos",
-    "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2", "peerHostname":
-    "dcedge01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 65522,
-    "peerAsn": 65534, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0,
-    "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
-    0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap":
-    "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
-    "keepaliveTime": 30, "updateSource": "169.254.127.3", "holdTime": 90, "updatesRx":
-    3, "updatesTx": 70, "peerRouterId": "10.0.0.41", "routerId": "169.254.253.9",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "False", "asndot": "0.65522", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65534", "peerIP":
+    "169.254.127.2", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "internet-vrf", "peer": "169.254.127.2", "peerHostname": "dcedge01", "state":
+    "Established", "afi": "ipv6", "safi": "unicast", "asn": 65522, "peerAsn": 65534,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
+    1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254,
+    "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard"], "defOriginate": false, "keepaliveTime":
+    30, "updateSource": "169.254.127.3", "holdTime": 90, "updatesRx": 3, "updatesTx":
+    70, "peerRouterId": "10.0.0.41", "routerId": "169.254.253.9", "bfdStatus": "up",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
     "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.127.2", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv6 unicast"}, {"namespace": "eos",
-    "hostname": "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname":
-    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
-    65520, "peerAsn": 65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
-    "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime":
-    9, "updatesRx": 76, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId":
-    "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.2", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos",
-    "hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname":
-    "firewall01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn":
-    65521, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
-    "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime":
-    9, "updatesRx": 76, "updatesTx": 73, "peerRouterId": "10.0.0.200", "routerId":
-    "169.254.253.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.6", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv6 unicast"},
+    false, "peerAsndot": "0.65534", "peerIP": "169.254.127.2", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
     {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
-    "peerHostname": "firewall01", "state": "Established", "afi": "ipv6", "safi": "unicast",
-    "asn": 65520, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65520, "peerAsn": 65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
     1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
@@ -1450,11 +1456,52 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime":
     9, "updatesRx": 76, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId":
     "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.2", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv6 unicast"}, {"namespace": "eos",
+    "False", "asndot": "0.65520", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP":
+    "169.254.253.2", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "evpn-vrf", "peer": "169.254.253.6", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv6", "safi": "unicast", "asn": 65521, "peerAsn": 65533, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.5",
+    "holdTime": 9, "updatesRx": 76, "updatesTx": 73, "peerRouterId": "10.0.0.200",
+    "routerId": "169.254.253.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "False", "asndot": "0.65521", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.253.6", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 65520, "peerAsn":
+    65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
+    1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254,
+    "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "169.254.253.1", "holdTime": 9, "updatesRx": 76, "updatesTx":
+    1, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus": "disabled",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.253.2", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime": 180, "updatesRx":
+    25292, "updatesTx": 6032, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.32",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
     "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
-    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
     64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
     1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
@@ -1462,116 +1509,108 @@ tests:
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32",
     "holdTime": 180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.22",
     "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "exit02", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32",
-    "holdTime": 180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "exit02", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
-    10, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32",
-    "holdTime": 180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime":
-    180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "exit02", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32",
-    "holdTime": 180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf",
-    "peer": "169.254.253.10", "peerHostname": "firewall01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn": 65533, "pfxRx": 4,
-    "pfxTx": 6, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.9",
-    "holdTime": 9, "updatesRx": 76, "updatesTx": 2, "peerRouterId": "10.0.0.200",
-    "routerId": "169.254.253.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.10", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime":
+    1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
     "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
-    false, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
-    1186, "updatesTx": 282, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.31",
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime": 180, "updatesRx":
+    25292, "updatesTx": 6032, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.32",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network
-    is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf",
-    "peer": "169.254.254.10", "peerHostname": "firewall01", "state": "Established",
-    "afi": "ipv6", "safi": "unicast", "asn": 65522, "peerAsn": 65533, "pfxRx": 0,
-    "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis":
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
+    1623025176020, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
     false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.9",
-    "holdTime": 9, "updatesRx": 7, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId":
-    "169.254.254.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.10", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv6 unicast"},
-    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
-    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65522, "peerAsn": 65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime":
-    1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
+    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.32",
+    "holdTime": 180, "updatesRx": 25292, "updatesTx": 6032, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime": 180, "updatesRx":
+    25292, "updatesTx": 6032, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.32",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65522, "peerAsn": 65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime":
+    1620677976020.0, "timestamp": 1623025176020, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime":
-    9, "updatesRx": 7, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId": "169.254.254.9",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.9", "holdTime":
+    9, "updatesRx": 76, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId":
+    "169.254.253.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65522", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.253.10", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.31",
+    "holdTime": 180, "updatesRx": 1186, "updatesTx": 282, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "peer":
+    "169.254.254.10", "peerHostname": "firewall01", "state": "Established", "afi":
+    "ipv6", "safi": "unicast", "asn": 65522, "peerAsn": 65533, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly":
+    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
+    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.9",
+    "holdTime": 9, "updatesRx": 7, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId":
+    "169.254.254.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65522", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.254.10", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn":
+    65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254,
+    "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx": 7, "updatesTx":
+    2, "peerRouterId": "10.0.0.200", "routerId": "169.254.254.9", "bfdStatus": "disabled",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
     "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.10", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos",
-    "hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "peerHostname":
-    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
-    65521, "peerAsn": 65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.254.10", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65521, "peerAsn": 65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime":
     1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
@@ -1579,11 +1618,25 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.5", "holdTime":
     9, "updatesRx": 7, "updatesTx": 282, "peerRouterId": "10.0.0.200", "routerId":
     "169.254.254.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.6", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22",
-    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "rrclient": "False", "asndot": "0.65521", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.254.6", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.31",
+    "holdTime": 180, "updatesRx": 1186, "updatesTx": 282, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv6", "safi": "unicast",
     "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
     1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
@@ -1592,51 +1645,27 @@ tests:
     false, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
     1186, "updatesTx": 282, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.31",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network
-    is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "exit01", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.31",
-    "holdTime": 180, "updatesRx": 1186, "updatesTx": 282, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "exit01", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
-    10, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.31",
-    "holdTime": 180, "updatesRx": 1186, "updatesTx": 282, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer":
-    "169.254.254.2", "peerHostname": "firewall01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 65520, "peerAsn": 65533, "pfxRx": 10, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.1",
-    "holdTime": 9, "updatesRx": 7, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId":
-    "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.254.2", "mrai": 0, "reason": "", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1622920776021.0,
+    "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
+    1186, "updatesTx": 282, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.31",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
     "hostname": "exit01", "vrf": "default", "peer": "169.254.254.2", "peerHostname":
-    "firewall01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn":
-    65520, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65520, "peerAsn": 65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
     1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
@@ -1644,36 +1673,51 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime":
     9, "updatesRx": 7, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.2", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv6 unicast"}, {"namespace": "eos",
-    "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "peerHostname":
-    "dcedge01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 65522,
-    "peerAsn": 65534, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0,
-    "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
-    0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap":
-    "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
-    "keepaliveTime": 30, "updateSource": "169.254.127.1", "holdTime": 90, "updatesRx":
-    3, "updatesTx": 3, "peerRouterId": "10.0.0.41", "routerId": "169.254.254.9", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.127.0", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv6 unicast"}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "asndot": "0.65520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.254.2",
+    "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "eos", "hostname": "exit01", "vrf": "default",
+    "peer": "169.254.254.2", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv6", "safi": "unicast", "asn": 65520, "peerAsn": 65533, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.1",
+    "holdTime": 9, "updatesRx": 7, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId":
+    "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65520", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP":
+    "169.254.254.2", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "ipv6 unicast", "active": true}, {"namespace": "eos", "hostname": "exit01", "vrf":
     "internet-vrf", "peer": "169.254.127.0", "peerHostname": "dcedge01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn": 65534,
-    "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    "Established", "afi": "ipv6", "safi": "unicast", "asn": 65522, "peerAsn": 65534,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
     1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": -254,
     "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "", "softReconfig":
     false, "communityTypes": ["standard"], "defOriginate": false, "keepaliveTime":
     30, "updateSource": "169.254.127.1", "holdTime": 90, "updatesRx": 3, "updatesTx":
     3, "peerRouterId": "10.0.0.41", "routerId": "169.254.254.9", "bfdStatus": "up",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.127.0", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos", "hostname": "exit01", "vrf":
-    "evpn-vrf", "peer": "169.254.254.6", "peerHostname": "firewall01", "state": "Established",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65534", "peerIP": "169.254.127.0", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65522, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime":
+    1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": -254, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
+    "defOriginate": false, "keepaliveTime": 30, "updateSource": "169.254.127.1", "holdTime":
+    90, "updatesRx": 3, "updatesTx": 3, "peerRouterId": "10.0.0.41", "routerId": "169.254.254.9",
+    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65522", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65534", "peerIP": "169.254.127.0",
+    "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "eos", "hostname": "exit01", "vrf": "evpn-vrf",
+    "peer": "169.254.254.6", "peerHostname": "firewall01", "state": "Established",
     "afi": "ipv6", "safi": "unicast", "asn": 65521, "peerAsn": 65533, "pfxRx": 0,
     "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
@@ -1682,12 +1726,26 @@ tests:
     ["standard"], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.5",
     "holdTime": 9, "updatesRx": 7, "updatesTx": 282, "peerRouterId": "10.0.0.200",
     "routerId": "169.254.254.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.6", "mrai": 0, "reason":
-    "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv6 unicast"},
-    {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime":
+    false, "rrclient": "False", "asndot": "0.65521", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.254.6", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    1623025176021, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.31",
+    "holdTime": 180, "updatesRx": 1186, "updatesTx": 282, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active":
+    true}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
     1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
     "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
@@ -1695,361 +1753,372 @@ tests:
     false, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
     1186, "updatesTx": 282, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.31",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network
-    is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1622920776021.0, "timestamp": 1623025176021, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime":
-    180, "updatesRx": 1186, "updatesTx": 282, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.14", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.14", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.14", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    2, "estdTime": 1622920776023.0, "timestamp": 1623025176023, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 6022, "updatesTx": 25266, "peerRouterId": "10.0.0.31", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
-    "ipv6", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 2, "estdTime": 1622920776023.0, "timestamp": 1623025176023, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 6022, "updatesTx": 25266, "peerRouterId": "10.0.0.31",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
-    42, "numChanges": 2, "estdTime": 1622920776023.0, "timestamp": 1623025176023,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 6022, "updatesTx": 25266, "peerRouterId": "10.0.0.31",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "socket-error:Connect
-    (Invalid argument)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
-    42, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "socket-error:Connect
-    (Invalid argument)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "socket-error:Connect
-    (Invalid argument)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4802, "updatesTx": 26522, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 2, "estdTime": 1622920776023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    6022, "updatesTx": 25266, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 2, "estdTime": 1622920776023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    6022, "updatesTx": 25266, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 2, "estdTime": 1622920776023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    6022, "updatesTx": 25266, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32",
+    "mrai": 0, "reason": "socket-error:Connect (Invalid argument)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32",
+    "mrai": 0, "reason": "socket-error:Connect (Invalid argument)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    6032, "updatesTx": 25292, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32",
+    "mrai": 0, "reason": "socket-error:Connect (Invalid argument)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv6 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0,
+    "timestamp": 1623025176023, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    4835, "updatesTx": 26489, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677976024.0,
+    "timestamp": 1623025176024, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp":
+    1623025176024, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.11",
     "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22",
     "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "peer":
-    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime":
-    180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.11",
-    "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.11",
-    "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv6",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"],
-    "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime":
-    180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21", "routerId":
-    "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv6 unicast"}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.22", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677976024.0,
+    "timestamp": 1623025176024, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard"], "defOriginate": false,
+    "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "eos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp":
+    1623025176024, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 12000, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard"], "defOriginate": false, "keepaliveTime": 60, "updateSource": "10.0.0.11",
     "holdTime": 180, "updatesRx": 26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect
-    (Network is unreachable)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "eos", "hostname": "firewall01", "vrf": "default",
-    "peer": "eth2.4", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65533, "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges":
-    3, "estdTime": 1620677000000.0, "timestamp": 1623025176025, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime":
-    9, "updatesRx": 5, "updatesTx": 82, "peerRouterId": "169.254.253.9", "routerId":
-    "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.253.9", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 15576000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos", "hostname": "firewall01",
-    "vrf": "default", "peer": "eth2.3", "peerHostname": "exit02", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3,
-    "pfxTx": 10, "numChanges": 3, "estdTime": 1620677000000.0, "timestamp": 1623025176025,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.6", "holdTime": 9, "updatesRx": 74, "updatesTx": 82, "peerRouterId":
-    "169.254.253.5", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.5",
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "socket-error:Connect (Network is
+    unreachable)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv6 unicast", "active":
+    true}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976024.0, "timestamp": 1623025176024, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 12000,
+    "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard"], "defOriginate":
+    false, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
+    26489, "updatesTx": 4835, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21",
+    "mrai": 0, "reason": "socket-error:Connect (Network is unreachable)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 3, "estdTime": 1620677000000.0,
+    "timestamp": 1623025176025, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
+    5, "updatesTx": 82, "peerRouterId": "169.254.253.9", "routerId": "10.0.0.200",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65522", "peerIP": "169.254.253.9",
     "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 15576000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos",
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65521, "pfxRx": 3, "pfxTx": 10, "numChanges": 3, "estdTime": 1620677000000.0,
+    "timestamp": 1623025176025, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime": 9, "updatesRx":
+    74, "updatesTx": 82, "peerRouterId": "169.254.253.5", "routerId": "10.0.0.200",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65521", "peerIP": "169.254.253.5",
+    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 15576000,
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos",
     "hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "peerHostname":
     "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
     "peerAsn": 65520, "pfxRx": 0, "pfxTx": 10, "numChanges": 3, "estdTime": 1620677000000.0,
@@ -2059,24 +2128,25 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime": 9, "updatesRx":
     2, "updatesTx": 82, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.200", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    15576000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "eos", "hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "peerHostname":
-    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
-    "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 5, "estdTime": 1622918156000.0,
-    "timestamp": 1623025176025, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
-    7, "updatesTx": 84, "peerRouterId": "169.254.254.9", "routerId": "10.0.0.200",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "Hold Timer Expired", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.9", "mrai": 0, "reason":
-    "BGP Notification send", "lastDownTime": 25394000, "ifname": "", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "eos", "hostname": "firewall01", "vrf":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65520", "peerIP": "169.254.253.1", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 15576000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65522,
+    "pfxRx": 6, "pfxTx": 10, "numChanges": 5, "estdTime": 1622918156000.0, "timestamp":
+    1623025176025, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.254.10", "holdTime": 9, "updatesRx": 7, "updatesTx": 84, "peerRouterId":
+    "169.254.254.9", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533", "notificnReason":
+    "Hold Timer Expired", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65522", "peerIP": "169.254.254.9", "mrai": 0, "reason":
+    "BGP Notification send", "lastDownTime": 25394000, "ifname": "", "afiSafi": "ipv4
+    unicast", "active": true}, {"namespace": "eos", "hostname": "firewall01", "vrf":
     "default", "peer": "eth1.3", "peerHostname": "exit01", "state": "Established",
     "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3,
     "pfxTx": 10, "numChanges": 5, "estdTime": 1622918155000.0, "timestamp": 1623025176025,
@@ -2086,37 +2156,39 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "169.254.254.6", "holdTime": 9, "updatesRx": 349, "updatesTx": 83, "peerRouterId":
     "169.254.254.5", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "Hold Timer Expired",
-    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.5", "mrai": 0, "reason": "BGP Notification send", "lastDownTime":
-    25394000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "eos", "hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "peerHostname":
-    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
-    "peerAsn": 65520, "pfxRx": 0, "pfxTx": 10, "numChanges": 5, "estdTime": 1622918156000.0,
-    "timestamp": 1623025176025, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime": 9, "updatesRx":
-    3, "updatesTx": 85, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    25395000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "eos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534,
-    "peerAsn": 65522, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1620676999989.0,
-    "timestamp": 1623025177989, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"],
-    "pfxBestRx": 4, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "169.254.127.2", "holdTime": 90, "updatesRx":
-    70, "updatesTx": 2, "peerRouterId": "169.254.253.9", "routerId": "10.0.0.41",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.127.3", "mrai": 0, "reason":
-    "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "xe-0/0/1.0", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "eos", "hostname": "dcedge01",
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533", "notificnReason":
+    "Hold Timer Expired", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65521", "peerIP": "169.254.254.5", "mrai": 0, "reason":
+    "BGP Notification send", "lastDownTime": 25394000, "ifname": "", "afiSafi": "ipv4
+    unicast", "active": true}, {"namespace": "eos", "hostname": "firewall01", "vrf":
+    "default", "peer": "eth1.2", "peerHostname": "exit01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0,
+    "pfxTx": 10, "numChanges": 5, "estdTime": 1622918156000.0, "timestamp": 1623025176025,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.254.2", "holdTime": 9, "updatesRx": 3, "updatesTx": 85, "peerRouterId":
+    "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65520", "peerIP": "169.254.254.1", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 25395000, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "eos", "hostname": "dcedge01", "vrf": "default",
+    "peer": "169.254.127.3", "peerHostname": "exit02", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 65522, "pfxRx": 4, "pfxTx":
+    6, "numChanges": 1, "estdTime": 1620676999989.0, "timestamp": 1623025177989, "afisAdvOnly":
+    [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 4, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "169.254.127.2", "holdTime": 90, "updatesRx": 70, "updatesTx": 2, "peerRouterId":
+    "169.254.253.9", "routerId": "10.0.0.41", "bfdStatus": "up", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65534", "notificnReason": "Hold
+    Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65522", "peerIP": "169.254.127.3", "mrai": 0, "reason":
+    "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "xe-0/0/1.0", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "eos", "hostname": "dcedge01",
     "vrf": "default", "peer": "169.254.127.1", "peerHostname": "exit01", "state":
     "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 65522,
     "pfxRx": 4, "pfxTx": 6, "numChanges": 2, "estdTime": 1622918156989.0, "timestamp":
@@ -2126,11 +2198,11 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 30, "updateSource": "169.254.127.0", "holdTime": 90, "updatesRx":
     3, "updatesTx": 2, "peerRouterId": "169.254.254.9", "routerId": "10.0.0.41", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.127.1", "mrai": 0, "reason": "Hold Timer
-    Expired Error", "lastDownTime": 0, "ifname": "xe-0/0/0.0", "active": true, "afiSafi":
-    "ipv4 unicast"}]'
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65534",
+    "notificnReason": "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65522", "peerIP": "169.254.127.1",
+    "mrai": 0, "reason": "Hold Timer Expired Error", "lastDownTime": 0, "ifname":
+    "xe-0/0/0.0", "afiSafi": "ipv4 unicast", "active": true}]'
 - command: device show --columns='*' --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: device show eos all

--- a/tests/integration/sqcmds/eos-samples/bgp.yml
+++ b/tests/integration/sqcmds/eos-samples/bgp.yml
@@ -721,3 +721,464 @@ tests:
       "result": "fail", "assertReason": "Not all Afi/Safis enabled", "timestamp":
       1623025177989}]'
   marks: bgp assert eos
+- command: bgp show --columns='hostname vrf peer state peerAsndot' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: bgp show eos filter
+  output: '[{"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.31", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.14", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.14", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.13", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf04", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf04", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf": "evpn-vrf",
+    "peer": "169.254.253.6", "state": "Established", "peerAsndot": "0.65533"}, {"hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "state": "Established",
+    "peerAsndot": "0.65533"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer":
+    "169.254.127.2", "state": "Established", "peerAsndot": "0.65534"}, {"hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2", "state": "Established",
+    "peerAsndot": "0.65534"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit02", "vrf":
+    "evpn-vrf", "peer": "169.254.253.6", "state": "Established", "peerAsndot": "0.65533"},
+    {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2", "state": "Established",
+    "peerAsndot": "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "state":
+    "Established", "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "state": "Established",
+    "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer":
+    "169.254.254.10", "state": "Established", "peerAsndot": "0.65533"}, {"hostname":
+    "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "state": "Established",
+    "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "exit01", "vrf":
+    "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf":
+    "default", "peer": "169.254.254.2", "state": "Established", "peerAsndot": "0.65533"},
+    {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "state":
+    "Established", "peerAsndot": "0.65534"}, {"hostname": "exit01", "vrf": "internet-vrf",
+    "peer": "169.254.127.0", "state": "Established", "peerAsndot": "0.65534"}, {"hostname":
+    "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "state": "Established",
+    "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "exit01", "vrf":
+    "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.13", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.14", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.31", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf":
+    "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf":
+    "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "state": "Established",
+    "peerAsndot": "0.65522"}, {"hostname": "firewall01", "vrf": "default", "peer":
+    "eth2.3", "state": "Established", "peerAsndot": "0.65521"}, {"hostname": "firewall01",
+    "vrf": "default", "peer": "eth2.2", "state": "Established", "peerAsndot": "0.65520"},
+    {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "state": "Established",
+    "peerAsndot": "0.65522"}, {"hostname": "firewall01", "vrf": "default", "peer":
+    "eth1.3", "state": "Established", "peerAsndot": "0.65521"}, {"hostname": "firewall01",
+    "vrf": "default", "peer": "eth1.2", "state": "Established", "peerAsndot": "0.65520"},
+    {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3", "state": "Established",
+    "peerAsndot": "0.65522"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
+    "state": "Established", "peerAsndot": "0.65522"}]'
+- command: bgp show --columns='hostname vrf peer state asndot' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: bgp show eos filter
+  output: '[{"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.31", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.14", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.14", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.13", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf04", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf04", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "evpn-vrf",
+    "peer": "169.254.253.6", "state": "Established", "asndot": "0.65521"}, {"hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "state": "Established",
+    "asndot": "0.65522"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "state": "Established", "asndot": "0.65522"}, {"hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "169.254.127.2", "state": "Established", "asndot": "0.65522"}, {"hostname":
+    "exit02", "vrf": "default", "peer": "169.254.253.2", "state": "Established", "asndot":
+    "0.65520"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "asndot": "0.65521"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "169.254.253.2", "state": "Established", "asndot": "0.65520"}, {"hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "169.254.253.10", "state": "Established", "asndot": "0.65522"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "asndot": "0.65522"}, {"hostname": "exit01", "vrf": "internet-vrf",
+    "peer": "169.254.254.10", "state": "Established", "asndot": "0.65522"}, {"hostname":
+    "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "state": "Established",
+    "asndot": "0.65521"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "asndot": "0.65520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "169.254.254.2", "state": "Established", "asndot": "0.65520"}, {"hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "state": "Established",
+    "asndot": "0.65522"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "state": "Established", "asndot": "0.65522"}, {"hostname": "exit01", "vrf": "evpn-vrf",
+    "peer": "169.254.254.6", "state": "Established", "asndot": "0.65521"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.12", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.13", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.13", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.14", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.14", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.31", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.32", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.11", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.32", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth2.4", "state": "Established", "asndot": "0.65533"}, {"hostname": "firewall01",
+    "vrf": "default", "peer": "eth2.3", "state": "Established", "asndot": "0.65533"},
+    {"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state": "Established",
+    "asndot": "0.65533"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4",
+    "state": "Established", "asndot": "0.65533"}, {"hostname": "firewall01", "vrf":
+    "default", "peer": "eth1.3", "state": "Established", "asndot": "0.65533"}, {"hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.2", "state": "Established", "asndot":
+    "0.65533"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
+    "state": "Established", "asndot": "0.65534"}, {"hostname": "dcedge01", "vrf":
+    "default", "peer": "169.254.127.1", "state": "Established", "asndot": "0.65534"}]'
+- command: bgp show --columns='hostname vrf peer state asn peerAsn asndot peerAsndot'
+    --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: bgp show eos filter
+  output: '[{"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "asn": 65521, "peerAsn": 65533, "asndot": "0.65521", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
+    "state": "Established", "asn": 65522, "peerAsn": 65533, "asndot": "0.65522", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "state": "Established", "asn": 65522, "peerAsn": 65534, "asndot": "0.65522", "peerAsndot":
+    "0.65534"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "state": "Established", "asn": 65522, "peerAsn": 65534, "asndot": "0.65522", "peerAsndot":
+    "0.65534"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "asn": 65520, "peerAsn": 65533, "asndot": "0.65520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "asn": 65521, "peerAsn": 65533, "asndot": "0.65521", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "asn": 65520, "peerAsn": 65533, "asndot": "0.65520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
+    "state": "Established", "asn": 65522, "peerAsn": 65533, "asndot": "0.65522", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "asn": 65522, "peerAsn": 65533, "asndot": "0.65522", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "asn": 65522, "peerAsn": 65533, "asndot": "0.65522", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "state": "Established", "asn": 65521, "peerAsn": 65533, "asndot": "0.65521", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "asn": 65520, "peerAsn": 65533, "asndot": "0.65520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "asn": 65520, "peerAsn": 65533, "asndot": "0.65520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "state": "Established", "asn": 65522, "peerAsn": 65534, "asndot": "0.65522", "peerAsndot":
+    "0.65534"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "state": "Established", "asn": 65522, "peerAsn": 65534, "asndot": "0.65522", "peerAsndot":
+    "0.65534"}, {"hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "state": "Established", "asn": 65521, "peerAsn": 65533, "asndot": "0.65521", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "state":
+    "Established", "asn": 65533, "peerAsn": 65522, "asndot": "0.65533", "peerAsndot":
+    "0.65522"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "state":
+    "Established", "asn": 65533, "peerAsn": 65521, "asndot": "0.65533", "peerAsndot":
+    "0.65521"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state":
+    "Established", "asn": 65533, "peerAsn": 65520, "asndot": "0.65533", "peerAsndot":
+    "0.65520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "state":
+    "Established", "asn": 65533, "peerAsn": 65522, "asndot": "0.65533", "peerAsndot":
+    "0.65522"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "state":
+    "Established", "asn": 65533, "peerAsn": 65521, "asndot": "0.65533", "peerAsndot":
+    "0.65521"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "state":
+    "Established", "asn": 65533, "peerAsn": 65520, "asndot": "0.65533", "peerAsndot":
+    "0.65520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
+    "state": "Established", "asn": 65534, "peerAsn": 65522, "asndot": "0.65534", "peerAsndot":
+    "0.65522"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
+    "state": "Established", "asn": 65534, "peerAsn": 65522, "asndot": "0.65534", "peerAsndot":
+    "0.65522"}]'

--- a/tests/integration/sqcmds/eos-samples/bgpunique.yml
+++ b/tests/integration/sqcmds/eos-samples/bgpunique.yml
@@ -96,3 +96,21 @@ tests:
     "numRows": 6}, {"routerId": "10.0.0.31", "numRows": 8}, {"routerId": "10.0.0.32",
     "numRows": 8}, {"routerId": "10.0.0.21", "numRows": 18}, {"routerId": "10.0.0.22",
     "numRows": 18}]'
+- command: bgp unique --count=True --format=json --namespace=eos --columns=peerAsndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique eos
+  output: '[{"peerAsndot": "0.65520", "numRows": 2}, {"peerAsndot": "0.65521", "numRows":
+    2}, {"peerAsndot": "0.65522", "numRows": 4}, {"peerAsndot": "0.65534", "numRows":
+    4}, {"peerAsndot": "0.65533", "numRows": 12}, {"peerAsndot": "0.64520", "numRows":
+    72}]'
+- command: bgp unique --count=True --format=json --namespace=eos --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique eos
+  output: '[{"asndot": "0.65534", "numRows": 2}, {"asndot": "0.65520", "numRows":
+    4}, {"asndot": "0.65521", "numRows": 4}, {"asndot": "0.65533", "numRows": 6},
+    {"asndot": "0.65522", "numRows": 8}, {"asndot": "0.64520", "numRows": 72}]'
+- command: bgp unique --format=json --namespace=eos --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique eos
+  output: '[{"asndot": "0.64520"}, {"asndot": "0.65520"}, {"asndot": "0.65521"}, {"asndot":
+    "0.65522"}, {"asndot": "0.65533"}, {"asndot": "0.65534"}]'

--- a/tests/integration/sqcmds/junos-samples/all.yml
+++ b/tests/integration/sqcmds/junos-samples/all.yml
@@ -1651,23 +1651,24 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.6", "holdTime":
     9, "updatesRx": 7, "updatesTx": 11, "peerRouterId": "10.0.0.121", "routerId":
     "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.5", "mrai": 0, "reason":
-    "No AFI/SAFI activated for peer", "lastDownTime": 26878000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname": "firewall01",
-    "vrf": "default", "peer": "eth2.4", "peerHostname": "exit02", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 64520, "pfxRx": 5,
-    "pfxTx": 9, "numChanges": 1, "estdTime": 1622999486000.0, "timestamp": 1623025795301,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.10", "holdTime": 9, "updatesRx": 2, "updatesTx": 11, "peerRouterId":
-    "169.254.253.9", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.9",
+    "rrclient": "False", "asndot": "0.65533", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "169.254.254.5", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 26878000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.4",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65533, "peerAsn": 64520, "pfxRx": 5, "pfxTx": 9, "numChanges": 1, "estdTime":
+    1622999486000.0, "timestamp": 1623025795301, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
+    2, "updatesTx": 11, "peerRouterId": "169.254.253.9", "routerId": "10.0.0.200",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "169.254.253.9",
     "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 26878000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos",
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos",
     "hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "peerHostname":
     "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
     "peerAsn": 64520, "pfxRx": 0, "pfxTx": 9, "numChanges": 1, "estdTime": 1622999478000.0,
@@ -1677,75 +1678,79 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime": 9, "updatesRx":
     5, "updatesTx": 11, "peerRouterId": "10.0.0.122", "routerId": "10.0.0.200", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.5", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    26878000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
-    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 9, "numChanges": 1, "estdTime": 1622999471000.0,
-    "timestamp": 1623025795301, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime": 9, "updatesRx":
-    1, "updatesTx": 11, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.200", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime":
-    26878000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "peerHostname":
-    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
-    "peerAsn": 64520, "pfxRx": 5, "pfxTx": 9, "numChanges": 1, "estdTime": 1622998918000.0,
-    "timestamp": 1623025795301, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
-    2, "updatesTx": 11, "peerRouterId": "169.254.254.9", "routerId": "10.0.0.200",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated
-    for peer", "lastDownTime": 26878000, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "junos", "hostname": "firewall01", "vrf": "default",
-    "peer": "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65533, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 9, "numChanges":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "169.254.253.5", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 26878000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos", "hostname":
+    "firewall01", "vrf": "default", "peer": "eth2.2", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 9, "numChanges": 1, "estdTime": 1622999471000.0, "timestamp":
+    1623025795301, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.253.2", "holdTime": 9, "updatesRx": 1, "updatesTx": 11, "peerRouterId":
+    "10.0.0.32", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated
+    for peer", "lastDownTime": 26878000, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "junos", "hostname": "firewall01", "vrf": "default",
+    "peer": "eth1.4", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65533, "peerAsn": 64520, "pfxRx": 5, "pfxTx": 9, "numChanges":
     1, "estdTime": 1622998918000.0, "timestamp": 1623025795301, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime":
-    9, "updatesRx": 1, "updatesTx": 11, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.1", "mrai": 0, "reason": "Waiting for peer OPEN",
-    "lastDownTime": 26878000, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
-    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx": 0, "numChanges": 0, "estdTime":
-    1622998781432.0, "timestamp": 1623025797432, "afisAdvOnly": [], "afisRcvOnly":
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime":
+    9, "updatesRx": 2, "updatesTx": 11, "peerRouterId": "169.254.254.9", "routerId":
+    "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65533", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated for peer",
+    "lastDownTime": 26878000, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth1.2",
+    "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65533, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 9, "numChanges": 1, "estdTime":
+    1622998918000.0, "timestamp": 1623025795301, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.0.11", "holdTime": 90, "updatesRx":
-    1389, "updatesTx": 9, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.22", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos", "hostname": "leaf01", "vrf":
-    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx":
-    0, "numChanges": 0, "estdTime": 1622998775432.0, "timestamp": 1623025797432, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 12, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime": 9, "updatesRx":
+    1, "updatesTx": 11, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "169.254.254.1", "mrai":
+    0, "reason": "Waiting for peer OPEN", "lastDownTime": 26878000, "ifname": "",
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos", "hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 12, "pfxTx": 0, "numChanges": 0, "estdTime": 1622998781432.0, "timestamp":
+    1623025797432, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
-    "10.0.0.11", "holdTime": 90, "updatesRx": 1101, "updatesTx": 9, "peerRouterId":
-    "10.0.0.21", "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai":
-    0, "reason": "None", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
+    "10.0.0.11", "holdTime": 90, "updatesRx": 1389, "updatesTx": 9, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 12, "pfxTx": 0, "numChanges": 0, "estdTime": 1622998775432.0,
+    "timestamp": 1623025797432, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    12, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.0.11", "holdTime": 90, "updatesRx":
+    1101, "updatesTx": 9, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai":
+    0, "reason": "None", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "junos", "hostname": "leaf02", "vrf": "default",
     "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
     "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx":
     0, "numChanges": 0, "estdTime": 1622998778434.0, "timestamp": 1623025797434, "afisAdvOnly":
@@ -1755,74 +1760,78 @@ tests:
     "defOriginate": false, "keepaliveTime": 30, "updateSource": "10.0.0.12", "holdTime":
     90, "updatesRx": 1389, "updatesTx": 9, "peerRouterId": "10.0.0.22", "routerId":
     "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "None", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos",
-    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
-    64520, "pfxRx": 12, "pfxTx": 0, "numChanges": 0, "estdTime": 1622998778434.0,
-    "timestamp": 1623025797434, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    12, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.0.12", "holdTime": 90, "updatesRx":
-    1101, "updatesTx": 9, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.12", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
+    "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.22", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx":
+    0, "numChanges": 0, "estdTime": 1622998778434.0, "timestamp": 1623025797434, "afisAdvOnly":
+    [], "afisRcvOnly": [], "pfxBestRx": 12, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.0.12", "holdTime": 90, "updatesRx": 1101, "updatesTx": 9, "peerRouterId":
+    "10.0.0.21", "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason":
     "Open Message Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "Open Message Error", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos",
-    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
-    "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 2, "pfxTx": 24, "numChanges": 137, "estdTime": 1623025778800.0,
-    "timestamp": 1623025797800, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    2, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.0.21", "holdTime": 90, "updatesRx":
-    2, "updatesTx": 11, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.21", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "Open
+    Message Error", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active":
+    true}, {"namespace": "junos", "hostname": "spine01", "vrf": "default", "peer":
+    "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 2, "pfxTx": 24, "numChanges":
+    137, "estdTime": 1623025778800.0, "timestamp": 1623025797800, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 2, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 30, "updateSource": "10.0.0.21", "holdTime":
+    90, "updatesRx": 2, "updatesTx": 11, "peerRouterId": "10.0.0.32", "routerId":
+    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.32", "mrai": 0, "reason": "Cease", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 2, "pfxTx": 24, "numChanges": 216, "estdTime": 1623025762800.0, "timestamp":
+    1623025797800, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 2, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.0.21", "holdTime": 90, "updatesRx": 2, "updatesTx": 14, "peerRouterId":
+    "10.0.0.31", "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
     "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai": 0, "reason": "Cease", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos",
-    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
-    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 2, "pfxTx": 24, "numChanges": 216, "estdTime": 1623025762800.0,
-    "timestamp": 1623025797800, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    2, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.0.21", "holdTime": 90, "updatesRx":
-    2, "updatesTx": 14, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.21", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai": 0, "reason": "Cease", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos",
-    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
-    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 11, "pfxTx": 15, "numChanges": 0, "estdTime": 1622998778800.0,
-    "timestamp": 1623025797800, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    11, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.0.21", "holdTime": 90, "updatesRx":
-    10, "updatesTx": 1100, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.12", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos", "hostname": "spine01",
-    "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx":
-    15, "numChanges": 0, "estdTime": 1622998774800.0, "timestamp": 1623025797800,
+    "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31", "mrai":
+    0, "reason": "Cease", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx":
+    15, "numChanges": 0, "estdTime": 1622998778800.0, "timestamp": 1623025797800,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 11, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.0.21", "holdTime": 90, "updatesRx": 10, "updatesTx": 1100, "peerRouterId":
-    "10.0.0.11", "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai":
-    0, "reason": "None", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
+    "10.0.0.12", "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.12", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "junos",
+    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 11, "pfxTx": 15, "numChanges": 0, "estdTime": 1622998774800.0,
+    "timestamp": 1623025797800, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    11, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.0.21", "holdTime": 90, "updatesRx":
+    10, "updatesTx": 1100, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.21", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11", "mrai":
+    0, "reason": "None", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
     "peer": "169.254.127.1", "peerHostname": "exit01", "state": "Established", "afi":
     "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 64520, "pfxRx": 3, "pfxTx":
     6, "numChanges": 0, "estdTime": 1622999270026.0, "timestamp": 1623025798026, "afisAdvOnly":
@@ -1832,36 +1841,37 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "169.254.127.0", "holdTime": 90, "updatesRx": 9, "updatesTx": 2, "peerRouterId":
     "169.254.254.9", "routerId": "10.0.0.41", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.1",
-    "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/0.0", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname": "exit01",
-    "vrf": "default", "peer": "169.254.254.2", "peerHostname": "firewall01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533,
-    "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime": 1622998918026.0, "timestamp":
-    1623025798026, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime": 90, "updatesRx":
-    11, "updatesTx": 0, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "Cease", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
-    "peerIP": "169.254.254.2", "mrai": 0, "reason": "Cease", "lastDownTime": 0, "ifname":
-    "xe-0/0/2.2", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos",
-    "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "peerHostname":
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65534", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "169.254.127.1", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "xe-0/0/0.0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "junos", "hostname": "exit01", "vrf": "default", "peer": "169.254.254.2", "peerHostname":
     "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
-    64520, "peerAsn": 65533, "pfxRx": 9, "pfxTx": 5, "numChanges": 0, "estdTime":
-    1622998919026.0, "timestamp": 1623025798026, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 3, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime": 90, "updatesRx":
-    11, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId": "169.254.254.9",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.10", "mrai": 0, "reason": "None", "lastDownTime":
-    0, "ifname": "xe-0/0/2.4", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
+    64520, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime":
+    1622998918026.0, "timestamp": 1623025798026, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4 unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime":
+    90, "updatesRx": 11, "updatesTx": 0, "peerRouterId": "10.0.0.200", "routerId":
+    "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.64520", "notificnReason": "Cease", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP":
+    "169.254.254.2", "mrai": 0, "reason": "Cease", "lastDownTime": 0, "ifname": "xe-0/0/2.2",
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 9, "pfxTx": 5, "numChanges": 0, "estdTime": 1622998919026.0, "timestamp":
+    1623025798026, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 3, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "169.254.254.9", "holdTime": 90, "updatesRx": 11, "updatesTx": 1, "peerRouterId":
+    "10.0.0.200", "routerId": "169.254.254.9", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65533", "peerIP": "169.254.254.10", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "xe-0/0/2.4", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
     "junos", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "peerHostname":
     "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
     64520, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 3, "numChanges": 0, "estdTime":
@@ -1872,88 +1882,93 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.5", "holdTime":
     90, "updatesRx": 11, "updatesTx": 6, "peerRouterId": "10.0.0.200", "routerId":
     "10.0.0.121", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "169.254.254.6", "mrai": 0, "reason":
-    "None", "lastDownTime": 0, "ifname": "xe-0/0/2.3", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
-    "peer": "169.254.127.0", "peerHostname": "dcedge01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx":
-    3, "numChanges": 0, "estdTime": 1622999270026.0, "timestamp": 1623025798026, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 5, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 30, "updateSource": "169.254.127.1", "holdTime":
-    90, "updatesRx": 3, "updatesTx": 8, "peerRouterId": "10.0.0.41", "routerId": "169.254.254.9",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.127.0", "mrai": 0, "reason": "None", "lastDownTime":
-    0, "ifname": "xe-0/0/3.0", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "junos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
-    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 12, "pfxTx": 0, "numChanges": 168, "estdTime": 1623021267026.0,
+    "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.254.6", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname":
+    "xe-0/0/2.3", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "peerHostname":
+    "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 65534, "pfxRx": 6, "pfxTx": 3, "numChanges": 0, "estdTime": 1622999270026.0,
     "timestamp": 1623025798026, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    12, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    5, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.0.31", "holdTime": 90, "updatesRx":
-    161, "updatesTx": 1, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.31", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
+    false, "keepaliveTime": 30, "updateSource": "169.254.127.1", "holdTime": 90, "updatesRx":
+    3, "updatesTx": 8, "peerRouterId": "10.0.0.41", "routerId": "169.254.254.9", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65534", "peerIP": "169.254.127.0", "mrai": 0, "reason":
+    "None", "lastDownTime": 0, "ifname": "xe-0/0/3.0", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx":
+    0, "numChanges": 168, "estdTime": 1623021267026.0, "timestamp": 1623025798026,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 12, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.0.31", "holdTime": 90, "updatesRx": 161, "updatesTx": 1, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason":
     "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "Hold Timer
-    Expired Error", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn
-    evpn"}, {"namespace": "junos", "hostname": "exit01", "vrf": "default", "peer":
-    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    216, "estdTime": 1623025762026.0, "timestamp": 1623025798026, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 30, "updateSource": "10.0.0.31", "holdTime":
-    90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.31",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "Open Message Error", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "Hold
-    Timer Expired Error", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default",
-    "peer": "169.254.127.3", "peerHostname": "exit02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 64520, "pfxRx": 3, "pfxTx":
-    6, "numChanges": 0, "estdTime": 1622999494026.0, "timestamp": 1623025798026, "afisAdvOnly":
-    [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 216, "estdTime": 1623025762026.0, "timestamp": 1623025798026,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.0.31", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "Open Message
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active":
+    true}, {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "peer":
+    "169.254.127.3", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65534, "peerAsn": 64520, "pfxRx": 3, "pfxTx": 6, "numChanges":
+    0, "estdTime": 1622999494026.0, "timestamp": 1623025798026, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "169.254.127.2", "holdTime": 90, "updatesRx": 11, "updatesTx": 2, "peerRouterId":
     "169.254.253.9", "routerId": "10.0.0.41", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "Cease", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.3",
-    "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/1.0", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname": "exit02",
-    "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname": "firewall01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533,
-    "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime": 1622999478028.0, "timestamp":
-    1623025798028, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime": 90, "updatesRx":
-    11, "updatesTx": 4, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.122", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.253.6", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/2.3",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname":
-    "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname": "firewall01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
-    65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime": 1622999470028.0, "timestamp":
-    1623025798028, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime": 90, "updatesRx":
-    11, "updatesTx": 0, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65534", "notificnReason": "Cease",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "169.254.127.3", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "xe-0/0/1.0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    64520, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime":
+    1622999478028.0, "timestamp": 1623025798028, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4 unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime":
+    90, "updatesRx": 11, "updatesTx": 4, "peerRouterId": "10.0.0.200", "routerId":
+    "10.0.0.122", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533",
+    "peerIP": "169.254.253.6", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname":
+    "xe-0/0/2.3", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    64520, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime":
+    1622999470028.0, "timestamp": 1623025798028, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4 unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime":
+    90, "updatesRx": 11, "updatesTx": 0, "peerRouterId": "10.0.0.200", "routerId":
+    "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP":
     "169.254.253.2", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/2.2",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname":
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "junos", "hostname":
     "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2", "peerHostname": "dcedge01",
     "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
     65534, "pfxRx": 6, "pfxTx": 3, "numChanges": 0, "estdTime": 1622999494028.0, "timestamp":
@@ -1963,49 +1978,52 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "169.254.127.3", "holdTime": 90, "updatesRx": 3, "updatesTx": 10, "peerRouterId":
     "10.0.0.41", "routerId": "169.254.253.9", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.2",
-    "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/3.0", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname": "exit02",
-    "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 281, "estdTime": 1623025725028.0, "timestamp": 1623025798028,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
-    "10.0.0.32", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai":
-    0, "reason": "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos", "hostname": "exit02", "vrf":
-    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 137, "estdTime": 1623025778028.0, "timestamp": 1623025798028,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
-    "10.0.0.32", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "False", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai":
-    0, "reason": "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos", "hostname": "exit02", "vrf":
-    "internet-vrf", "peer": "169.254.253.10", "peerHostname": "firewall01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533,
-    "pfxRx": 9, "pfxTx": 5, "numChanges": 0, "estdTime": 1622999486028.0, "timestamp":
-    1623025798028, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 3, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.9", "holdTime": 90, "updatesRx": 11, "updatesTx": 1, "peerRouterId":
-    "10.0.0.200", "routerId": "169.254.253.9", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.10",
-    "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/2.4", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "junos", "hostname": "spine02",
+    "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65534", "peerIP": "169.254.127.2", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "xe-0/0/3.0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "junos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
+    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 281, "estdTime": 1623025725028.0,
+    "timestamp": 1623025798028, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.0.32", "holdTime": 90, "updatesRx":
+    0, "updatesTx": 1, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.32", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.64520", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.22", "mrai": 0, "reason": "Hold Timer Expired Error", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 137, "estdTime": 1623025778028.0,
+    "timestamp": 1623025798028, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.0.32", "holdTime": 90, "updatesRx":
+    0, "updatesTx": 1, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.32", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.64520", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.21", "mrai": 0, "reason": "Hold Timer Expired Error", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "junos",
+    "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    64520, "peerAsn": 65533, "pfxRx": 9, "pfxTx": 5, "numChanges": 0, "estdTime":
+    1622999486028.0, "timestamp": 1623025798028, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 3, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.9", "holdTime": 90, "updatesRx":
+    11, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId": "169.254.253.9",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.253.10",
+    "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/2.4", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "junos", "hostname": "spine02",
     "vrf": "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx":
     15, "numChanges": 0, "estdTime": 1622998778030.0, "timestamp": 1623025798030,
@@ -2015,49 +2033,51 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.0.22", "holdTime": 90, "updatesRx": 10, "updatesTx": 1388, "peerRouterId":
     "10.0.0.12", "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.12", "mrai":
-    0, "reason": "None", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 2, "pfxTx":
-    24, "numChanges": 168, "estdTime": 1623021266030.0, "timestamp": 1623025798030,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 2, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.12", "mrai": 0, "reason": "None", "lastDownTime":
+    0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "junos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 2, "pfxTx": 24, "numChanges": 168, "estdTime": 1623021266030.0,
+    "timestamp": 1623025798030, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    2, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.0.22", "holdTime": 90, "updatesRx":
+    2, "updatesTx": 160, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.22", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.31", "mrai": 0, "reason": "Cease", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "junos", "hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx":
+    15, "numChanges": 0, "estdTime": 1622998781030.0, "timestamp": 1623025798030,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 11, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
-    "10.0.0.22", "holdTime": 90, "updatesRx": 2, "updatesTx": 160, "peerRouterId":
-    "10.0.0.31", "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "Hold Timer Expired
-    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
-    "peerIP": "10.0.0.31", "mrai": 0, "reason": "Cease", "lastDownTime": 0, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos", "hostname":
-    "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 11, "pfxTx": 15, "numChanges": 0, "estdTime": 1622998781030.0, "timestamp":
-    1623025798030, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 11, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.0.22", "holdTime": 90, "updatesRx": 10, "updatesTx": 1388, "peerRouterId":
     "10.0.0.11", "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "Open Message Error",
-    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.11", "mrai": 0, "reason": "Open Message Error", "lastDownTime": 0, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "junos", "hostname":
-    "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 2, "pfxTx": 24, "numChanges": 282, "estdTime": 1623025725030.0, "timestamp":
-    1623025798030, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 2, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
-    "10.0.0.22", "holdTime": 90, "updatesRx": 2, "updatesTx": 11, "peerRouterId":
-    "10.0.0.32", "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "Hold Timer Expired
-    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
+    "Open Message Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11", "mrai": 0, "reason": "Open
+    Message Error", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active":
+    true}, {"namespace": "junos", "hostname": "spine02", "vrf": "default", "peer":
+    "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 2, "pfxTx": 24, "numChanges":
+    282, "estdTime": 1623025725030.0, "timestamp": 1623025798030, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 2, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 30, "updateSource": "10.0.0.22", "holdTime":
+    90, "updatesRx": 2, "updatesTx": 11, "peerRouterId": "10.0.0.32", "routerId":
+    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
     "peerIP": "10.0.0.32", "mrai": 0, "reason": "Cease", "lastDownTime": 0, "ifname":
-    "", "active": true, "afiSafi": "l2vpn evpn"}]'
+    "", "afiSafi": "l2vpn evpn", "active": true}]'
 - command: device show --columns='*' --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: device show junos all

--- a/tests/integration/sqcmds/junos-samples/bgp.yml
+++ b/tests/integration/sqcmds/junos-samples/bgp.yml
@@ -260,3 +260,165 @@ tests:
       "peerAsn": 64520, "state": "Established", "peerHostname": "exit02", "result":
       "pass", "assertReason": "-", "timestamp": 1623025798030}]'
   marks: bgp assert junos junos
+- command: bgp show --columns='hostname vrf peer state peerAsndot' --format=json --namespace=junos
+  data-directory: tests/data/parquet/
+  marks: bgp show junos filter
+  output: '[{"hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth2.4", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "firewall01", "vrf": "default", "peer": "eth2.3", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth1.4", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.2", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.32", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.31", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "dcedge01", "vrf": "default", "peer": "169.254.127.1", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf":
+    "internet-vrf", "peer": "169.254.254.10", "state": "Established", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf":
+    "internet-vrf", "peer": "169.254.127.0", "state": "Established", "peerAsndot":
+    "0.65534"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "dcedge01", "vrf": "default", "peer": "169.254.127.3", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit02", "vrf":
+    "default", "peer": "169.254.253.2", "state": "Established", "peerAsndot": "0.65533"},
+    {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2", "state":
+    "Established", "peerAsndot": "0.65534"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.32", "state": "Established", "peerAsndot": "0.64520"}]'
+- command: bgp show --columns='hostname vrf peer state asndot' --format=json --namespace=junos
+  data-directory: tests/data/parquet/
+  marks: bgp show junos filter
+  output: '[{"hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "state":
+    "Established", "asndot": "0.65533"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth2.4", "state": "Established", "asndot": "0.65533"}, {"hostname": "firewall01",
+    "vrf": "default", "peer": "eth2.3", "state": "Established", "asndot": "0.65533"},
+    {"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state": "Established",
+    "asndot": "0.65533"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4",
+    "state": "Established", "asndot": "0.65533"}, {"hostname": "firewall01", "vrf":
+    "default", "peer": "eth1.2", "state": "Established", "asndot": "0.65533"}, {"hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "dcedge01", "vrf": "default",
+    "peer": "169.254.127.1", "state": "Established", "asndot": "0.65534"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "169.254.254.2", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "evpn-vrf",
+    "peer": "169.254.254.6", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "state": "Established",
+    "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "dcedge01", "vrf": "default", "peer": "169.254.127.3", "state": "Established",
+    "asndot": "0.65534"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "169.254.253.2", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2", "state": "Established",
+    "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "state": "Established",
+    "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.11", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asndot": "0.64520"}]'
+- command: bgp show --columns='hostname vrf peer state asn peerAsn asndot peerAsndot'
+    --format=json --namespace=junos
+  data-directory: tests/data/parquet/
+  marks: bgp show junos filter
+  output: '[{"hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "state":
+    "Established", "asn": 65533, "peerAsn": 64520, "asndot": "0.65533", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "state":
+    "Established", "asn": 65533, "peerAsn": 64520, "asndot": "0.65533", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "state":
+    "Established", "asn": 65533, "peerAsn": 64520, "asndot": "0.65533", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state":
+    "Established", "asn": 65533, "peerAsn": 64520, "asndot": "0.65533", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "state":
+    "Established", "asn": 65533, "peerAsn": 64520, "asndot": "0.65533", "peerAsndot":
+    "0.64520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "state":
+    "Established", "asn": 65533, "peerAsn": 64520, "asndot": "0.65533", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
+    "state": "Established", "asn": 65534, "peerAsn": 64520, "asndot": "0.65534", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "state": "Established", "asn": 64520, "peerAsn": 65534, "asndot": "0.64520", "peerAsndot":
+    "0.65534"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
+    "state": "Established", "asn": 65534, "peerAsn": 64520, "asndot": "0.65534", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "state": "Established", "asn": 64520, "peerAsn": 65534, "asndot": "0.64520", "peerAsndot":
+    "0.65534"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}]'

--- a/tests/integration/sqcmds/junos-samples/bgpunique.yml
+++ b/tests/integration/sqcmds/junos-samples/bgpunique.yml
@@ -89,3 +89,13 @@ tests:
     3}, {"routerId": "10.0.0.32", "numRows": 3}, {"routerId": "10.0.0.21", "numRows":
     4}, {"routerId": "10.0.0.22", "numRows": 4}, {"routerId": "10.0.0.200", "numRows":
     6}]'
+- command: bgp unique --count=True --format=json --namespace=junos --columns=peerAsndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique junos
+  output: '[{"peerAsndot": "0.65534", "numRows": 2}, {"peerAsndot": "0.65533", "numRows":
+    6}, {"peerAsndot": "0.64520", "numRows": 24}]'
+- command: bgp unique --count=True --format=json --namespace=junos --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique junos
+  output: '[{"asndot": "0.65534", "numRows": 2}, {"asndot": "0.65533", "numRows":
+    6}, {"asndot": "0.64520", "numRows": 24}]'

--- a/tests/integration/sqcmds/nxos-samples/all.yml
+++ b/tests/integration/sqcmds/nxos-samples/all.yml
@@ -2473,36 +2473,38 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime":
     9, "updatesRx": 3, "updatesTx": 48, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.200",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "169.254.253.1", "mrai": 0, "reason": "No AFI/SAFI activated for
-    peer", "lastDownTime": 78486000, "ifname": "", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "peer":
-    "eth2.4", "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65533, "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges":
-    5, "estdTime": 1619110466000.0, "timestamp": 1619275256921, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime":
-    9, "updatesRx": 10, "updatesTx": 42, "peerRouterId": "169.254.253.9", "routerId":
-    "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "169.254.253.9", "mrai": 0, "reason": "No
-    AFI/SAFI activated for peer", "lastDownTime": 78486000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "firewall01",
-    "vrf": "default", "peer": "eth2.3", "peerHostname": "exit02", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3,
-    "pfxTx": 10, "numChanges": 5, "estdTime": 1619110462000.0, "timestamp": 1619275256921,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.6", "holdTime": 9, "updatesRx": 30, "updatesTx": 44, "peerRouterId":
-    "169.254.253.5", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "169.254.253.5",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65520", "peerIP": "169.254.253.1",
     "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 78486000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos",
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 5, "estdTime": 1619110466000.0,
+    "timestamp": 1619275256921, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
+    10, "updatesTx": 42, "peerRouterId": "169.254.253.9", "routerId": "10.0.0.200",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65522", "peerIP": "169.254.253.9",
+    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 78486000,
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65521, "pfxRx": 3, "pfxTx": 10, "numChanges": 5, "estdTime": 1619110462000.0,
+    "timestamp": 1619275256921, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime": 9, "updatesRx":
+    30, "updatesTx": 44, "peerRouterId": "169.254.253.5", "routerId": "10.0.0.200",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65521", "peerIP": "169.254.253.5",
+    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 78486000,
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
     "hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "peerHostname":
     "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
     "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 7, "estdTime": 1619117517000.0,
@@ -2513,65 +2515,54 @@ tests:
     false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
     15, "updatesTx": 46, "peerRouterId": "169.254.254.9", "routerId": "10.0.0.200",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    true, "peerIP": "169.254.254.9", "mrai": 0, "reason": "No AFI/SAFI activated for
-    peer", "lastDownTime": 71350000, "ifname": "", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "peer":
-    "eth1.3", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3, "pfxTx": 10, "numChanges":
-    15, "estdTime": 1619110462000.0, "timestamp": 1619275256921, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.6", "holdTime":
-    9, "updatesRx": 32, "updatesTx": 51, "peerRouterId": "169.254.254.5", "routerId":
-    "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": true, "peerIP": "169.254.254.5", "mrai": 0, "reason": "No
-    AFI/SAFI activated for peer", "lastDownTime": 78506000, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "firewall01",
-    "vrf": "default", "peer": "eth1.2", "peerHostname": "exit01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0,
-    "pfxTx": 10, "numChanges": 5, "estdTime": 1619110455000.0, "timestamp": 1619275256921,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.254.2", "holdTime": 9, "updatesRx": 3, "updatesTx": 50, "peerRouterId":
-    "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": true, "peerIP": "169.254.254.1",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65522", "peerIP": "169.254.254.9",
+    "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 71350000,
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65521, "pfxRx": 3, "pfxTx": 10, "numChanges": 15, "estdTime": 1619110462000.0,
+    "timestamp": 1619275256921, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.6", "holdTime": 9, "updatesRx":
+    32, "updatesTx": 51, "peerRouterId": "169.254.254.5", "routerId": "10.0.0.200",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": true, "peerAsndot": "0.65521", "peerIP": "169.254.254.5",
     "mrai": 0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 78506000,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos",
-    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
-    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 0, "numChanges": 3, "estdTime": 1619110444329.0,
-    "timestamp": 1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65520, "pfxRx": 0, "pfxTx": 10, "numChanges": 5, "estdTime": 1619110455000.0,
+    "timestamp": 1619275256921, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
-    39, "updatesTx": 1561, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.22", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.2", "holdTime": 9, "updatesRx":
+    3, "updatesTx": 50, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65533", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": true, "peerAsndot": "0.65520", "peerIP": "169.254.254.1", "mrai":
+    0, "reason": "No AFI/SAFI activated for peer", "lastDownTime": 78506000, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 10, "pfxTx": 0, "numChanges": 3, "estdTime": 1619110444329.0, "timestamp":
+    1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
+    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
+    "10.0.0.22", "holdTime": 180, "updatesRx": 39, "updatesTx": 1561, "peerRouterId":
+    "10.0.0.32", "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
     "session closed", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled":
-    true, "peerIP": "10.0.0.32", "mrai": 0, "reason": "No error", "lastDownTime":
-    0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
-    "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime": 1619044327329.0,
-    "timestamp": 1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
-    403, "updatesTx": 1191, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.22",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.11", "mrai": 0, "reason": "holdtimer expired
-    error", "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges":
+    true, "peerAsndot": "0.64520", "peerIP": "10.0.0.32", "mrai": 0, "reason": "No
+    error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer":
+    "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
     3, "estdTime": 1619044327329.0, "timestamp": 1619275258329, "afisAdvOnly": [],
     "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
     0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
@@ -2579,49 +2570,65 @@ tests:
     "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
     180, "updatesRx": 403, "updatesTx": 1191, "peerRouterId": "10.0.0.11", "routerId":
     "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
-    true, "extnhEnabled": true, "peerIP": "10.0.0.11", "mrai": 0, "reason": "holdtimer
-    expired error", "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi":
-    "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 3, "estdTime": 1619044327329.0, "timestamp": 1619275258329, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
-    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
-    180, "updatesRx": 403, "updatesTx": 1191, "peerRouterId": "10.0.0.12", "routerId":
-    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
-    true, "extnhEnabled": true, "peerIP": "10.0.0.12", "mrai": 0, "reason": "holdtimer
-    expired error", "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
-    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 3, "estdTime": 1619044327329.0, "timestamp": 1619275258329,
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.11", "mrai": 0, "reason": "holdtimer expired error", "lastDownTime": 0,
+    "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044327329.0,
+    "timestamp": 1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    403, "updatesTx": 1191, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.11", "mrai":
+    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine02",
+    "vrf": "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 3, "estdTime": 1619044327329.0, "timestamp": 1619275258329,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
     "holdTime": 180, "updatesRx": 403, "updatesTx": 1191, "peerRouterId": "10.0.0.12",
     "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.12", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine02",
-    "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
-    "pfxTx": 0, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp": 1619275258329,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 404, "updatesTx": 1189, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.13", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.12", "mrai": 0, "reason": "holdtimer expired error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer":
+    "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges":
+    3, "estdTime": 1619044327329.0, "timestamp": 1619275258329, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
+    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime":
+    180, "updatesRx": 403, "updatesTx": 1191, "peerRouterId": "10.0.0.12", "routerId":
+    "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.12", "mrai": 0, "reason": "holdtimer expired error", "lastDownTime": 0,
+    "ifname": "loopback0", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime": 1619044328329.0,
+    "timestamp": 1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    404, "updatesTx": 1189, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.13", "mrai":
+    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname":
     "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
     "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
     "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp":
@@ -2631,12 +2638,13 @@ tests:
     ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
     "10.0.0.22", "holdTime": 180, "updatesRx": 404, "updatesTx": 1189, "peerRouterId":
     "10.0.0.13", "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.13", "mrai":
-    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine02",
-    "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
+    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
+    "peerAsndot": "0.64520", "peerIP": "10.0.0.13", "mrai": 0, "reason": "holdtimer
+    expired error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
     42, "numChanges": 3, "estdTime": 1619110444329.0, "timestamp": 1619275258329,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
@@ -2644,23 +2652,24 @@ tests:
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
     "holdTime": 180, "updatesRx": 39, "updatesTx": 1561, "peerRouterId": "10.0.0.32",
     "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "session closed", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.32", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine02", "vrf":
-    "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp": 1619275258329,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 403, "updatesTx": 1190, "peerRouterId": "10.0.0.14",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.14", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine02",
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "session closed",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.32", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044328329.0,
+    "timestamp": 1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    403, "updatesTx": 1190, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.22",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.14", "mrai":
+    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine02",
     "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
     "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 10,
     "pfxTx": 0, "numChanges": 3, "estdTime": 1619110443329.0, "timestamp": 1619275258329,
@@ -2670,23 +2679,24 @@ tests:
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
     "holdTime": 180, "updatesRx": 39, "updatesTx": 1559, "peerRouterId": "10.0.0.31",
     "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "session closed", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.31", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "spine02", "vrf":
-    "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
-    42, "numChanges": 3, "estdTime": 1619110443329.0, "timestamp": 1619275258329,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
-    "holdTime": 180, "updatesRx": 39, "updatesTx": 1559, "peerRouterId": "10.0.0.31",
-    "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "session closed", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.31", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "session closed",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.31", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 3, "estdTime": 1619110443329.0,
+    "timestamp": 1619275258329, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.22", "holdTime": 180, "updatesRx":
+    39, "updatesTx": 1559, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.22", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "session closed", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.31", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine02", "vrf":
     "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established",
     "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
     "pfxTx": 0, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp": 1619275258329,
@@ -2696,204 +2706,212 @@ tests:
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.22",
     "holdTime": 180, "updatesRx": 403, "updatesTx": 1190, "peerRouterId": "10.0.0.14",
     "routerId": "10.0.0.22", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.14", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname":
-    "leaf03", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime": 1619044328347.0, "timestamp":
-    1619275258347, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
-    "10.0.0.13", "holdTime": 180, "updatesRx": 1187, "updatesTx": 400, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1619044328347.0, "timestamp": 1619275258347, "afisAdvOnly":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.14", "mrai": 0, "reason": "holdtimer expired error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1619044328347.0, "timestamp": 1619275258347, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
+    1187, "updatesTx": 400, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.13",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1619044328347.0, "timestamp": 1619275258347,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.13",
+    "holdTime": 180, "updatesRx": 1187, "updatesTx": 400, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
+    "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime": 1619044326347.0,
+    "timestamp": 1619275258347, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
+    1197, "updatesTx": 400, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1619044326347.0, "timestamp": 1619275258347,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.13",
+    "holdTime": 180, "updatesRx": 1197, "updatesTx": 400, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
+    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime": 1619044326542.0,
+    "timestamp": 1619275258542, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
+    1189, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1619044326542.0, "timestamp": 1619275258542,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.11",
+    "holdTime": 180, "updatesRx": 1189, "updatesTx": 399, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
+    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1619044326542.0,
+    "timestamp": 1619275258542, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
+    1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1619044326542.0, "timestamp": 1619275258542, "afisAdvOnly":
     [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
     "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
-    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime":
-    180, "updatesRx": 1187, "updatesTx": 400, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.13", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
-    true, "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1619044326347.0, "timestamp": 1619275258347, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
-    1197, "updatesTx": 400, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1619044326347.0, "timestamp": 1619275258347, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.13", "holdTime": 180, "updatesRx":
-    1197, "updatesTx": 400, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.13",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
-    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1619044326542.0, "timestamp": 1619275258542, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
-    1189, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
-    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1619044326542.0, "timestamp": 1619275258542, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
-    1189, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1619044326542.0, "timestamp": 1619275258542, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
-    1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1619044326542.0, "timestamp": 1619275258542, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime": 180, "updatesRx":
-    1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 10, "numChanges": 1, "estdTime":
-    1619110439986.0, "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
-    1141, "updatesTx": 27, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.31", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
-    "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
-    "loopback0", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos",
-    "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
-    64520, "pfxRx": 0, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110442986.0,
+    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.11", "holdTime":
+    180, "updatesRx": 1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.11", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "exit01",
+    "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 10, "numChanges": 1, "estdTime": 1619110439986.0, "timestamp": 1619275258986,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.31",
+    "holdTime": 180, "updatesRx": 1141, "updatesTx": 27, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
+    "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110442986.0,
     "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
     1132, "updatesTx": 27, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.31", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
-    "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
-    "loopback0", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos",
-    "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
-    64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110442986.0,
-    "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
-    1132, "updatesTx": 27, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.31", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
-    "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
-    "loopback0", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname":
-    "exit01", "vrf": "default", "peer": "169.254.254.2", "peerHostname": "firewall01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
-    65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1619110460986.0,
-    "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
+    10, "numChanges": 1, "estdTime": 1619110442986.0, "timestamp": 1619275258986,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.31",
+    "holdTime": 180, "updatesRx": 1132, "updatesTx": 27, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "nxos", "hostname": "exit01", "vrf": "default", "peer": "169.254.254.2", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    64520, "peerAsn": 65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1619110460986.0, "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
     3, "updateSource": "169.254.254.1", "holdTime": 9, "updatesRx": 19, "updatesTx":
     1, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "No
-    error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.254.2", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/3.2", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "peerHostname":
-    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
-    64520, "peerAsn": 65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime":
-    1619110468986.0, "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
-    3, "updateSource": "169.254.254.5", "holdTime": 9, "updatesRx": 17, "updatesTx":
-    12, "peerRouterId": "10.0.0.200", "routerId": "169.254.254.5", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "No
-    error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.254.6", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/3.3", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
-    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime":
-    1619116288986.0, "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
+    "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.254.2", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "Ethernet1/3.2", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "peer": "169.254.254.6", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533, "pfxRx": 7,
+    "pfxTx": 3, "numChanges": 1, "estdTime": 1619110468986.0, "timestamp": 1619275258986,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": [],
+    "defOriginate": true, "keepaliveTime": 3, "updateSource": "169.254.254.5", "holdTime":
+    9, "updatesRx": 17, "updatesTx": 12, "peerRouterId": "10.0.0.200", "routerId":
+    "169.254.254.5", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP":
+    "169.254.254.6", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
+    "Ethernet1/3.3", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "peerHostname":
+    "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime": 1619116288986.0,
+    "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
     30, "updateSource": "169.254.127.1", "holdTime": 90, "updatesRx": 3, "updatesTx":
     12, "peerRouterId": "10.0.0.41", "routerId": "169.254.254.9", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "No
-    error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.127.0", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/4", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
-    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 3, "estdTime":
-    1619117522986.0, "timestamp": 1619275258986, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
-    3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx": 17, "updatesTx":
-    7, "peerRouterId": "10.0.0.200", "routerId": "169.254.254.9", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "session
-    cleared", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.254.10", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/3.4", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
+    "extnhEnabled": false, "peerAsndot": "0.65534", "peerIP": "169.254.127.0", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "Ethernet1/4", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "internet-vrf", "peer": "169.254.254.10", "peerHostname": "firewall01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533,
+    "pfxRx": 4, "pfxTx": 6, "numChanges": 3, "estdTime": 1619117522986.0, "timestamp":
+    1619275258986, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
+    [], "defOriginate": true, "keepaliveTime": 3, "updateSource": "169.254.254.9",
+    "holdTime": 9, "updatesRx": 17, "updatesTx": 7, "peerRouterId": "10.0.0.200",
+    "routerId": "169.254.254.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "session cleared",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false, "peerAsndot":
+    "0.65533", "peerIP": "169.254.254.10", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "Ethernet1/3.4", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
     "nxos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
     "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
     "peerAsn": 64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110439986.0,
@@ -2903,36 +2921,38 @@ tests:
     "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 60, "updateSource": "10.0.0.31", "holdTime": 180, "updatesRx":
     1141, "updatesTx": 27, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.31", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
-    "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
-    "loopback0", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname":
-    "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp":
-    1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
-    "10.0.0.21", "holdTime": 180, "updatesRx": 404, "updatesTx": 1199, "peerRouterId":
-    "10.0.0.13", "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.13", "mrai":
-    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname":
-    "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 10, "pfxTx": 42, "numChanges": 3, "estdTime": 1619110441180.0, "timestamp":
-    1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
-    "10.0.0.21", "holdTime": 180, "updatesRx": 39, "updatesTx": 1573, "peerRouterId":
-    "10.0.0.32", "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "session closed",
-    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerIP":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp": 1619275259180,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
+    "holdTime": 180, "updatesRx": 404, "updatesTx": 1199, "peerRouterId": "10.0.0.13",
+    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.13", "mrai": 0, "reason": "holdtimer expired error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer":
+    "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges":
+    3, "estdTime": 1619110441180.0, "timestamp": 1619275259180, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
+    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
+    180, "updatesRx": 39, "updatesTx": 1573, "peerRouterId": "10.0.0.32", "routerId":
+    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "session closed", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
     "10.0.0.32", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine01",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine01",
     "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established",
     "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 10,
     "pfxTx": 0, "numChanges": 3, "estdTime": 1619110441180.0, "timestamp": 1619275259180,
@@ -2942,23 +2962,24 @@ tests:
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
     "holdTime": 180, "updatesRx": 39, "updatesTx": 1573, "peerRouterId": "10.0.0.32",
     "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "session closed", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.32", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "spine01", "vrf":
-    "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
-    42, "numChanges": 3, "estdTime": 1619110440180.0, "timestamp": 1619275259180,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 39, "updatesTx": 1571, "peerRouterId": "10.0.0.31",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "session closed", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.31", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "session closed",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.32", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 3, "estdTime": 1619110440180.0,
+    "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    39, "updatesTx": 1571, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.21", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "session closed", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.31", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine01", "vrf":
     "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
     "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 10,
     "pfxTx": 0, "numChanges": 3, "estdTime": 1619110440180.0, "timestamp": 1619275259180,
@@ -2968,23 +2989,24 @@ tests:
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
     "holdTime": 180, "updatesRx": 39, "updatesTx": 1571, "peerRouterId": "10.0.0.31",
     "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "session closed", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.31", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "spine01", "vrf":
-    "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 3, "estdTime": 1619044325180.0, "timestamp": 1619275259180,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 403, "updatesTx": 1199, "peerRouterId": "10.0.0.14",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.14", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine01",
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "session closed",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.31", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044325180.0,
+    "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    403, "updatesTx": 1199, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.14", "mrai":
+    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "spine01",
     "vrf": "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established",
     "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
     "pfxTx": 0, "numChanges": 3, "estdTime": 1619044325180.0, "timestamp": 1619275259180,
@@ -2994,36 +3016,38 @@ tests:
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
     "holdTime": 180, "updatesRx": 403, "updatesTx": 1199, "peerRouterId": "10.0.0.14",
     "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.14", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname":
-    "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp":
-    1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
-    "10.0.0.21", "holdTime": 180, "updatesRx": 404, "updatesTx": 1199, "peerRouterId":
-    "10.0.0.13", "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.13", "mrai":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.14", "mrai": 0, "reason": "holdtimer expired error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer":
+    "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges":
+    3, "estdTime": 1619044327180.0, "timestamp": 1619275259180, "afisAdvOnly": [],
+    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
+    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
+    180, "updatesRx": 404, "updatesTx": 1199, "peerRouterId": "10.0.0.13", "routerId":
+    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.13", "mrai": 0, "reason": "holdtimer expired error", "lastDownTime": 0,
+    "ifname": "loopback0", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044326180.0,
+    "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
+    403, "updatesTx": 1194, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21",
+    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.12", "mrai":
     0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "spine01",
-    "vrf": "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    44, "numChanges": 3, "estdTime": 1619044326180.0, "timestamp": 1619275259180,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
-    "holdTime": 180, "updatesRx": 403, "updatesTx": 1194, "peerRouterId": "10.0.0.12",
-    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.12", "mrai": 0,
-    "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
-    "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "dcedge01",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "dcedge01",
     "vrf": "default", "peer": "169.254.127.1", "peerHostname": "exit01", "state":
     "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 65522,
     "pfxRx": 4, "pfxTx": 6, "numChanges": 0, "estdTime": 1619116284180.0, "timestamp":
@@ -3034,48 +3058,50 @@ tests:
     false, "keepaliveTime": 30, "updateSource": "169.254.127.0", "holdTime": 90, "updatesRx":
     12, "updatesTx": 2, "peerRouterId": "169.254.254.9", "routerId": "10.0.0.41",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.127.1", "mrai": 0, "reason": "None", "lastDownTime":
-    0, "ifname": "xe-0/0/0.0", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
-    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044327180.0,
-    "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "asndot": "0.65534", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.65522", "peerIP": "169.254.127.1",
+    "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/0.0", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "spine01",
+    "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    44, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp": 1619275259180,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
+    "holdTime": 180, "updatesRx": 403, "updatesTx": 1194, "peerRouterId": "10.0.0.11",
+    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.11", "mrai": 0, "reason": "holdtimer expired error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "l2vpn evpn", "active": true},
+    {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11",
+    "peerHostname": "leaf01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime":
+    1619044327180.0, "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
     403, "updatesTx": 1194, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.21",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.11", "mrai": 0, "reason": "holdtimer expired
-    error", "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn
-    evpn"}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
-    3, "estdTime": 1619044327180.0, "timestamp": 1619275259180, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
-    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime":
-    180, "updatesRx": 403, "updatesTx": 1194, "peerRouterId": "10.0.0.11", "routerId":
-    "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
-    true, "extnhEnabled": true, "peerIP": "10.0.0.11", "mrai": 0, "reason": "holdtimer
-    expired error", "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1619044329180.0, "timestamp": 1619275259180, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
-    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime":
-    180, "updatesRx": 1188, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
-    true, "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.11", "mrai":
+    0, "reason": "holdtimer expired error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime": 1619044329180.0, "timestamp":
+    1619275259180, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
+    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
+    "10.0.0.14", "holdTime": 180, "updatesRx": 1188, "updatesTx": 399, "peerRouterId":
+    "10.0.0.22", "routerId": "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason":
+    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
+    "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "l2vpn evpn", "active": true},
     {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22",
     "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
     "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
@@ -3086,90 +3112,66 @@ tests:
     true, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
     1188, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.14",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1619044325180.0, "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
-    1197, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.14",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1619044325180.0, "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime": 180, "updatesRx":
-    1197, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.14",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
-    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65534, "peerAsn": 65522, "pfxRx": 4, "pfxTx": 6, "numChanges": 0, "estdTime":
-    1619116288180.0, "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly":
-    ["ipv4 unicast"], "pfxBestRx": 4, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 30, "updateSource": "169.254.127.2", "holdTime":
-    90, "updatesRx": 9, "updatesTx": 2, "peerRouterId": "169.254.253.9", "routerId":
-    "10.0.0.41", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.127.3", "mrai": 0, "reason": "None",
-    "lastDownTime": 0, "ifname": "xe-0/0/1.0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12",
-    "peerHostname": "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime":
-    1619044326180.0, "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.21", "holdTime": 180, "updatesRx":
-    403, "updatesTx": 1194, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.12", "mrai": 0, "reason": "holdtimer expired
-    error", "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer":
-    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges":
-    1, "estdTime": 1619044328186.0, "timestamp": 1619275259186, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1619044325180.0, "timestamp": 1619275259180, "afisAdvOnly":
+    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
+    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
     "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
-    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime":
-    180, "updatesRx": 1189, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId":
-    "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "True", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
-    true, "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
-    1619044326186.0, "timestamp": 1619275259186, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.14", "holdTime":
+    180, "updatesRx": 1197, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "leaf04",
+    "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1619044325180.0, "timestamp": 1619275259180,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.14",
+    "holdTime": 180, "updatesRx": 1197, "updatesTx": 399, "peerRouterId": "10.0.0.21",
+    "routerId": "10.0.0.14", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534,
+    "peerAsn": 65522, "pfxRx": 4, "pfxTx": 6, "numChanges": 0, "estdTime": 1619116288180.0,
+    "timestamp": 1619275259180, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"],
+    "pfxBestRx": 4, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
-    true, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime": 180, "updatesRx":
-    1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.12",
-    "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "l2vpn evpn"},
-    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22",
-    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "169.254.127.2", "holdTime": 90, "updatesRx":
+    9, "updatesTx": 2, "peerRouterId": "169.254.253.9", "routerId": "10.0.0.41", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65534", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65522", "peerIP": "169.254.127.3", "mrai":
+    0, "reason": "None", "lastDownTime": 0, "ifname": "xe-0/0/1.0", "afiSafi": "ipv4
+    unicast", "active": true}, {"namespace": "nxos", "hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 3, "estdTime": 1619044326180.0, "timestamp": 1619275259180,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.21",
+    "holdTime": 180, "updatesRx": 403, "updatesTx": 1194, "peerRouterId": "10.0.0.12",
+    "routerId": "10.0.0.21", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.12", "mrai": 0, "reason": "holdtimer expired error",
+    "lastDownTime": 0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
     1619044328186.0, "timestamp": 1619275259186, "afisAdvOnly": [], "afisRcvOnly":
     [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
@@ -3177,36 +3179,64 @@ tests:
     true, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime": 180, "updatesRx":
     1189, "updatesTx": 399, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.12",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21",
-    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1619044326186.0, "timestamp": 1619275259186, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "leaf02", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1619044326186.0, "timestamp": 1619275259186, "afisAdvOnly":
+    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
+    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard", "extended"],
+    "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime":
+    180, "updatesRx": 1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1619044328186.0, "timestamp": 1619275259186,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.12",
+    "holdTime": 180, "updatesRx": 1189, "updatesTx": 399, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.12", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
+    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1619044326186.0,
+    "timestamp": 1619275259186, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 60, "updateSource": "10.0.0.12", "holdTime": 180, "updatesRx":
     1192, "updatesTx": 399, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.12",
     "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True",
-    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
-    "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error",
-    "lastDownTime": 0, "ifname": "loopback0", "active": true, "afiSafi": "ipv4 unicast"},
-    {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
-    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime":
-    1619116293384.0, "timestamp": 1619275259384, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
-    30, "updateSource": "169.254.127.3", "holdTime": 90, "updatesRx": 3, "updatesTx":
-    9, "peerRouterId": "10.0.0.41", "routerId": "169.254.253.9", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "No
-    error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.127.2", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/4", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname":
+    "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "internet-vrf", "peer": "169.254.127.2", "peerHostname": "dcedge01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65534,
+    "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime": 1619116293384.0, "timestamp":
+    1619275259384, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
+    [], "defOriginate": true, "keepaliveTime": 30, "updateSource": "169.254.127.3",
+    "holdTime": 90, "updatesRx": 3, "updatesTx": 9, "peerRouterId": "10.0.0.41", "routerId":
+    "169.254.253.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": false, "peerAsndot": "0.65534", "peerIP":
+    "169.254.127.2", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
+    "Ethernet1/4", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname":
     "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
     64520, "peerAsn": 65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime":
     1619110469384.0, "timestamp": 1619275259384, "afisAdvOnly": [], "afisRcvOnly":
@@ -3215,88 +3245,92 @@ tests:
     "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
     3, "updateSource": "169.254.253.5", "holdTime": 9, "updatesRx": 17, "updatesTx":
     20, "peerRouterId": "10.0.0.200", "routerId": "169.254.253.5", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "No
-    error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.253.6", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/3.3", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname":
-    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
-    64520, "peerAsn": 65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1619110459384.0, "timestamp": 1619275259384, "afisAdvOnly": [], "afisRcvOnly":
-    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
-    3, "updateSource": "169.254.253.1", "holdTime": 9, "updatesRx": 19, "updatesTx":
-    1, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus": "disabled",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason": "No
-    error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": false,
-    "peerIP": "169.254.253.2", "mrai": 0, "reason": "No error", "lastDownTime": 0,
-    "ifname": "Ethernet1/3.2", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "nxos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
-    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110444384.0,
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
+    "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.253.6", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "Ethernet1/3.3", "afiSafi":
+    "ipv4 unicast", "active": true}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "peer": "169.254.253.2", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533, "pfxRx": 10,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1619110459384.0, "timestamp": 1619275259384,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": [],
+    "defOriginate": true, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime":
+    9, "updatesRx": 19, "updatesTx": 1, "peerRouterId": "10.0.0.200", "routerId":
+    "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "True", "asndot": "0.64520", "notificnReason": "No error", "extnhAdvertised":
+    true, "extnhReceived": true, "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP":
+    "169.254.253.2", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
+    "Ethernet1/3.2", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110444384.0,
     "timestamp": 1619275259384, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
     0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
     "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime": 180, "updatesRx":
     1133, "updatesTx": 26, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.32", "bfdStatus":
-    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "No error", "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true,
-    "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime": 0, "ifname":
-    "loopback0", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname":
-    "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
-    "pfxRx": 0, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110444384.0, "timestamp":
-    1619275259384, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    ["standard", "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource":
-    "10.0.0.32", "holdTime": 180, "updatesRx": 1133, "updatesTx": 26, "peerRouterId":
-    "10.0.0.22", "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised":
-    true, "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.22", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 10, "numChanges": 1, "estdTime": 1619110444384.0, "timestamp": 1619275259384,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
+    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.32",
+    "holdTime": 180, "updatesRx": 1133, "updatesTx": 26, "peerRouterId": "10.0.0.22",
+    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
+    "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110441384.0,
+    "timestamp": 1619275259384, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 60, "updateSource": "10.0.0.32", "holdTime": 180, "updatesRx":
+    1142, "updatesTx": 26, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.32", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot":
+    "0.64520", "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived":
+    true, "extnhEnabled": true, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "nxos", "hostname": "exit02", "vrf":
     "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
-    10, "numChanges": 1, "estdTime": 1619110441384.0, "timestamp": 1619275259384,
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 10, "numChanges": 1, "estdTime": 1619110441384.0, "timestamp": 1619275259384,
     "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
     "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
     "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.32",
     "holdTime": 180, "updatesRx": 1142, "updatesTx": 26, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0,
-    "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "l2vpn evpn"}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
-    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
-    10, "numChanges": 1, "estdTime": 1619110441384.0, "timestamp": 1619275259384,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": ["standard",
-    "extended"], "defOriginate": true, "keepaliveTime": 60, "updateSource": "10.0.0.32",
-    "holdTime": 180, "updatesRx": 1142, "updatesTx": 26, "peerRouterId": "10.0.0.21",
-    "routerId": "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": true, "peerIP": "10.0.0.21", "mrai": 0,
-    "reason": "No error", "lastDownTime": 0, "ifname": "loopback0", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "nxos", "hostname": "exit02", "vrf":
-    "internet-vrf", "peer": "169.254.253.10", "peerHostname": "firewall01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533,
-    "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1619110472384.0, "timestamp":
-    1619275259384, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    [], "defOriginate": true, "keepaliveTime": 3, "updateSource": "169.254.253.9",
-    "holdTime": 9, "updatesRx": 15, "updatesTx": 4, "peerRouterId": "10.0.0.200",
-    "routerId": "169.254.253.9", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf":
-    false, "rrclient": "True", "notificnReason": "No error", "extnhAdvertised": true,
-    "extnhReceived": true, "extnhEnabled": false, "peerIP": "169.254.253.10", "mrai":
-    0, "reason": "No error", "lastDownTime": 0, "ifname": "Ethernet1/3.4", "active":
-    true, "afiSafi": "ipv4 unicast"}]'
+    false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "No error",
+    "extnhAdvertised": true, "extnhReceived": true, "extnhEnabled": true, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "No error", "lastDownTime":
+    0, "ifname": "loopback0", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "nxos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime":
+    1619110472384.0, "timestamp": 1619275259384, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": [], "defOriginate": true, "keepaliveTime":
+    3, "updateSource": "169.254.253.9", "holdTime": 9, "updatesRx": 15, "updatesTx":
+    4, "peerRouterId": "10.0.0.200", "routerId": "169.254.253.9", "bfdStatus": "disabled",
+    "nhUnchanged": false, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "No error", "extnhAdvertised": true, "extnhReceived": true,
+    "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.253.10", "mrai":
+    0, "reason": "No error", "lastDownTime": 0, "ifname": "Ethernet1/3.4", "afiSafi":
+    "ipv4 unicast", "active": true}]'
 - command: device show --columns='*' --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: device show nxos all

--- a/tests/integration/sqcmds/nxos-samples/bgp.yml
+++ b/tests/integration/sqcmds/nxos-samples/bgp.yml
@@ -564,3 +564,315 @@ tests:
     "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
     "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
     10, "numChanges": 1, "estdTime": 1619110441384.0, "timestamp": 1619275259384}]'
+- command: bgp show --columns='hostname vrf peer state peerAsndot' --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  marks: bgp show nxos filter
+  output: '[{"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state":
+    "Established", "peerAsndot": "0.65520"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth2.4", "state": "Established", "peerAsndot": "0.65522"}, {"hostname":
+    "firewall01", "vrf": "default", "peer": "eth2.3", "state": "Established", "peerAsndot":
+    "0.65521"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "state":
+    "Established", "peerAsndot": "0.65522"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth1.3", "state": "Established", "peerAsndot": "0.65521"}, {"hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.2", "state": "Established", "peerAsndot":
+    "0.65520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.11", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.13", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.32", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.14", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.14", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "peerAsndot": "0.64520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "169.254.254.2", "state": "Established", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf":
+    "internet-vrf", "peer": "169.254.127.0", "state": "Established", "peerAsndot":
+    "0.65534"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit01", "vrf":
+    "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.32", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.14", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "state": "Established",
+    "peerAsndot": "0.65522"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.11", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf04", "vrf":
+    "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
+    "state": "Established", "peerAsndot": "0.65522"}, {"hostname": "spine01", "vrf":
+    "default", "peer": "10.0.0.12", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "leaf02", "vrf":
+    "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer":
+    "169.254.127.2", "state": "Established", "peerAsndot": "0.65534"}, {"hostname":
+    "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "state": "Established",
+    "peerAsndot": "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "peerAsndot": "0.65533"}, {"hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.22", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state": "Established",
+    "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "state": "Established", "peerAsndot": "0.64520"}, {"hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.21", "state": "Established", "peerAsndot": "0.64520"},
+    {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "state":
+    "Established", "peerAsndot": "0.65533"}]'
+- command: bgp show --columns='hostname vrf peer state asndot' --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  marks: bgp show nxos filter
+  output: '[{"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state":
+    "Established", "asndot": "0.65533"}, {"hostname": "firewall01", "vrf": "default",
+    "peer": "eth2.4", "state": "Established", "asndot": "0.65533"}, {"hostname": "firewall01",
+    "vrf": "default", "peer": "eth2.3", "state": "Established", "asndot": "0.65533"},
+    {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "state": "Established",
+    "asndot": "0.65533"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.3",
+    "state": "Established", "asndot": "0.65533"}, {"hostname": "firewall01", "vrf":
+    "default", "peer": "eth1.2", "state": "Established", "asndot": "0.65533"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.13", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.13", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.14", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.31", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.14", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "default",
+    "peer": "169.254.254.2", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "state": "Established",
+    "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit01", "vrf": "internet-vrf",
+    "peer": "169.254.254.10", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.32", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.32", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.14", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.13", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
+    "state": "Established", "asndot": "0.65534"}, {"hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.11", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf04", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.21", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "dcedge01", "vrf": "default",
+    "peer": "169.254.127.3", "state": "Established", "asndot": "0.65534"}, {"hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "169.254.127.2", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "state": "Established",
+    "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.22", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.22", "state": "Established", "asndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asndot": "0.64520"}, {"hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.21", "state": "Established", "asndot": "0.64520"}, {"hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "state": "Established",
+    "asndot": "0.64520"}]'
+- command: bgp show --columns='hostname vrf peer state asn peerAsn asndot peerAsndot'
+    --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  marks: bgp show nxos filter
+  output: '[{"hostname": "firewall01", "vrf": "default", "peer": "eth2.2", "state":
+    "Established", "asn": 65533, "peerAsn": 65520, "asndot": "0.65533", "peerAsndot":
+    "0.65520"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "state":
+    "Established", "asn": 65533, "peerAsn": 65522, "asndot": "0.65533", "peerAsndot":
+    "0.65522"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "state":
+    "Established", "asn": 65533, "peerAsn": 65521, "asndot": "0.65533", "peerAsndot":
+    "0.65521"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.4", "state":
+    "Established", "asn": 65533, "peerAsn": 65522, "asndot": "0.65533", "peerAsndot":
+    "0.65522"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.3", "state":
+    "Established", "asn": 65533, "peerAsn": 65521, "asndot": "0.65533", "peerAsndot":
+    "0.65521"}, {"hostname": "firewall01", "vrf": "default", "peer": "eth1.2", "state":
+    "Established", "asn": 65533, "peerAsn": 65520, "asndot": "0.65533", "peerAsndot":
+    "0.65520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf03", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit01", "vrf": "default", "peer": "169.254.254.2",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "state": "Established", "asn": 64520, "peerAsn": 65534, "asndot": "0.64520", "peerAsndot":
+    "0.65534"}, {"hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
+    "state": "Established", "asn": 65534, "peerAsn": 65522, "asndot": "0.65534", "peerAsndot":
+    "0.65522"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
+    "state": "Established", "asn": 65534, "peerAsn": 65522, "asndot": "0.65534", "peerAsndot":
+    "0.65522"}, {"hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "state": "Established", "asn": 64520, "peerAsn": 65534, "asndot": "0.64520", "peerAsndot":
+    "0.65534"}, {"hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "169.254.253.2",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.22", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "state":
+    "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
+    "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
+    "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
+    "0.65533"}]'

--- a/tests/integration/sqcmds/nxos-samples/bgpunique.yml
+++ b/tests/integration/sqcmds/nxos-samples/bgpunique.yml
@@ -96,3 +96,19 @@ tests:
     "numRows": 5}, {"routerId": "10.0.0.32", "numRows": 5}, {"routerId": "10.0.0.200",
     "numRows": 6}, {"routerId": "10.0.0.21", "numRows": 12}, {"routerId": "10.0.0.22",
     "numRows": 12}]'
+- command: bgp unique --count=True --format=json --namespace=nxos --columns=peerAsndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique nxos
+  output: '[{"peerAsndot": "0.65520", "numRows": 2}, {"peerAsndot": "0.65521", "numRows":
+    2}, {"peerAsndot": "0.65534", "numRows": 2}, {"peerAsndot": "0.65522", "numRows":
+    4}, {"peerAsndot": "0.65533", "numRows": 6}, {"peerAsndot": "0.64520", "numRows":
+    48}]'
+- command: bgp unique --count=True --format=json --namespace=nxos --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique nxos
+  output: '[{"asndot": "0.65534", "numRows": 2}, {"asndot": "0.65533", "numRows":
+    6}, {"asndot": "0.64520", "numRows": 56}]'
+- command: bgp unique --format=json --namespace=nxos --columns=asndot
+  data-directory: tests/data/parquet/
+  marks: bgp unique nxos
+  output: '[{"asndot": "0.64520"}, {"asndot": "0.65533"}, {"asndot": "0.65534"}]'

--- a/tests/integration/sqcmds/panos-samples/all.yml
+++ b/tests/integration/sqcmds/panos-samples/all.yml
@@ -609,6 +609,133 @@ tests:
     "leaf01", "ifname": "swp3", "ipAddressList": [], "macaddr": "52:54:00:05:e0:cc",
     "ip6AddressList": [], "state": "up", "timestamp": 1639476254854, "vlan": 0, "type":
     "bond_slave", "vrf": "", "active": true, "ipAddress": []}]'
+- command: bgp show --columns='*' --format=json --namespace=vmx
+  data-directory: tests/data/parquet
+  marks: bgp show junos all vmx
+  output: '[{"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "vrf": "default",
+    "peer": "10.0.100.1", "peerHostname": "", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65100, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1630658723674.0, "timestamp": 1631009088674, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 6, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.100.0", "holdTime": 90, "updatesRx": 0, "updatesTx": 0, "peerRouterId":
+    "10.0.0.0", "routerId": "10.0.100.0", "bfdStatus": "down", "nhUnchanged": false,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65100", "notificnReason": "Hold
+    Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65000", "peerIP": "10.0.100.1", "mrai": 0, "reason": "Hold
+    Timer Expired Error", "lastDownTime": 0, "ifname": "ge-0/0/2.0", "afiSafi": "ipv4
+    unicast", "active": true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "VRF-A", "peer": "10.0.10.1", "peerHostname": "", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1,
+    "pfxTx": 2, "numChanges": 2, "estdTime": 1630658722674.0, "timestamp": 1631009088674,
+    "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.10.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.0",
+    "routerId": "10.0.0.3", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.10.1", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "peer":
+    "10.0.10.3", "peerHostname": "TOR4CRP-DGW-RT01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2, "pfxTx":
+    2, "numChanges": 3, "estdTime": 1630916580674.0, "timestamp": 1631009088674, "afisAdvOnly":
+    [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.10.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.4",
+    "routerId": "10.0.0.3", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.10.3", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "peer":
+    "10.0.20.1", "peerHostname": "", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1, "pfxTx": 2, "numChanges":
+    1, "estdTime": 1630658722674.0, "timestamp": 1631009088674, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.20.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.0",
+    "routerId": "10.0.0.3", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.20.1", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "peer":
+    "10.0.20.3", "peerHostname": "TOR4CRP-DGW-RT01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2, "pfxTx":
+    2, "numChanges": 3, "estdTime": 1630916572674.0, "timestamp": 1631009088674, "afisAdvOnly":
+    [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.20.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.4",
+    "routerId": "10.0.0.3", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.20.3", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "peer":
+    "10.0.10.1", "peerHostname": "", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1, "pfxTx": 2, "numChanges":
+    0, "estdTime": 1630916569873.0, "timestamp": 1631009088873, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.10.3", "holdTime": 90, "updatesRx": 0, "updatesTx": 2, "peerRouterId": "10.0.0.0",
+    "routerId": "10.0.0.4", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65000",
+    "peerIP": "10.0.10.1", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "peer": "10.0.10.2", "peerHostname": "TOR1CRP-DGW-RT01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 2, "pfxTx": 2, "numChanges": 0, "estdTime": 1630916579873.0, "timestamp":
+    1631009088873, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
+    1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.10.3", "holdTime": 90, "updatesRx":
+    0, "updatesTx": 2, "peerRouterId": "10.0.0.3", "routerId": "10.0.0.4", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65000",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65000", "peerIP": "10.0.10.2", "mrai": 0, "reason": "None",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "peer": "10.0.20.1", "peerHostname":
+    "", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 1, "pfxTx": 2, "numChanges": 0, "estdTime": 1630916569873.0, "timestamp":
+    1631009088873, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
+    1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.20.3", "holdTime": 90, "updatesRx":
+    0, "updatesTx": 2, "peerRouterId": "10.0.0.0", "routerId": "10.0.0.4", "bfdStatus":
+    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65000", "peerIP": "10.0.20.1", "mrai":
+    0, "reason": "None", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "peer": "10.0.20.2", "peerHostname": "TOR1CRP-DGW-RT01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2,
+    "pfxTx": 2, "numChanges": 0, "estdTime": 1630916571873.0, "timestamp": 1631009088873,
+    "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.20.3", "holdTime": 90, "updatesRx": 0, "updatesTx": 2, "peerRouterId": "10.0.0.3",
+    "routerId": "10.0.0.4", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65000",
+    "peerIP": "10.0.20.2", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}]'
 - command: sqPoller show --columns='*' --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: sqPoller show all panos

--- a/tests/integration/sqcmds/panos-samples/bgp.yml
+++ b/tests/integration/sqcmds/panos-samples/bgp.yml
@@ -177,23 +177,24 @@ tests:
     "", "ingressRmap": "", "softReconfig": true, "communityTypes": [], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "169.254.254.10", "holdTime": 9, "updatesRx":
     16, "updatesTx": 8, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.254.9", "mrai": -1, "reason": "HoldTimer expired (4)", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos",
-    "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.5", "peerHostname":
-    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
-    "peerAsn": 65521, "pfxRx": 3, "pfxTx": 1, "numChanges": 526, "estdTime": 1639476228000.0,
-    "timestamp": 1639476253357, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
-    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 5000, "pfxWarnPercent":
-    0, "hopsMax": 2, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": true, "communityTypes": [], "defOriginate": false, "keepaliveTime":
-    3, "updateSource": "169.254.254.6", "holdTime": 9, "updatesRx": 1734, "updatesTx":
-    528, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus": "down",
-    "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65522", "peerIP": "169.254.254.9", "mrai": -1, "reason":
+    "HoldTimer expired (4)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    "peer": "169.254.254.5", "peerHostname": "exit01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3, "pfxTx":
+    1, "numChanges": 526, "estdTime": 1639476228000.0, "timestamp": 1639476253357,
+    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 5000, "pfxWarnPercent": 0, "hopsMax": 2, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": [],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.6", "holdTime":
+    9, "updatesRx": 1734, "updatesTx": 528, "peerRouterId": "10.0.0.31", "routerId":
+    "10.0.0.200", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65521", "peerIP":
     "169.254.254.5", "mrai": -1, "reason": "HoldTimer expired (4)", "lastDownTime":
-    0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos",
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "panos",
     "hostname": "firewall01", "vrf": "default", "peer": "169.254.254.1", "peerHostname":
     "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
     "peerAsn": 65520, "pfxRx": 0, "pfxTx": 1, "numChanges": 6, "estdTime": 1639471291000.0,
@@ -203,23 +204,24 @@ tests:
     "softReconfig": true, "communityTypes": [], "defOriginate": false, "keepaliveTime":
     3, "updateSource": "169.254.254.2", "holdTime": 9, "updatesRx": 8, "updatesTx":
     8, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.200", "bfdStatus": "up", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.254.1",
-    "mrai": -1, "reason": "HoldTimer expired (4)", "lastDownTime": 0, "ifname": "",
-    "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos", "hostname":
-    "firewall01", "vrf": "default", "peer": "169.254.253.9", "peerHostname": "exit02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn":
-    65522, "pfxRx": 2, "pfxTx": 1, "numChanges": 6, "estdTime": 1639471291000.0, "timestamp":
-    1639476253357, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 5000, "pfxWarnPercent": 0, "hopsMax": 2, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes":
-    [], "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.10",
-    "holdTime": 9, "updatesRx": 16, "updatesTx": 8, "peerRouterId": "10.0.0.32", "routerId":
-    "10.0.0.200", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.9", "mrai": -1, "reason": "HoldTimer
-    expired (4)", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65520", "peerIP": "169.254.254.1", "mrai": -1, "reason": "HoldTimer expired
+    (4)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.9",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65533, "peerAsn": 65522, "pfxRx": 2, "pfxTx": 1, "numChanges": 6, "estdTime":
+    1639471291000.0, "timestamp": 1639476253357, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 5000,
+    "pfxWarnPercent": 0, "hopsMax": 2, "advertiseAllVnis": false, "egressRmap": "",
+    "ingressRmap": "", "softReconfig": true, "communityTypes": [], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.10", "holdTime": 9, "updatesRx":
+    16, "updatesTx": 8, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.200", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65522", "peerIP": "169.254.253.9", "mrai": -1, "reason":
+    "HoldTimer expired (4)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "panos", "hostname": "firewall01", "vrf": "default",
     "peer": "169.254.253.5", "peerHostname": "exit02", "state": "Established", "afi":
     "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3, "pfxTx":
     1, "numChanges": 525, "estdTime": 1639476228000.0, "timestamp": 1639476253357,
@@ -229,37 +231,39 @@ tests:
     "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.6", "holdTime":
     9, "updatesRx": 1727, "updatesTx": 526, "peerRouterId": "10.0.0.32", "routerId":
     "10.0.0.200", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.5", "mrai": -1, "reason": "Cease
-    (6) : peer unconfigured (3)", "lastDownTime": 0, "ifname": "", "active": true,
-    "afiSafi": "ipv4 unicast"}, {"namespace": "panos", "hostname": "firewall01", "vrf":
-    "default", "peer": "169.254.253.1", "peerHostname": "exit02", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0,
-    "pfxTx": 1, "numChanges": 6, "estdTime": 1639471291000.0, "timestamp": 1639476253357,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 5000, "pfxWarnPercent": 0, "hopsMax": 2, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": true, "communityTypes": [],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.2", "holdTime":
-    9, "updatesRx": 8, "updatesTx": 8, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.200",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.253.1", "mrai": -1, "reason": "HoldTimer expired (4)",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
-    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0,
-    "timestamp": 1639476253942, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "10.0.0.13", "holdTime": 9, "updatesRx":
-    91, "updatesTx": 8, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.13", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.22", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "leaf03", "vrf":
-    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 18, "pfxTx":
+    "False", "asndot": "0.65533", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65521", "peerIP":
+    "169.254.253.5", "mrai": -1, "reason": "Cease (6) : peer unconfigured (3)", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "panos",
+    "hostname": "firewall01", "vrf": "default", "peer": "169.254.253.1", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65520, "pfxRx": 0, "pfxTx": 1, "numChanges": 6, "estdTime": 1639471291000.0,
+    "timestamp": 1639476253357, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 5000, "pfxWarnPercent":
+    0, "hopsMax": 2, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": true, "communityTypes": [], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "169.254.253.2", "holdTime": 9, "updatesRx": 8, "updatesTx":
+    8, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.200", "bfdStatus": "up", "nhUnchanged":
+    false, "nhSelf": false, "rrclient": "False", "asndot": "0.65533", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65520", "peerIP": "169.254.253.1", "mrai": -1, "reason": "HoldTimer expired
+    (4)", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1639470259000.0, "timestamp": 1639476253942, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "10.0.0.13", "holdTime":
+    9, "updatesRx": 91, "updatesTx": 8, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.13",
+    "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False",
+    "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
+    false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22",
+    "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn",
+    "active": true}, {"namespace": "panos", "hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 18, "pfxTx":
     8, "numChanges": 1, "estdTime": 1639470261000.0, "timestamp": 1639476253942, "afisAdvOnly":
     [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
@@ -267,22 +271,23 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "10.0.0.13", "holdTime": 9, "updatesRx": 91, "updatesTx": 8, "peerRouterId": "10.0.0.21",
     "routerId": "10.0.0.13", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.21", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
-    "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
-    "timestamp": 1639476253943, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "10.0.0.22", "holdTime": 9, "updatesRx":
-    8, "updatesTx": 91, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.14", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "spine02",
+    "rrclient": "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "spine02",
+    "vrf": "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253943,
+    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "10.0.0.22", "holdTime": 9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.14",
+    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.14", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "spine02",
     "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
     34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253943,
@@ -292,22 +297,23 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "10.0.0.22", "holdTime": 9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.13",
     "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
-    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
-    "timestamp": 1639476253943, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "10.0.0.22", "holdTime": 9, "updatesRx":
-    8, "updatesTx": 91, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.12", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "spine02",
+    "rrclient": "True", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.13", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "spine02",
+    "vrf": "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253943,
+    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
+    "10.0.0.22", "holdTime": 9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.12",
+    "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
+    "rrclient": "True", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.12", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "spine02",
     "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
     34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253943,
@@ -317,23 +323,11 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "10.0.0.22", "holdTime": 9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.11",
     "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "panos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
-    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 1, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
-    "timestamp": 1639476253943, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "10.0.0.22", "holdTime": 9, "updatesRx":
-    32, "updatesTx": 91, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.22", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.31", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "spine02",
-    "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established",
+    "rrclient": "True", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520",
+    "peerIP": "10.0.0.11", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "",
+    "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "spine02",
+    "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 1, "pfxTx":
     34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253943,
     "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
@@ -341,36 +335,51 @@ tests:
     false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "10.0.0.22", "holdTime": 9, "updatesRx": 32, "updatesTx": 91, "peerRouterId":
-    "10.0.0.32", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.32", "mrai":
-    0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn
-    evpn"}, {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer":
-    "swp3.2", "peerHostname": "firewall01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65520, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 1, "numChanges":
-    1, "estdTime": 1639471291000.0, "timestamp": 1639476253943, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime":
-    9, "updatesRx": 2, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
-    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.2", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos",
-    "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
-    64520, "pfxRx": 33, "pfxTx": 1, "numChanges": 1, "estdTime": 1639470259000.0,
-    "timestamp": 1639476253943, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
+    "10.0.0.31", "routerId": "10.0.0.22", "bfdStatus": "up", "nhUnchanged": true,
+    "nhSelf": false, "rrclient": "True", "asndot": "0.64520", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.31", "mrai": 0, "reason": "", "lastDownTime": 0,
+    "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 1, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
+    "timestamp": 1639476253943, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
     "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "10.0.0.31", "holdTime": 9, "updatesRx":
-    91, "updatesTx": 32, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.31", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "exit01", "vrf":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.22", "holdTime": 9, "updatesRx":
+    32, "updatesTx": 91, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.22", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "exit01", "vrf": "default", "peer": "swp3.2", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65520, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 1, "numChanges": 1, "estdTime":
+    1639471291000.0, "timestamp": 1639476253943, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.1", "holdTime": 9, "updatesRx":
+    2, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.254.2", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 33, "pfxTx": 1, "numChanges": 1, "estdTime":
+    1639470259000.0, "timestamp": 1639476253943, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "10.0.0.31", "holdTime":
+    9, "updatesRx": 91, "updatesTx": 32, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.31", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "exit01", "vrf":
     "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 33, "pfxTx":
     1, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253943, "afisAdvOnly":
@@ -380,48 +389,50 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "10.0.0.31", "holdTime": 9, "updatesRx": 91, "updatesTx": 32, "peerRouterId":
     "10.0.0.22", "routerId": "10.0.0.31", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai":
-    0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn
-    evpn"}, {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf", "peer":
-    "swp3.4", "peerHostname": "firewall01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65522, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 3, "numChanges":
-    1, "estdTime": 1639471291000.0, "timestamp": 1639476253943, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime":
-    9, "updatesRx": 2, "updatesTx": 4, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "", "lastDownTime": 0,
+    "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp3.4", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65522, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 3, "numChanges": 1, "estdTime":
+    1639471291000.0, "timestamp": 1639476253943, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.9", "holdTime": 9, "updatesRx":
+    2, "updatesTx": 4, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
     "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.254.10", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos",
-    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp4", "peerHostname": "dcedge01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn":
-    65534, "pfxRx": 2, "pfxTx": 3, "numChanges": 1, "estdTime": 1639470240000.0, "timestamp":
-    1639476253943, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.127.1", "holdTime": 9, "updatesRx": 4, "updatesTx": 4, "peerRouterId":
-    "10.0.0.41", "routerId": "10.0.0.31", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.0",
-    "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "panos", "hostname": "exit01", "vrf": "evpn-vrf",
-    "peer": "swp3.3", "peerHostname": "firewall01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 65521, "peerAsn": 65533, "pfxRx": 1, "pfxTx":
-    4, "numChanges": 61, "estdTime": 1639476228000.0, "timestamp": 1639476253943,
-    "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.254.5", "holdTime": 9, "updatesRx": 62, "updatesTx": 124, "peerRouterId":
-    "10.0.0.200", "routerId": "10.0.0.31", "bfdStatus": "disabled", "nhUnchanged":
-    false, "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.254.6",
-    "mrai": 0, "reason": "NSF peer closed the session", "lastDownTime": 40000, "ifname":
-    "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos", "hostname":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.254.10", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp4",
+    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65522, "peerAsn": 65534, "pfxRx": 2, "pfxTx": 3, "numChanges": 1, "estdTime":
+    1639470240000.0, "timestamp": 1639476253943, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.127.1", "holdTime": 9, "updatesRx":
+    4, "updatesTx": 4, "peerRouterId": "10.0.0.41", "routerId": "10.0.0.31", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65534", "peerIP": "169.254.127.0", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "swp3.3",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65521, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 4, "numChanges": 61, "estdTime":
+    1639476228000.0, "timestamp": 1639476253943, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.254.5", "holdTime": 9, "updatesRx":
+    62, "updatesTx": 124, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.31", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65521", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.254.6", "mrai":
+    0, "reason": "NSF peer closed the session", "lastDownTime": 40000, "ifname": "",
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "panos", "hostname":
     "exit02", "vrf": "internet-vrf", "peer": "swp4", "peerHostname": "dcedge01", "state":
     "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn": 65534,
     "pfxRx": 2, "pfxTx": 3, "numChanges": 1, "estdTime": 1639470240000.0, "timestamp":
@@ -431,72 +442,75 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "169.254.127.3", "holdTime": 9, "updatesRx": 4, "updatesTx": 4, "peerRouterId":
     "10.0.0.41", "routerId": "10.0.0.32", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.127.2",
-    "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "panos", "hostname": "dcedge01", "vrf": "default",
-    "peer": "169.254.127.3", "peerHostname": "exit02", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 65522, "pfxRx": 1, "pfxTx":
-    2, "numChanges": 1, "estdTime": 1639470240000.0, "timestamp": 1639476253948, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": true, "keepaliveTime": 3, "updateSource": "169.254.127.2", "holdTime":
-    9, "updatesRx": 4, "updatesTx": 4, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.41",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65522", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.65534", "peerIP": "169.254.127.2", "mrai": 0, "reason": "", "lastDownTime":
+    0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "panos",
+    "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534,
+    "peerAsn": 65522, "pfxRx": 1, "pfxTx": 2, "numChanges": 1, "estdTime": 1639470240000.0,
+    "timestamp": 1639476253948, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    true, "keepaliveTime": 3, "updateSource": "169.254.127.2", "holdTime": 9, "updatesRx":
+    4, "updatesTx": 4, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.41", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65534",
     "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.127.3", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos",
-    "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
-    "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    false, "peerAsndot": "0.65522", "peerIP": "169.254.127.3", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 1, "pfxTx": 34, "numChanges": 1, "estdTime":
+    1639470259000.0, "timestamp": 1639476253948, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime": 9, "updatesRx":
+    32, "updatesTx": 91, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.21", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.32", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
+    "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
     "peerAsn": 64520, "pfxRx": 1, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
     "timestamp": 1639476253948, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
     "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime": 9, "updatesRx":
-    32, "updatesTx": 91, "peerRouterId": "10.0.0.32", "routerId": "10.0.0.21", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.32", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 1, "pfxTx":
-    34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253948,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "10.0.0.21", "holdTime": 9, "updatesRx": 32, "updatesTx": 91, "peerRouterId":
-    "10.0.0.31", "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "True", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.31", "mrai":
-    0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn
-    evpn"}, {"namespace": "panos", "hostname": "spine01", "vrf": "default", "peer":
-    "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges":
-    1, "estdTime": 1639470254000.0, "timestamp": 1639476253948, "afisAdvOnly": ["ipv4Unicast"],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime":
-    9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21",
-    "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.14", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    34, "numChanges": 1, "estdTime": 1639470261000.0, "timestamp": 1639476253948,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "10.0.0.21", "holdTime": 9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.13",
-    "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.13", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
+    32, "updatesTx": 91, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.21", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.31", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14", "peerHostname":
+    "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470254000.0,
+    "timestamp": 1639476253948, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime": 9, "updatesRx":
+    8, "updatesTx": 91, "peerRouterId": "10.0.0.14", "routerId": "10.0.0.21", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.14", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname":
+    "leaf03", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470261000.0,
+    "timestamp": 1639476253948, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime": 9, "updatesRx":
+    8, "updatesTx": 91, "peerRouterId": "10.0.0.13", "routerId": "10.0.0.21", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.13", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
     "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
     "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
     "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
@@ -506,22 +520,23 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime": 9, "updatesRx":
     8, "updatesTx": 91, "peerRouterId": "10.0.0.12", "routerId": "10.0.0.21", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.12", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "spine01",
-    "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
-    34, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253948,
-    "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "10.0.0.21", "holdTime": 9, "updatesRx": 8, "updatesTx": 91, "peerRouterId": "10.0.0.11",
-    "routerId": "10.0.0.21", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "True", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.11", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.12", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname":
+    "leaf01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 34, "numChanges": 1, "estdTime": 1639470259000.0,
+    "timestamp": 1639476253948, "afisAdvOnly": ["ipv4Unicast"], "afisRcvOnly": [],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.21", "holdTime": 9, "updatesRx":
+    8, "updatesTx": 91, "peerRouterId": "10.0.0.11", "routerId": "10.0.0.21", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "True", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.11", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
     "panos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "peerHostname":
     "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534,
     "peerAsn": 65522, "pfxRx": 1, "pfxTx": 2, "numChanges": 1, "estdTime": 1639470240000.0,
@@ -531,48 +546,50 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     true, "keepaliveTime": 3, "updateSource": "169.254.127.0", "holdTime": 9, "updatesRx":
     4, "updatesTx": 4, "peerRouterId": "10.0.0.31", "routerId": "10.0.0.41", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "169.254.127.1", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos", "hostname": "exit02",
-    "vrf": "internet-vrf", "peer": "swp3.4", "peerHostname": "firewall01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn": 65533,
-    "pfxRx": 1, "pfxTx": 3, "numChanges": 1, "estdTime": 1639471291000.0, "timestamp":
-    1639476253948, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "169.254.253.9", "holdTime": 9, "updatesRx": 2, "updatesTx": 4, "peerRouterId":
-    "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus": "up", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "169.254.253.10",
-    "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
-    "peer": "swp3.2", "peerHostname": "firewall01", "state": "Established", "afi":
-    "ipv4", "safi": "unicast", "asn": 65520, "peerAsn": 65533, "pfxRx": 1, "pfxTx":
-    1, "numChanges": 1, "estdTime": 1639471291000.0, "timestamp": 1639476253948, "afisAdvOnly":
-    [], "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0,
-    "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime":
-    9, "updatesRx": 2, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65534",
     "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "169.254.253.2", "mrai": 0, "reason": "", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "panos",
-    "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
-    64520, "pfxRx": 33, "pfxTx": 1, "numChanges": 1, "estdTime": 1639470259000.0,
-    "timestamp": 1639476253948, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
-    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
-    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    false, "peerAsndot": "0.65522", "peerIP": "169.254.127.1", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp3.4",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65522, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 3, "numChanges": 1, "estdTime":
+    1639471291000.0, "timestamp": 1639476253948, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 3, "updateSource": "10.0.0.32", "holdTime": 9, "updatesRx":
-    91, "updatesTx": 32, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.32", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "exit02", "vrf":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.9", "holdTime": 9, "updatesRx":
+    2, "updatesTx": 4, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65522",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.253.10", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "peer": "swp3.2",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65520, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 1, "numChanges": 1, "estdTime":
+    1639471291000.0, "timestamp": 1639476253948, "afisAdvOnly": [], "afisRcvOnly":
+    [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.1", "holdTime": 9, "updatesRx":
+    2, "updatesTx": 2, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65533", "peerIP": "169.254.253.2", "mrai": 0, "reason":
+    "", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true},
+    {"namespace": "panos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 33, "pfxTx": 1, "numChanges": 1, "estdTime":
+    1639470259000.0, "timestamp": 1639476253948, "afisAdvOnly": [], "afisRcvOnly":
+    ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
+    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap":
+    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
+    "defOriginate": false, "keepaliveTime": 3, "updateSource": "10.0.0.32", "holdTime":
+    9, "updatesRx": 91, "updatesTx": 32, "peerRouterId": "10.0.0.21", "routerId":
+    "10.0.0.32", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false, "rrclient":
+    "False", "asndot": "0.64520", "notificnReason": "", "extnhAdvertised": false,
+    "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.64520", "peerIP":
+    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "afiSafi":
+    "l2vpn evpn", "active": true}, {"namespace": "panos", "hostname": "exit02", "vrf":
     "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
     "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 33, "pfxTx":
     1, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253948, "afisAdvOnly":
@@ -582,60 +599,63 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
     "10.0.0.32", "holdTime": 9, "updatesRx": 91, "updatesTx": 32, "peerRouterId":
     "10.0.0.22", "routerId": "10.0.0.32", "bfdStatus": "up", "nhUnchanged": true,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai":
-    0, "reason": "", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn
-    evpn"}, {"namespace": "panos", "hostname": "exit02", "vrf": "evpn-vrf", "peer":
-    "swp3.3", "peerHostname": "firewall01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65521, "peerAsn": 65533, "pfxRx": 1, "pfxTx": 4, "numChanges":
-    61, "estdTime": 1639476228000.0, "timestamp": 1639476253948, "afisAdvOnly": [],
-    "afisRcvOnly": [], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime":
-    9, "updatesRx": 62, "updatesTx": 124, "peerRouterId": "10.0.0.200", "routerId":
-    "10.0.0.32", "bfdStatus": "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient":
-    "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "169.254.253.6", "mrai": 0, "reason": "NSF peer
-    closed the session", "lastDownTime": 40000, "ifname": "", "active": true, "afiSafi":
-    "ipv4 unicast"}, {"namespace": "panos", "hostname": "leaf02", "vrf": "default",
-    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
-    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 18, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253949, "afisAdvOnly":
-    [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "10.0.0.12", "holdTime": 9, "updatesRx": 91, "updatesTx": 8, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
-    "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason": "",
+    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "", "lastDownTime": 0,
+    "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos",
+    "hostname": "exit02", "vrf": "evpn-vrf", "peer": "swp3.3", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65521, "peerAsn":
+    65533, "pfxRx": 1, "pfxTx": 4, "numChanges": 61, "estdTime": 1639476228000.0,
+    "timestamp": 1639476253948, "afisAdvOnly": [], "afisRcvOnly": [], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "169.254.253.5", "holdTime": 9, "updatesRx":
+    62, "updatesTx": 124, "peerRouterId": "10.0.0.200", "routerId": "10.0.0.32", "bfdStatus":
+    "disabled", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65521", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65533", "peerIP": "169.254.253.6", "mrai":
+    0, "reason": "NSF peer closed the session", "lastDownTime": 40000, "ifname": "",
+    "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "panos", "hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp":
+    1639476253949, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx":
+    0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "", "softReconfig":
+    false, "communityTypes": ["standard", "extended"], "defOriginate": false, "keepaliveTime":
+    3, "updateSource": "10.0.0.12", "holdTime": 9, "updatesRx": 91, "updatesTx": 8,
+    "peerRouterId": "10.0.0.22", "routerId": "10.0.0.12", "bfdStatus": "up", "nhUnchanged":
+    true, "nhSelf": false, "rrclient": "False", "asndot": "0.64520", "notificnReason":
+    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot":
+    "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "", "lastDownTime": 0,
+    "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace": "panos",
+    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0,
     "timestamp": 1639476253949, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
     "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
     0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "10.0.0.12", "holdTime": 9, "updatesRx":
     91, "updatesTx": 8, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.12", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "leaf01", "vrf":
-    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 18, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253949, "afisAdvOnly":
-    [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "10.0.0.11", "holdTime": 9, "updatesRx": 91, "updatesTx": 8, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.11", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
+    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0,
+    "timestamp": 1639476253949, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.11", "holdTime": 9, "updatesRx":
+    91, "updatesTx": 8, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.11", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
     "panos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
     "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
     "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0,
@@ -645,22 +665,23 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "10.0.0.11", "holdTime": 9, "updatesRx":
     91, "updatesTx": 8, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.11", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}, {"namespace": "panos", "hostname": "leaf04", "vrf":
-    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 18, "pfxTx":
-    8, "numChanges": 1, "estdTime": 1639470259000.0, "timestamp": 1639476253949, "afisAdvOnly":
-    [], "afisRcvOnly": ["ipv4Unicast"], "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx":
-    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": true,
-    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
-    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 3, "updateSource":
-    "10.0.0.14", "holdTime": 9, "updatesRx": 91, "updatesTx": 8, "peerRouterId": "10.0.0.22",
-    "routerId": "10.0.0.14", "bfdStatus": "up", "nhUnchanged": true, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.0.22", "mrai": 0, "reason": "",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "l2vpn evpn"}, {"namespace":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
+    "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22", "peerHostname":
+    "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470259000.0,
+    "timestamp": 1639476253949, "afisAdvOnly": [], "afisRcvOnly": ["ipv4Unicast"],
+    "pfxBestRx": 0, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent":
+    0, "hopsMax": 0, "advertiseAllVnis": true, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 3, "updateSource": "10.0.0.14", "holdTime": 9, "updatesRx":
+    91, "updatesTx": 8, "peerRouterId": "10.0.0.22", "routerId": "10.0.0.14", "bfdStatus":
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.22", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}, {"namespace":
     "panos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
     "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
     "peerAsn": 64520, "pfxRx": 18, "pfxTx": 8, "numChanges": 1, "estdTime": 1639470254000.0,
@@ -670,10 +691,10 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 3, "updateSource": "10.0.0.14", "holdTime": 9, "updatesRx":
     91, "updatesTx": 8, "peerRouterId": "10.0.0.21", "routerId": "10.0.0.14", "bfdStatus":
-    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.0.21", "mrai": 0, "reason": "", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "l2vpn evpn"}]'
+    "up", "nhUnchanged": true, "nhSelf": false, "rrclient": "False", "asndot": "0.64520",
+    "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.64520", "peerIP": "10.0.0.21", "mrai": 0, "reason": "",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "l2vpn evpn", "active": true}]'
 - command: bgp summarize --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: bgp summarize panos

--- a/tests/integration/sqcmds/vmx-samples/all.yml
+++ b/tests/integration/sqcmds/vmx-samples/all.yml
@@ -894,66 +894,69 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.100.0", "holdTime": 90, "updatesRx": 0, "updatesTx": 0, "peerRouterId":
     "10.0.0.0", "routerId": "10.0.100.0", "bfdStatus": "down", "nhUnchanged": false,
-    "nhSelf": false, "rrclient": "False", "notificnReason": "Hold Timer Expired Error",
-    "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.100.1", "mrai": 0, "reason": "Hold Timer Expired Error", "lastDownTime":
-    0, "ifname": "ge-0/0/2.0", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "peer": "10.0.10.1", "peerHostname":
-    "", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 1, "pfxTx": 2, "numChanges": 2, "estdTime": 1630658722674.0, "timestamp":
-    1631009088674, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
-    1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.10.2", "holdTime": 90, "updatesRx":
-    0, "updatesTx": 1, "peerRouterId": "10.0.0.0", "routerId": "10.0.0.3", "bfdStatus":
-    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.10.1", "mrai": 0, "reason": "Hold Timer
-    Expired Error", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A",
-    "peer": "10.0.10.3", "peerHostname": "TOR4CRP-DGW-RT01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2,
-    "pfxTx": 2, "numChanges": 3, "estdTime": 1630916580674.0, "timestamp": 1631009088674,
+    "nhSelf": false, "rrclient": "False", "asndot": "0.65100", "notificnReason": "Hold
+    Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
+    false, "peerAsndot": "0.65000", "peerIP": "10.0.100.1", "mrai": 0, "reason": "Hold
+    Timer Expired Error", "lastDownTime": 0, "ifname": "ge-0/0/2.0", "afiSafi": "ipv4
+    unicast", "active": true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "VRF-A", "peer": "10.0.10.1", "peerHostname": "", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1,
+    "pfxTx": 2, "numChanges": 2, "estdTime": 1630658722674.0, "timestamp": 1631009088674,
     "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx":
     0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
     false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.10.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.0",
+    "routerId": "10.0.0.3", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.10.1", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-A", "peer":
+    "10.0.10.3", "peerHostname": "TOR4CRP-DGW-RT01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2, "pfxTx":
+    2, "numChanges": 3, "estdTime": 1630916580674.0, "timestamp": 1631009088674, "afisAdvOnly":
+    [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.10.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.4",
     "routerId": "10.0.0.3", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.10.3", "mrai":
-    0, "reason": "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
-    "vrf": "VRF-B", "peer": "10.0.20.1", "peerHostname": "", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1,
-    "pfxTx": 2, "numChanges": 1, "estdTime": 1630658722674.0, "timestamp": 1631009088674,
-    "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx":
-    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
-    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.10.3", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "peer":
+    "10.0.20.1", "peerHostname": "", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1, "pfxTx": 2, "numChanges":
+    1, "estdTime": 1630658722674.0, "timestamp": 1631009088674, "afisAdvOnly": [],
+    "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.20.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.0",
     "routerId": "10.0.0.3", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "Hold Timer Expired Error", "extnhAdvertised":
-    false, "extnhReceived": false, "extnhEnabled": false, "peerIP": "10.0.20.1", "mrai":
-    0, "reason": "Hold Timer Expired Error", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
-    "vrf": "VRF-B", "peer": "10.0.20.3", "peerHostname": "TOR4CRP-DGW-RT01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 2, "pfxTx": 2, "numChanges": 3, "estdTime": 1630916572674.0, "timestamp":
-    1631009088674, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
-    1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.20.2", "holdTime": 90, "updatesRx":
-    0, "updatesTx": 1, "peerRouterId": "10.0.0.4", "routerId": "10.0.0.3", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "Hold Timer Expired Error", "extnhAdvertised": false, "extnhReceived": false,
-    "extnhEnabled": false, "peerIP": "10.0.20.3", "mrai": 0, "reason": "Hold Timer
-    Expired Error", "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4
-    unicast"}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A",
-    "peer": "10.0.10.1", "peerHostname": "", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1, "pfxTx": 2, "numChanges":
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.20.1", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "VRF-B", "peer":
+    "10.0.20.3", "peerHostname": "TOR4CRP-DGW-RT01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2, "pfxTx":
+    2, "numChanges": 3, "estdTime": 1630916572674.0, "timestamp": 1631009088674, "afisAdvOnly":
+    [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
+    0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
+    "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.20.2", "holdTime": 90, "updatesRx": 0, "updatesTx": 1, "peerRouterId": "10.0.0.4",
+    "routerId": "10.0.0.3", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "Hold Timer Expired
+    Error", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false,
+    "peerAsndot": "0.65000", "peerIP": "10.0.20.3", "mrai": 0, "reason": "Hold Timer
+    Expired Error", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active":
+    true}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "peer":
+    "10.0.10.1", "peerHostname": "", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 1, "pfxTx": 2, "numChanges":
     0, "estdTime": 1630916569873.0, "timestamp": 1631009088873, "afisAdvOnly": [],
     "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx":
     0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false,
@@ -961,23 +964,24 @@ tests:
     ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
     "10.0.10.3", "holdTime": 90, "updatesRx": 0, "updatesTx": 2, "peerRouterId": "10.0.0.0",
     "routerId": "10.0.0.4", "bfdStatus": "down", "nhUnchanged": false, "nhSelf": false,
-    "rrclient": "False", "notificnReason": "", "extnhAdvertised": false, "extnhReceived":
-    false, "extnhEnabled": false, "peerIP": "10.0.10.1", "mrai": 0, "reason": "None",
-    "lastDownTime": 0, "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace":
-    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "peer": "10.0.10.2", "peerHostname":
-    "TOR1CRP-DGW-RT01", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65000, "peerAsn": 65000, "pfxRx": 2, "pfxTx": 2, "numChanges": 0, "estdTime":
-    1630916579873.0, "timestamp": 1631009088873, "afisAdvOnly": [], "afisRcvOnly":
-    ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx":
-    0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis": false, "egressRmap":
-    "", "ingressRmap": "", "softReconfig": false, "communityTypes": ["standard", "extended"],
-    "defOriginate": false, "keepaliveTime": 30, "updateSource": "10.0.10.3", "holdTime":
-    90, "updatesRx": 0, "updatesTx": 2, "peerRouterId": "10.0.0.3", "routerId": "10.0.0.4",
-    "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False",
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65000",
+    "peerIP": "10.0.10.1", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "vrf": "VRF-A", "peer": "10.0.10.2", "peerHostname": "TOR1CRP-DGW-RT01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 2, "pfxTx": 2, "numChanges": 0, "estdTime": 1630916579873.0, "timestamp":
+    1631009088873, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
+    1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
+    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
+    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
+    false, "keepaliveTime": 30, "updateSource": "10.0.10.3", "holdTime": 90, "updatesRx":
+    0, "updatesTx": 2, "peerRouterId": "10.0.0.3", "routerId": "10.0.0.4", "bfdStatus":
+    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot": "0.65000",
     "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled":
-    false, "peerIP": "10.0.10.2", "mrai": 0, "reason": "None", "lastDownTime": 0,
-    "ifname": "", "active": true, "afiSafi": "ipv4 unicast"}, {"namespace": "vmx",
-    "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "peer": "10.0.20.1", "peerHostname":
+    false, "peerAsndot": "0.65000", "peerIP": "10.0.10.2", "mrai": 0, "reason": "None",
+    "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast", "active": true}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B", "peer": "10.0.20.1", "peerHostname":
     "", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
     65000, "pfxRx": 1, "pfxTx": 2, "numChanges": 0, "estdTime": 1630916569873.0, "timestamp":
     1631009088873, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
@@ -986,23 +990,24 @@ tests:
     "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
     false, "keepaliveTime": 30, "updateSource": "10.0.20.3", "holdTime": 90, "updatesRx":
     0, "updatesTx": 2, "peerRouterId": "10.0.0.0", "routerId": "10.0.0.4", "bfdStatus":
-    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.20.1", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
-    "vrf": "VRF-B", "peer": "10.0.20.2", "peerHostname": "TOR1CRP-DGW-RT01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000,
-    "pfxRx": 2, "pfxTx": 2, "numChanges": 0, "estdTime": 1630916571873.0, "timestamp":
-    1631009088873, "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx":
-    1, "pfxWithdrawnRx": 0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0,
-    "hopsMax": 0, "advertiseAllVnis": false, "egressRmap": "", "ingressRmap": "",
-    "softReconfig": false, "communityTypes": ["standard", "extended"], "defOriginate":
-    false, "keepaliveTime": 30, "updateSource": "10.0.20.3", "holdTime": 90, "updatesRx":
-    0, "updatesTx": 2, "peerRouterId": "10.0.0.3", "routerId": "10.0.0.4", "bfdStatus":
-    "up", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "notificnReason":
-    "", "extnhAdvertised": false, "extnhReceived": false, "extnhEnabled": false, "peerIP":
-    "10.0.20.2", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname": "", "active":
-    true, "afiSafi": "ipv4 unicast"}]'
+    "down", "nhUnchanged": false, "nhSelf": false, "rrclient": "False", "asndot":
+    "0.65000", "notificnReason": "", "extnhAdvertised": false, "extnhReceived": false,
+    "extnhEnabled": false, "peerAsndot": "0.65000", "peerIP": "10.0.20.1", "mrai":
+    0, "reason": "None", "lastDownTime": 0, "ifname": "", "afiSafi": "ipv4 unicast",
+    "active": true}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "vrf": "VRF-B",
+    "peer": "10.0.20.2", "peerHostname": "TOR1CRP-DGW-RT01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 2,
+    "pfxTx": 2, "numChanges": 0, "estdTime": 1630916571873.0, "timestamp": 1631009088873,
+    "afisAdvOnly": [], "afisRcvOnly": ["ipv4 unicast"], "pfxBestRx": 1, "pfxWithdrawnRx":
+    0, "pfxSuppressRx": 0, "pfxMaxRx": 0, "pfxWarnPercent": 0, "hopsMax": 0, "advertiseAllVnis":
+    false, "egressRmap": "", "ingressRmap": "", "softReconfig": false, "communityTypes":
+    ["standard", "extended"], "defOriginate": false, "keepaliveTime": 30, "updateSource":
+    "10.0.20.3", "holdTime": 90, "updatesRx": 0, "updatesTx": 2, "peerRouterId": "10.0.0.3",
+    "routerId": "10.0.0.4", "bfdStatus": "up", "nhUnchanged": false, "nhSelf": false,
+    "rrclient": "False", "asndot": "0.65000", "notificnReason": "", "extnhAdvertised":
+    false, "extnhReceived": false, "extnhEnabled": false, "peerAsndot": "0.65000",
+    "peerIP": "10.0.20.2", "mrai": 0, "reason": "None", "lastDownTime": 0, "ifname":
+    "", "afiSafi": "ipv4 unicast", "active": true}]'
 - command: device show --columns='*' --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: device show junos all vmx


### PR DESCRIPTION
This adds support for 4B ASN parsing in case the NOS reports the ASN in asndot format, and for displaying the ASN in asndot format.