### PR TITLE
Add hysteresis for marking record as inactive

### DIFF
--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -25,7 +25,7 @@ from suzieq.version import SUZIEQ_VERSION
 # How long b4 declaring node dead
 HOLD_TIME_IN_MSECS = 60000
 # How many unsuccessful polls before marking records with active=false
-HYSTERESIS_FAILURE_CNT = 2
+HYSTERESIS_FAILURE_CNT = 3
 
 
 @dataclass

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -602,7 +602,7 @@ class Service(SqPlugin):
         """Write the result data out"""
         # pylint: disable=protected-access
         records = []
-        key = f'{namespace}-{hostname}'
+        key = f'{namespace}.{hostname}'
         prev_res = self.previous_results.get(key, None)
         # No data previously polled with this service from the the
         # current namespace and hostname. Check if the datastore contains some
@@ -758,30 +758,25 @@ class Service(SqPlugin):
             if output:
                 ostatus = [x.get('status', -1) for x in output]
 
-                hostname = output[0]["hostname"]
-                namespace = output[0]["namespace"]
-                key = f'{namespace}-{hostname}'
-
                 should_commit = True
 
                 # we should always commit during the first run of the service
                 # for each node regardless their status.
-                if not self.is_first_run(key):
+                if not self.is_first_run(token.nodename):
                     # If it's not the first run and some command did fail,
                     # increment the count to be used in hysteresis.
                     # The info will be committed in a future run.
                     if any((not Service.is_status_ok(x) for x in ostatus)):
-                        self._consecutive_failures[key] = \
-                            self._consecutive_failures[key] + 1
+                        self._consecutive_failures[token.nodename] += 1
                     # otherwise reset the counter.
                     else:
-                        self._consecutive_failures[key] = 0
+                        self._consecutive_failures[token.nodename] = 0
 
-                if 0 < self._consecutive_failures[key] < \
+                if 0 < self._consecutive_failures[token.nodename] < \
                         HYSTERESIS_FAILURE_CNT:
                     self.logger.info(
-                        f"{self.name} {key} node failure hysteresis,"
-                        "skipping data commit")
+                        f"{self.name} {token.nodename} node failure hysteresis"
+                        ", skipping data commit")
                     should_commit = False
 
                 # pylint: disable=use-a-generator
@@ -845,7 +840,7 @@ class Service(SqPlugin):
 
                 if should_commit:
                     await self.commit_data(result, output[0]["namespace"],
-                                           hostname)
+                                           output[0]["hostname"])
             elif self.run_once in ["gather", "process", "update"]:
                 total_nodes -= 1
                 if total_nodes <= 0:
@@ -857,14 +852,13 @@ class Service(SqPlugin):
             total_time = int(time.time()*1000) - token.start_time
 
             if output:
-                statskey = output[0]["namespace"] + '/' + output[0]["hostname"]
 
-                stats = pernode_stats[statskey]
+                stats = pernode_stats[token.nodename]
                 write_poller_stat = (self.update_stats(
                     stats, total_time, gather_time, qsize,
                     self.writer_queue.qsize(), token.nodeQsize, rxBytes) or
                     write_poller_stat)
-                pernode_stats[statskey] = stats
+                pernode_stats[token.nodename] = stats
                 if write_poller_stat:
                     poller_stat = [
                         {"hostname": (output[0]["hostname"] or
@@ -894,7 +888,7 @@ class Service(SqPlugin):
                             "schema": self.poller_schema,
                             "partition_cols": self.partition_cols
                         })
-                    self.reset_stats(pernode_stats[statskey])
+                    self.reset_stats(pernode_stats[token.nodename])
 
             # Post a cmd to fire up the next poll after the specified period
             if self.run_once == "update":

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -91,7 +91,7 @@ class Service(SqPlugin):
         self._poller_schema = {}
         self.node_boot_times = defaultdict(int)
         self._failed_node_set = set()
-        self._consecutive_failures = {}
+        self._consecutive_failures = defaultdict(int)
 
         self.poller_schema = property(
             self.get_poller_schema, self.set_poller_schema)
@@ -772,12 +772,12 @@ class Service(SqPlugin):
                     # The info will be committed in a future run.
                     if any((not Service.is_status_ok(x) for x in ostatus)):
                         self._consecutive_failures[key] = \
-                            self._consecutive_failures.get(key, 0) + 1
+                            self._consecutive_failures[key] + 1
                     # otherwise reset the counter.
                     else:
                         self._consecutive_failures[key] = 0
 
-                if 0 < self._consecutive_failures.get(key, 0) < \
+                if 0 < self._consecutive_failures[key] < \
                         HYSTERESIS_FAILURE_CNT:
                     self.logger.info(
                         f"{self.name} {key} node failure hysteresis,"


### PR DESCRIPTION
This change avoids having records swinging back and forth between active and inactive and causing a wrong device count in summarize (#607).
This might happen in case of:
- slow nodes
- timeouts on busy TACACS server authorizing the cmd
- nodes unreachable just for a polling event

As default, the number of unsuccessful polling event before marking the record as inactive is 2 but it is open to be discussed and to be made configurable.  

Signed-off-by: Claudio Usai <claudio.usai@stardustsystems.net>