### PR TITLE
Remove support for run bash in NXOS

### DIFF
--- a/suzieq/config/fs.yml
+++ b/suzieq/config/fs.yml
@@ -33,10 +33,10 @@ apply:
     command: bash timeout 5 df -hT
     textfsm: textfsm_templates/fs.tfsm
     
-  nxos:
-    version: all
-    command: run bash df -hT
-    textfsm: textfsm_templates/fs.tfsm
+  # nxos:
+  #   version: all
+  #   command: run bash df -hT
+  #   textfsm: textfsm_templates/fs.tfsm
 
   junos-qfx:
     version: all

--- a/suzieq/config/topcpu.yml
+++ b/suzieq/config/topcpu.yml
@@ -36,8 +36,8 @@ apply:
     format: text
     textfsm: textfsm_templates/cl_top.tfsm
 
-  nxos:
-    version: all
-    command: run bash top -bn 1 | head -17
-    format: text
-    textfsm: textfsm_templates/cl_top.tfsm
+  # nxos:
+  #   version: all
+  #   command: run bash top -bn 1 | head -17
+  #   format: text
+  #   textfsm: textfsm_templates/cl_top.tfsm


### PR DESCRIPTION
Address #591, run bash commands are now disabled. Left as commented lines in the service configuration so that it's easier to keep track and update it with commands that do not rely on feature bash-shell.

Service involved:
- fs
- topcpu 

Signed-off-by: Claudio Usai <claudio.usai@stardustsystems.net>