### PR TITLE
Filter afisafi

### DIFF
--- a/suzieq/cli/sqcmds/BgpCmd.py
+++ b/suzieq/cli/sqcmds/BgpCmd.py
@@ -16,6 +16,7 @@ from suzieq.sqobjects.bgp import BgpObj
 @argument("peer",
           description=("IP address(es), in quotes, or the interface name(s), "
                        "space separated"))
+@argument("afiSafi", description="AFI SAFI string to filter by")
 class BgpCmd(SqCommand):
     """BGP protocol information"""
 
@@ -32,7 +33,8 @@ class BgpCmd(SqCommand):
             query_str: str = ' ',
             vrf: str = '',
             state: str = '',
-            peer: str = ''
+            peer: str = '',
+            afiSafi: str = '',
     ) -> None:
         super().__init__(
             engine=engine,
@@ -50,6 +52,7 @@ class BgpCmd(SqCommand):
             'vrf': vrf.split(),
             'state': state,
             'peer': peer.split(),
+            'afiSafi': afiSafi,
         }
 
     def _clean_output(self, df) -> pd.DataFrame:

--- a/suzieq/cli/sqcmds/SqPollerCmd.py
+++ b/suzieq/cli/sqcmds/SqPollerCmd.py
@@ -27,7 +27,7 @@ class SqPollerCmd(SqCommand):
             query_str: str = "",
             columns: str = "default",
             service: str = '',
-            status: str = 'all',
+            status: str = '',
             poll_period_exceeded: str = '',
     ) -> None:
         super().__init__(
@@ -58,7 +58,7 @@ class SqPollerCmd(SqCommand):
             'service': [],
             'status': 'all',
             'pollExcdPeriodCount': '0'
-            }
+        }
 
         # check if lvars are the default args,
         # if yes clean before calling super

--- a/suzieq/cli/sqcmds/TopologyCmd.py
+++ b/suzieq/cli/sqcmds/TopologyCmd.py
@@ -15,6 +15,7 @@ from suzieq.sqobjects.topology import TopologyObj
 @argument("vrf", description="VRF(s), space separated")
 @argument("asn", description="BGP ASN(s), space separated")
 @argument("area", description="OSPF Area(s), space separated")
+@argument("afiSafi", description="BGP AFI SAFI lens to filter the topology")
 @ argument("peerHostname",
            description="Peer hostname(s), space separated, "
            "space separated")
@@ -38,7 +39,8 @@ class TopologyCmd(SqCommand):
             vrf: str = '',
             asn: str = '',
             area: str = '',
-            peerHostname: str = ''
+            peerHostname: str = '',
+            afiSafi: str = ''
     ) -> None:
         super().__init__(
             engine=engine,
@@ -59,5 +61,6 @@ class TopologyCmd(SqCommand):
             'area': area.split(),
             'via': via.split(),
             'vrf': vrf.split(),
-            'peerHostname': peerHostname.split()
+            'peerHostname': peerHostname.split(),
+            'afiSafi': afiSafi,
         }

--- a/suzieq/engines/pandas/bgp.py
+++ b/suzieq/engines/pandas/bgp.py
@@ -22,6 +22,7 @@ class BgpObj(SqPandasEngine):
         peer = kwargs.pop('peer', None)
         hostname = kwargs.pop('hostname', None)
         user_query = kwargs.pop('query_str', None)
+        afi_safi = kwargs.pop('afiSafi', '')
 
         addnl_fields.extend(['origPeer'])
         sch = self.schema
@@ -35,6 +36,9 @@ class BgpObj(SqPandasEngine):
                     'peer', 'hostname']:
             if col not in fields:
                 addnl_fields.append(col)
+
+        if afi_safi and afi_safi not in fields:
+            addnl_fields.append('afiSafi')
 
         try:
             df = super().get(addnl_fields=addnl_fields, **kwargs)
@@ -50,10 +54,10 @@ class BgpObj(SqPandasEngine):
             # augmented columns yet and so can fail.
             return df
 
-        if 'afiSafi' in columns or (columns == ['*']):
+        if afi_safi or 'afiSafi' in fields or (columns == ['*']):
             df['afiSafi'] = df['afi'] + ' ' + df['safi']
         query_str = build_query_str([], sch, vrf=vrf, peer=peer,
-                                    hostname=hostname,
+                                    hostname=hostname, afiSafi=afi_safi,
                                     ignore_regex=False)
         if 'peer' in df.columns:
             df['peer'] = np.where(df['origPeer'] != "",

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -325,6 +325,7 @@ async def query_bgp(verb: CommonExtraVerbs, request: Request,
                     vrf: List[str] = Query(None),
                     asn: List[str] = Query(None),
                     result: AssertResultValue = Query(None),
+                    afiSafi: str = Query(None),
                     query_str: str = None, what: str = None,
                     ):
     function_name = inspect.currentframe().f_code.co_name
@@ -632,6 +633,7 @@ async def query_topology(verb: CommonVerbs, request: Request,
                          asn: List[str] = Query(None),
                          area: List[str] = Query(None),
                          vrf: List[str] = Query(None),
+                         afiSafi: str = Query(None),
                          query_str: str = None, what: str = None,
                          ):
     function_name = inspect.currentframe().f_code.co_name

--- a/suzieq/sqobjects/bgp.py
+++ b/suzieq/sqobjects/bgp.py
@@ -10,7 +10,7 @@ class BgpObj(SqObject):
     def __init__(self, **kwargs):
         super().__init__(table='bgp', **kwargs)
         self._valid_get_args = ['namespace', 'hostname', 'columns', 'state',
-                                'vrf', 'peer', 'asn', 'query_str']
+                                'vrf', 'peer', 'asn', 'afiSafi', 'query_str']
         self._valid_arg_vals = {
             'state': ['Established', 'NotEstd', 'dynamic', ''],
             'result': ['all', 'pass', 'fail'],

--- a/suzieq/sqobjects/sqPoller.py
+++ b/suzieq/sqobjects/sqPoller.py
@@ -9,5 +9,5 @@ class SqPollerObj(SqObject):
         self._valid_get_args = ['namespace', 'hostname', 'columns', 'service',
                                 'status', 'pollExcdPeriodCount', 'query_str']
         self._valid_arg_vals = {
-            'status': ['all', 'pass', 'fail'],
+            'status': ['', 'all', 'pass', 'fail'],
         }

--- a/suzieq/sqobjects/topology.py
+++ b/suzieq/sqobjects/topology.py
@@ -11,7 +11,7 @@ class TopologyObj(SqObject):
         self._cat_fields = []
         self._valid_get_args = ['namespace', 'hostname', 'columns',
                                 'polled', 'ifname', 'via', 'vrf', 'asn',
-                                'area', 'peerHostname', 'query_str']
+                                'area', 'peerHostname', 'afiSafi', 'query_str']
         self._valid_summarize_args = ['namespace', 'hostname', 'via', 'vrf',
                                       'asn', 'area', 'query_str']
         self._valid_arg_vals = {

--- a/tests/integration/sqcmds/common-samples/help.yml
+++ b/tests/integration/sqcmds/common-samples/help.yml
@@ -170,24 +170,26 @@ tests:
   format: text
   marks: bgp help
   output: "bgp aver: \e[36mAssert BGP is functioning properly\e[0m\n\e[33m\nUse quotes\
-    \ when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - columns:\
-    \ \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - end_time: \e\
-    [36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e[36m\e\
-    [1mSelect the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s),\
-    \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
-    [0m\n - peer: \e[36m\e[1mIP address(es), in quotes, or the interface name(s),\
-    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
-    \ query format to further filter the output\e[0m\n - result: \e[36m\e[1mShow only\
-    \ assert that matches this value\e[0m\n - start_time: \e[36m\e[1mStart of time\
-    \ window, try natural language spec\e[0m\n - state: \e[36m\e[1mState of VLAN to\
-    \ query\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e[0m\n -\
-    \ vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
+    \ when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - afiSafi:\
+    \ \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e[0m\n - columns: \e[36m\e\
+    [1mSpace separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd\
+    \ of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
+    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
+    [0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - peer: \e\
+    [36m\e[1mIP address(es), in quotes, or the interface name(s), space separated\e\
+    [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
+    \ further filter the output\e[0m\n - result: \e[36m\e[1mShow only assert that\
+    \ matches this value\e[0m\n - start_time: \e[36m\e[1mStart of time window, try\
+    \ natural language spec\e[0m\n - state: \e[36m\e[1mState of VLAN to query\e[0m\n\
+    \ - view: \e[36m\e[1mView all records or just the latest\e[0m\n - vrf: \e[36m\e\
+    [1mVRF(s), space separated\e[0m\n"
 - command: bgp help --command=show
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: bgp help command
   output: "bgp show: \e[36mShow BGP info\e[0m\n\e[33m\nUse quotes when providing more\
-    \ than one value\e[0m\n\e[33m\nArguments:\e[0m\n - columns: \e[36m\e[1mSpace separated\
+    \ than one value\e[0m\n\e[33m\nArguments:\e[0m\n - afiSafi: \e[36m\e[1mBGP AFI\
+    \ SAFI lens to filter the topology\e[0m\n - columns: \e[36m\e[1mSpace separated\
     \ list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window,\
     \ try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of\
     \ the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
@@ -204,50 +206,53 @@ tests:
   marks: bgp help command
   output: "bgp summarize: \e[36mSummarize relevant information about the table\e[0m\n\
     \e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
-    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
-    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
-    [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
-    \ space separated\e[0m\n - peer: \e[36m\e[1mIP address(es), in quotes, or the\
-    \ interface name(s), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank\
-    \ terminated pandas query format to further filter the output\e[0m\n - start_time:\
-    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e\
-    [36m\e[1mState of VLAN to query\e[0m\n - view: \e[36m\e[1mView all records or\
-    \ just the latest\e[0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
+    [0m\n - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e[0m\n -\
+    \ columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - end_time:\
+    \ \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e\
+    [36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s),\
+    \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
+    [0m\n - peer: \e[36m\e[1mIP address(es), in quotes, or the interface name(s),\
+    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
+    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
+    \ of time window, try natural language spec\e[0m\n - state: \e[36m\e[1mState of\
+    \ VLAN to query\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e\
+    [0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
 - command: bgp help --command=unique
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: bgp help command
   output: "bgp unique: \e[36mGet unique values (and counts) associated with requested\
     \ field\e[0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\n\
-    Arguments:\e[0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for\
-    \ all\e[0m\n - count: \e[36m\e[1minclude count of times a value is seen\e[0m\n\
-    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
-    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
-    [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
-    \ space separated\e[0m\n - peer: \e[36m\e[1mIP address(es), in quotes, or the\
-    \ interface name(s), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank\
-    \ terminated pandas query format to further filter the output\e[0m\n - start_time:\
-    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e\
-    [36m\e[1mState of VLAN to query\e[0m\n - view: \e[36m\e[1mView all records or\
-    \ just the latest\e[0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
+    Arguments:\e[0m\n - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e\
+    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
+    \ - count: \e[36m\e[1minclude count of times a value is seen\e[0m\n - end_time:\
+    \ \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e\
+    [36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s),\
+    \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
+    [0m\n - peer: \e[36m\e[1mIP address(es), in quotes, or the interface name(s),\
+    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
+    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
+    \ of time window, try natural language spec\e[0m\n - state: \e[36m\e[1mState of\
+    \ VLAN to query\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e\
+    [0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
 - command: bgp help --command=top
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: bgp help command
   output: "bgp top: \e[36mReturn the top n values for a field in a table\e[0m\n\e\
     [33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
-    \ - count: \e[36m\e[1mnumber of rows to return\e[0m\n - end_time: \e[36m\e[1mEnd\
-    \ of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
-    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
-    [0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - peer: \e\
-    [36m\e[1mIP address(es), in quotes, or the interface name(s), space separated\e\
-    [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
-    \ further filter the output\e[0m\n - reverse: \e[36m\e[1mreturn bottom n values\e\
-    [0m\n - start_time: \e[36m\e[1mStart of time window, try natural language spec\e\
-    [0m\n - state: \e[36m\e[1mState of VLAN to query\e[0m\n - view: \e[36m\e[1mView\
-    \ all records or just the latest\e[0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e\
+    [0m\n - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e[0m\n -\
+    \ columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - count:\
+    \ \e[36m\e[1mnumber of rows to return\e[0m\n - end_time: \e[36m\e[1mEnd of time\
+    \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
+    \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
+    \ - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - peer: \e[36m\e\
+    [1mIP address(es), in quotes, or the interface name(s), space separated\e[0m\n\
+    \ - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to further\
+    \ filter the output\e[0m\n - reverse: \e[36m\e[1mreturn bottom n values\e[0m\n\
+    \ - start_time: \e[36m\e[1mStart of time window, try natural language spec\e[0m\n\
+    \ - state: \e[36m\e[1mState of VLAN to query\e[0m\n - view: \e[36m\e[1mView all\
+    \ records or just the latest\e[0m\n - vrf: \e[36m\e[1mVRF(s), space separated\e\
     [0m\n - what: \e[36m\e[1mnumeric field to get top values for\e[0m\n"
 - command: devconfig help
   data-directory: tests/data/eos/parquet-out/
@@ -1082,7 +1087,7 @@ tests:
   marks: ospf help command
   output: "ospf describe: \e[36mDisplay the schema of the table\e[0m\n\e[33m\nUse\
     \ quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n -\
-    \ area: \e[36m\e[1mArea(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace\
+    \ area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace\
     \ separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time\
     \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
     \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
@@ -1098,11 +1103,11 @@ tests:
   marks: ospf help command
   output: "ospf aver: \e[36mTest OSPF runtime state is without errors\e[0m\n\e[33m\n\
     Use quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n\
-    \ - area: \e[36m\e[1mArea(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace\
-    \ separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time\
-    \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
-    \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
-    \ - ifname: \e[36m\e[1mInterface name(s), space separated\e[0m\n - namespace:\
+    \ - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - columns: \e[36m\e\
+    [1mSpace separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd\
+    \ of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
+    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
+    [0m\n - ifname: \e[36m\e[1mInterface name(s), space separated\e[0m\n - namespace:\
     \ \e[36m\e[1mNamespace(s), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing\
     \ blank terminated pandas query format to further filter the output\e[0m\n - result:\
     \ \e[36m\e[1mShow only assert that matches this value\e[0m\n - start_time: \e\
@@ -1114,12 +1119,12 @@ tests:
   format: text
   marks: ospf help command
   output: "ospf show: \e[36mShow address info\e[0m\n\e[33m\nUse quotes when providing\
-    \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - area: \e[36m\e[1mArea(s),\
-    \ space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list of columns,\
-    \ * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural language\
-    \ spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n -\
-    \ hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e\
-    [1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - area: \e[36m\e[1mOSPF\
+    \ Area(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list of\
+    \ columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural\
+    \ language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e\
+    [0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e\
+    [36m\e[1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
     \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
     \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
     \ of time window, try natural language spec\e[0m\n - state: \e[36m\e[1mState of\
@@ -1131,11 +1136,11 @@ tests:
   marks: ospf help command
   output: "ospf summarize: \e[36mSummarize relevant information about the table\e\
     [0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - area: \e[36m\e[1mArea(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace\
-    \ separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time\
-    \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
-    \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
-    \ - ifname: \e[36m\e[1mInterface name(s), space separated\e[0m\n - namespace:\
+    [0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - columns: \e[36m\e\
+    [1mSpace separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd\
+    \ of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
+    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
+    [0m\n - ifname: \e[36m\e[1mInterface name(s), space separated\e[0m\n - namespace:\
     \ \e[36m\e[1mNamespace(s), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing\
     \ blank terminated pandas query format to further filter the output\e[0m\n - start_time:\
     \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - state: \e\
@@ -1147,12 +1152,12 @@ tests:
   marks: ospf help command
   output: "ospf top: \e[36mReturn the top n values for a field in a table\e[0m\n\e\
     [33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - area: \e[36m\e[1mArea(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace\
-    \ separated list of columns, * for all\e[0m\n - count: \e[36m\e[1mnumber of rows\
-    \ to return\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural language\
-    \ spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n -\
-    \ hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e\
-    [1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    [0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - columns: \e[36m\e\
+    [1mSpace separated list of columns, * for all\e[0m\n - count: \e[36m\e[1mnumber\
+    \ of rows to return\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural\
+    \ language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e\
+    [0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e\
+    [36m\e[1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
     \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
     \ query format to further filter the output\e[0m\n - reverse: \e[36m\e[1mreturn\
     \ bottom n values\e[0m\n - start_time: \e[36m\e[1mStart of time window, try natural\
@@ -1166,7 +1171,7 @@ tests:
   marks: ospf help command
   output: "ospf unique: \e[36mGet unique values (and counts) associated with requested\
     \ field\e[0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\n\
-    Arguments:\e[0m\n - area: \e[36m\e[1mArea(s), space separated\e[0m\n - columns:\
+    Arguments:\e[0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - columns:\
     \ \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - count: \e[36m\e\
     [1minclude count of times a value is seen\e[0m\n - end_time: \e[36m\e[1mEnd of\
     \ time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the\
@@ -1311,12 +1316,13 @@ tests:
   marks: topology help command
   output: "topology describe: \e[36mDisplay the schema of the table\e[0m\n\e[33m\n\
     Use quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n\
-    \ - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e[1mBGP\
-    \ ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list of\
-    \ columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural\
-    \ language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e\
-    [0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e\
-    [36m\e[1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    \ - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e[0m\n - area:\
+    \ \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e[1mBGP ASN(s),\
+    \ space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list of columns,\
+    \ * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural language\
+    \ spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n -\
+    \ hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e\
+    [1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
     \ space separated\e[0m\n - peerHostname: \e[36m\e[1mPeer hostname(s), space separated,\
     \ space separated\e[0m\n - polled: \e[36m\e[1mIs the device polled by Suzieq\e\
     [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
@@ -1329,32 +1335,34 @@ tests:
   format: text
   marks: topology help command
   output: "topology show: \e[36mShow address info\e[0m\n\e[33m\nUse quotes when providing\
-    \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - area: \e[36m\e[1mOSPF\
-    \ Area(s), space separated\e[0m\n - asn: \e[36m\e[1mBGP ASN(s), space separated\e\
-    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
-    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
-    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
-    [36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e[1mInterface name(s),\
-    \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
-    [0m\n - peerHostname: \e[36m\e[1mPeer hostname(s), space separated, space separated\e\
-    [0m\n - polled: \e[36m\e[1mIs the device polled by Suzieq\e[0m\n - query_str:\
-    \ \e[36m\e[1mTrailing blank terminated pandas query format to further filter the\
-    \ output\e[0m\n - start_time: \e[36m\e[1mStart of time window, try natural language\
-    \ spec\e[0m\n - via: \e[36m\e[1mProtocol(s) via which nodes are connected, space\
-    \ separated\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e[0m\n\
-    \ - vrf: \e[36m\e[1mVRF(s), space separated\e[0m\n"
+    \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - afiSafi: \e[36m\e[1mBGP\
+    \ AFI SAFI lens to filter the topology\e[0m\n - area: \e[36m\e[1mOSPF Area(s),\
+    \ space separated\e[0m\n - asn: \e[36m\e[1mBGP ASN(s), space separated\e[0m\n\
+    \ - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - end_time:\
+    \ \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e\
+    [36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s),\
+    \ space separated\e[0m\n - ifname: \e[36m\e[1mInterface name(s), space separated\e\
+    [0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - peerHostname:\
+    \ \e[36m\e[1mPeer hostname(s), space separated, space separated\e[0m\n - polled:\
+    \ \e[36m\e[1mIs the device polled by Suzieq\e[0m\n - query_str: \e[36m\e[1mTrailing\
+    \ blank terminated pandas query format to further filter the output\e[0m\n - start_time:\
+    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - via: \e\
+    [36m\e[1mProtocol(s) via which nodes are connected, space separated\e[0m\n - view:\
+    \ \e[36m\e[1mView all records or just the latest\e[0m\n - vrf: \e[36m\e[1mVRF(s),\
+    \ space separated\e[0m\n"
 - command: topology help --command=summarize
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: topology help command
   output: "topology summarize: \e[36mSummarize relevant information about the table\e\
     [0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e\
-    [1mBGP ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list\
-    \ of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try\
-    \ natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the\
-    \ output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname:\
-    \ \e[36m\e[1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    [0m\n - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e[0m\n -\
+    \ area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e[1mBGP\
+    \ ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list of\
+    \ columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural\
+    \ language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e\
+    [0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e\
+    [36m\e[1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
     \ space separated\e[0m\n - peerHostname: \e[36m\e[1mPeer hostname(s), space separated,\
     \ space separated\e[0m\n - polled: \e[36m\e[1mIs the device polled by Suzieq\e\
     [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
@@ -1368,35 +1376,37 @@ tests:
   marks: topology help command
   output: "topology top: \e[36mReturn the top n values for a field in a table\e[0m\n\
     \e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e\
-    [1mBGP ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list\
-    \ of columns, * for all\e[0m\n - count: \e[36m\e[1mnumber of rows to return\e\
-    [0m\n - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e\
-    [0m\n - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname:\
-    \ \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e[1mInterface\
-    \ name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space\
-    \ separated\e[0m\n - peerHostname: \e[36m\e[1mPeer hostname(s), space separated,\
-    \ space separated\e[0m\n - polled: \e[36m\e[1mIs the device polled by Suzieq\e\
-    [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
-    \ further filter the output\e[0m\n - reverse: \e[36m\e[1mreturn bottom n values\e\
-    [0m\n - start_time: \e[36m\e[1mStart of time window, try natural language spec\e\
-    [0m\n - via: \e[36m\e[1mProtocol(s) via which nodes are connected, space separated\e\
-    [0m\n - view: \e[36m\e[1mView all records or just the latest\e[0m\n - vrf: \e\
-    [36m\e[1mVRF(s), space separated\e[0m\n - what: \e[36m\e[1mnumeric field to get\
-    \ top values for\e[0m\n"
+    [0m\n - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e[0m\n -\
+    \ area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e[1mBGP\
+    \ ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list of\
+    \ columns, * for all\e[0m\n - count: \e[36m\e[1mnumber of rows to return\e[0m\n\
+    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
+    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
+    [36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e[1mInterface name(s),\
+    \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
+    [0m\n - peerHostname: \e[36m\e[1mPeer hostname(s), space separated, space separated\e\
+    [0m\n - polled: \e[36m\e[1mIs the device polled by Suzieq\e[0m\n - query_str:\
+    \ \e[36m\e[1mTrailing blank terminated pandas query format to further filter the\
+    \ output\e[0m\n - reverse: \e[36m\e[1mreturn bottom n values\e[0m\n - start_time:\
+    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - via: \e\
+    [36m\e[1mProtocol(s) via which nodes are connected, space separated\e[0m\n - view:\
+    \ \e[36m\e[1mView all records or just the latest\e[0m\n - vrf: \e[36m\e[1mVRF(s),\
+    \ space separated\e[0m\n - what: \e[36m\e[1mnumeric field to get top values for\e\
+    [0m\n"
 - command: topology help --command=unique
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: topology help command
   output: "topology unique: \e[36mGet unique values (and counts) associated with requested\
     \ field\e[0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\n\
-    Arguments:\e[0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn:\
-    \ \e[36m\e[1mBGP ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated\
-    \ list of columns, * for all\e[0m\n - count: \e[36m\e[1minclude count of times\
-    \ a value is seen\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural\
-    \ language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e\
-    [0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e\
-    [36m\e[1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    Arguments:\e[0m\n - afiSafi: \e[36m\e[1mBGP AFI SAFI lens to filter the topology\e\
+    [0m\n - area: \e[36m\e[1mOSPF Area(s), space separated\e[0m\n - asn: \e[36m\e\
+    [1mBGP ASN(s), space separated\e[0m\n - columns: \e[36m\e[1mSpace separated list\
+    \ of columns, * for all\e[0m\n - count: \e[36m\e[1minclude count of times a value\
+    \ is seen\e[0m\n - end_time: \e[36m\e[1mEnd of time window, try natural language\
+    \ spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n -\
+    \ hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n - ifname: \e[36m\e\
+    [1mInterface name(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
     \ space separated\e[0m\n - peerHostname: \e[36m\e[1mPeer hostname(s), space separated,\
     \ space separated\e[0m\n - polled: \e[36m\e[1mIs the device polled by Suzieq\e\
     [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\

--- a/tests/integration/sqcmds/cumulus-samples/bgp.yml
+++ b/tests/integration/sqcmds/cumulus-samples/bgp.yml
@@ -1800,3 +1800,542 @@ tests:
   output: '[{"hostname": "edge01"}, {"hostname": "exit01"}, {"hostname": "exit02"},
     {"hostname": "internet"}, {"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname":
     "leaf03"}, {"hostname": "leaf04"}, {"hostname": "spine01"}, {"hostname": "spine02"}]'
+- command: bgp show --afiSafi='ipv4 unicast' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show cumulus filter
+  output: '[{"namespace": "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer":
+    "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65530, "peerAsn": 65000, "pfxRx": 10, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681582563}, {"namespace": "ospf-ibgp",
+    "hostname": "edge01", "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
+    65000, "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0,
+    "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65001, "pfxRx": 3,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp": 1616681582563},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.2",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65530, "peerAsn": 65000, "pfxRx": 10, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681582563}, {"namespace": "ospf-ibgp", "hostname":
+    "edge01", "vrf": "default", "peer": "eth2.3", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65000,
+    "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp":
+    1616681582563}, {"namespace": "ospf-ibgp", "hostname": "edge01", "vrf": "default",
+    "peer": "eth2.4", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65530, "peerAsn": 65001, "pfxRx": 3, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681582563}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001, "peerAsn":
+    25253, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681048000.0,
+    "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname": "edge01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65001, "peerAsn": 65530, "pfxRx": 13,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp": 1616681582980},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "evpn-vrf", "peer": "swp5.3",
+    "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65530, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime":
+    1616681049000.0, "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname":
+    "exit01", "vrf": "default", "peer": "swp5.2", "peerHostname": "edge01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530,
+    "pfxRx": 4, "pfxTx": 14, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
+    1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 0, "pfxTx": 13, "numChanges":
+    1, "estdTime": 1616681049000.0, "timestamp": 1616681582980}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 1, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681050000.0,
+    "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65001, "peerAsn": 25253, "pfxRx": 3,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616681047000.0, "timestamp": 1616681583200},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681583200}, {"namespace": "ospf-ibgp", "hostname":
+    "exit02", "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65530,
+    "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681048000.0, "timestamp":
+    1616681583200}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vrf": "default",
+    "peer": "swp5.2", "peerHostname": "edge01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65530, "pfxRx": 4, "pfxTx": 14, "numChanges":
+    1, "estdTime": 1616681048000.0, "timestamp": 1616681583200}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65001,
+    "peerAsn": 65530, "pfxRx": 13, "pfxTx": 16, "numChanges": 1, "estdTime": 1616681048000.0,
+    "timestamp": 1616681583200}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65000, "pfxRx": 13,
+    "pfxTx": 14, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583330},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp5",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 13, "pfxTx": 14, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681583330}, {"namespace": "ospf-ibgp", "hostname":
+    "internet", "vrf": "default", "peer": "swp2", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn": 65001,
+    "pfxRx": 13, "pfxTx": 15, "numChanges": 1, "estdTime": 1616681046000.0, "timestamp":
+    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "internet", "vrf": "default",
+    "peer": "swp1", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 25253, "peerAsn": 65001, "pfxRx": 13, "pfxTx": 15, "numChanges":
+    1, "estdTime": 1616681047000.0, "timestamp": 1616681583330}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000.0,
+    "timestamp": 1616681583504}]'
+- command: bgp show --afiSafi='l2vpn evpn' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show cumulus filter
+  output: '[{"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "peer":
+    "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 32, "pfxTx": 6, "numChanges":
+    1, "estdTime": 1616681049000.0, "timestamp": 1616681582980}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 38, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681050000.0,
+    "timestamp": 1616681582980}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583091},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1616681050000.0, "timestamp": 1616681583091}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp":
+    1616681583091}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681049000.0, "timestamp": 1616681583091}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 38, "pfxTx": 6, "numChanges": 1, "estdTime": 1616681047000.0,
+    "timestamp": 1616681583200}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx":
+    44, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583330},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "peer": "swp5",
+    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 44, "numChanges": 1, "estdTime":
+    1616681047000.0, "timestamp": 1616681583330}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
+    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default",
+    "peer": "swp4", "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 44, "numChanges":
+    1, "estdTime": 1616681050000.0, "timestamp": 1616681583330}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0,
+    "timestamp": 1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1616681051000.0, "timestamp": 1616681583330},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1616681050000.0, "timestamp": 1616681583330}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
+    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681052000.0, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 28, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000.0,
+    "timestamp": 1616681583393}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx":
+    38, "numChanges": 1, "estdTime": 1616681050000.0, "timestamp": 1616681583504},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer": "swp2",
+    "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime":
+    1616681050000.0, "timestamp": 1616681583504}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65000,
+    "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681049000.0, "timestamp":
+    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp4", "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681051000.0, "timestamp": 1616681583504}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 6, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681049000.0,
+    "timestamp": 1616681583504}]'
+- command: bgp show --afiSafi='ipv4 unicast' --namespace=dual-bgp --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show cumulus filter
+  output: '[{"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer":
+    "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 12, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638156000.0, "timestamp": 1616638469998}, {"namespace": "dual-bgp",
+    "hostname": "edge01", "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
+    65201, "pfxRx": 5, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638156000.0,
+    "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname": "edge01", "vrf":
+    "default", "peer": "eth2.2", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65202, "pfxRx": 12,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616638156000.0, "timestamp": 1616638469998},
+    {"namespace": "dual-bgp", "hostname": "edge01", "vrf": "default", "peer": "eth2.4",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65530, "peerAsn": 65202, "pfxRx": 5, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616638156000.0, "timestamp": 1616638469998}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65104,
+    "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638096000.0, "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp3", "peerHostname": "leaf03", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65103, "pfxRx": 3, "pfxTx": 15, "numChanges":
+    1, "estdTime": 1616638096000.0, "timestamp": 1616638470426}, {"namespace": "dual-bgp",
+    "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65102, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638096000.0,
+    "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname": "spine02",
+    "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65101, "pfxRx": 3,
+    "pfxTx": 15, "numChanges": 1, "estdTime": 1616638096000.0, "timestamp": 1616638470426},
+    {"namespace": "dual-bgp", "hostname": "spine02", "vrf": "default", "peer": "swp5",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65202, "pfxRx": 5, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638094000.0, "timestamp": 1616638470426}, {"namespace": "dual-bgp", "hostname":
+    "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65201,
+    "pfxRx": 2, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp":
+    1616638470426}, {"namespace": "dual-bgp", "hostname": "internet", "vrf": "default",
+    "peer": "swp1", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 25253, "peerAsn": 65201, "pfxRx": 12, "pfxTx": 15, "numChanges":
+    1, "estdTime": 1616638094000.0, "timestamp": 1616638470550}, {"namespace": "dual-bgp",
+    "hostname": "exit02", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202,
+    "peerAsn": 65530, "pfxRx": 16, "pfxTx": 16, "numChanges": 3, "estdTime": 1616638156000.0,
+    "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf":
+    "internet-vrf", "peer": "swp6", "peerHostname": "internet", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 25253, "pfxRx": 15,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp": 1616638470550},
+    {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65202, "peerAsn": 65000, "pfxRx": 11, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616638094000.0, "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname":
+    "exit02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 65000,
+    "pfxRx": 11, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp":
+    1616638470550}, {"namespace": "dual-bgp", "hostname": "exit02", "vrf": "default",
+    "peer": "swp5.2", "peerHostname": "edge01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65202, "peerAsn": 65530, "pfxRx": 15, "pfxTx": 16, "numChanges":
+    3, "estdTime": 1616638156000.0, "timestamp": 1616638470550}, {"namespace": "dual-bgp",
+    "hostname": "internet", "vrf": "default", "peer": "swp2", "peerHostname": "exit02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn":
+    65202, "pfxRx": 12, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638094000.0,
+    "timestamp": 1616638470550}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf":
+    "internet-vrf", "peer": "swp6", "peerHostname": "internet", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 25253, "pfxRx": 4,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp": 1616638470555},
+    {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default", "peer": "swp5.2",
+    "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65201, "peerAsn": 65530, "pfxRx": 2, "pfxTx": 13, "numChanges": 3, "estdTime":
+    1616638156000.0, "timestamp": 1616638470555}, {"namespace": "dual-bgp", "hostname":
+    "exit01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 65000,
+    "pfxRx": 10, "pfxTx": 13, "numChanges": 1, "estdTime": 1616638095000.0, "timestamp":
+    1616638470555}, {"namespace": "dual-bgp", "hostname": "exit01", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65201, "peerAsn": 65000, "pfxRx": 10, "pfxTx": 13, "numChanges":
+    1, "estdTime": 1616638094000.0, "timestamp": 1616638470555}, {"namespace": "dual-bgp",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp5.4", "peerHostname":
+    "edge01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201,
+    "peerAsn": 65530, "pfxRx": 16, "pfxTx": 16, "numChanges": 3, "estdTime": 1616638156000.0,
+    "timestamp": 1616638470555}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "peer": "swp6", "peerHostname": "exit01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65201, "pfxRx": 2,
+    "pfxTx": 15, "numChanges": 1, "estdTime": 1616638094000.0, "timestamp": 1616638470647},
+    {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default", "peer": "swp5",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65000, "peerAsn": 65202, "pfxRx": 5, "pfxTx": 15, "numChanges": 1, "estdTime":
+    1616638094000.0, "timestamp": 1616638470647}, {"namespace": "dual-bgp", "hostname":
+    "spine01", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65104,
+    "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638097000.0, "timestamp":
+    1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01", "vrf": "default",
+    "peer": "swp3", "peerHostname": "leaf03", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65103, "pfxRx": 3, "pfxTx": 15, "numChanges":
+    1, "estdTime": 1616638097000.0, "timestamp": 1616638470647}, {"namespace": "dual-bgp",
+    "hostname": "spine01", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65102, "pfxRx": 3, "pfxTx": 15, "numChanges": 1, "estdTime": 1616638097000.0,
+    "timestamp": 1616638470647}, {"namespace": "dual-bgp", "hostname": "spine01",
+    "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65101, "pfxRx": 3,
+    "pfxTx": 15, "numChanges": 1, "estdTime": 1616638097000.0, "timestamp": 1616638470647},
+    {"namespace": "dual-bgp", "hostname": "leaf02", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65102, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616638096000.0, "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname":
+    "leaf02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65102, "peerAsn": 65000,
+    "pfxRx": 14, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638095000.0, "timestamp":
+    1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf04", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65104, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638096000.0, "timestamp": 1616638471112}, {"namespace": "dual-bgp",
+    "hostname": "leaf04", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65104, "peerAsn":
+    65000, "pfxRx": 14, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638095000.0,
+    "timestamp": 1616638471112}, {"namespace": "dual-bgp", "hostname": "leaf01", "vrf":
+    "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65101, "peerAsn": 65000, "pfxRx": 12,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616638095000.0, "timestamp": 1616638471143},
+    {"namespace": "dual-bgp", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65101, "peerAsn": 65000, "pfxRx": 12, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616638096000.0, "timestamp": 1616638471143}, {"namespace": "dual-bgp", "hostname":
+    "leaf03", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65103, "peerAsn": 65000,
+    "pfxRx": 12, "pfxTx": 16, "numChanges": 1, "estdTime": 1616638098000.0, "timestamp":
+    1616638471475}, {"namespace": "dual-bgp", "hostname": "leaf03", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65103, "peerAsn": 65000, "pfxRx": 12, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616638097000.0, "timestamp": 1616638471475}]'
+- command: bgp show --afiSafi='l2vpn evpn' --namespace=dual-bgp --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show cumulus filter
+  output: '[]'
+- command: bgp show --afiSafi='ipv4 unicast' --namespace=dual-evpn --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show cumulus filter
+  output: '[{"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer":
+    "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822492}, {"namespace": "dual-evpn",
+    "hostname": "edge01", "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
+    65201, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0,
+    "timestamp": 1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01",
+    "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 4,
+    "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822492},
+    {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer": "eth2.2",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65530, "peerAsn": 65202, "pfxRx": 9, "pfxTx": 16, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644822492}, {"namespace": "dual-evpn", "hostname":
+    "edge01", "vrf": "default", "peer": "eth2.3", "peerHostname": "exit02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn": 65202,
+    "pfxRx": 2, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
+    "peer": "eth2.4", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65530, "peerAsn": 65202, "pfxRx": 4, "pfxTx": 16, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822492}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65102, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp3", "peerHostname": "leaf03", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65103, "pfxRx": 2, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65104, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65101, "pfxRx": 2, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp5", "peerHostname": "exit02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65202, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp6", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65201, "pfxRx": 7, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65101, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644609000.0, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default",
+    "peer": "swp3", "peerHostname": "leaf03", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65103, "pfxRx": 2, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65104, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default",
+    "peer": "swp5", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65202, "pfxRx": 8, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65201, "pfxRx": 7, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default",
+    "peer": "swp2", "peerHostname": "leaf02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65000, "peerAsn": 65102, "pfxRx": 2, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn":
+    25253, "pfxRx": 4, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "internet-vrf",
+    "peer": "swp5.4", "peerHostname": "edge01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65201, "peerAsn": 65530, "pfxRx": 16, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822941}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn":
+    65530, "pfxRx": 16, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
+    "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
+    "vrf": "default", "peer": "swp5.2", "peerHostname": "edge01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 65530, "pfxRx": 16,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822941},
+    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65201, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+    "exit01", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 65000,
+    "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65202, "peerAsn": 65000, "pfxRx": 12, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644607000.0, "timestamp": 1616644822972}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vrf": "default", "peer": "swp5.2", "peerHostname": "edge01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn":
+    65530, "pfxRx": 16, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
+    "timestamp": 1616644822972}, {"namespace": "dual-evpn", "hostname": "exit02",
+    "vrf": "evpn-vrf", "peer": "swp5.3", "peerHostname": "edge01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 65530, "pfxRx": 16,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp": 1616644822972},
+    {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "internet-vrf", "peer":
+    "swp5.4", "peerHostname": "edge01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65202, "peerAsn": 65530, "pfxRx": 16, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644607000.0, "timestamp": 1616644822972}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn":
+    65000, "pfxRx": 12, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
+    "timestamp": 1616644822972}, {"namespace": "dual-evpn", "hostname": "exit02",
+    "vrf": "internet-vrf", "peer": "swp6", "peerHostname": "internet", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65202, "peerAsn": 25253, "pfxRx": 13,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp": 1616644822972},
+    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65103, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
+    "leaf03", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65103, "peerAsn": 65000,
+    "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822983}, {"namespace": "dual-evpn", "hostname": "internet", "vrf": "default",
+    "peer": "swp1", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 25253, "peerAsn": 65201, "pfxRx": 13, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644607000.0, "timestamp": 1616644822996}, {"namespace": "dual-evpn",
+    "hostname": "internet", "vrf": "default", "peer": "swp2", "peerHostname": "exit02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 25253, "peerAsn":
+    65202, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
+    "timestamp": 1616644822996}, {"namespace": "dual-evpn", "hostname": "leaf01",
+    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65101, "peerAsn": 65000, "pfxRx": 14,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp": 1616644823039},
+    {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65101, "peerAsn": 65000, "pfxRx": 14, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644823039}, {"namespace": "dual-evpn", "hostname":
+    "leaf04", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65104, "peerAsn": 65000,
+    "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644823113}, {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65104, "peerAsn": 65000, "pfxRx": 13, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644823113}, {"namespace": "dual-evpn",
+    "hostname": "leaf02", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65102, "peerAsn":
+    65000, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
+    "timestamp": 1616644823117}, {"namespace": "dual-evpn", "hostname": "leaf02",
+    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65102, "peerAsn": 65000, "pfxRx": 13,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644823117}]'
+- command: bgp show --afiSafi='l2vpn evpn' --namespace=dual-evpn --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show cumulus filter
+  output: '[{"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer":
+    "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65102, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp4", "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65104, "pfxRx": 8, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp5", "peerHostname": "exit02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65202, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
+    "timestamp": 1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02",
+    "vrf": "default", "peer": "swp3", "peerHostname": "leaf03", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65103, "pfxRx": 8, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822793},
+    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp6",
+    "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65000, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644822793}, {"namespace": "dual-evpn", "hostname":
+    "spine01", "vrf": "default", "peer": "swp2", "peerHostname": "leaf02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65102,
+    "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default",
+    "peer": "swp3", "peerHostname": "leaf03", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65103, "pfxRx": 8, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65104, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default",
+    "peer": "swp5", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65202, "pfxRx": 10, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65201, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
+    "timestamp": 1616644822861}, {"namespace": "dual-evpn", "hostname": "spine01",
+    "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1616644609000.0, "timestamp": 1616644822861},
+    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65201, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
+    "exit01", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65201, "peerAsn": 65000,
+    "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65202, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644607000.0, "timestamp": 1616644822972}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65202, "peerAsn":
+    65000, "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0,
+    "timestamp": 1616644822972}, {"namespace": "dual-evpn", "hostname": "leaf03",
+    "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65103, "peerAsn": 65000, "pfxRx": 36, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644822983},
+    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "peer": "swp2",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65103, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644822983}, {"namespace": "dual-evpn", "hostname":
+    "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65101, "peerAsn": 65000,
+    "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000.0, "timestamp":
+    1616644823039}, {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default",
+    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65101, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000.0, "timestamp": 1616644823039}, {"namespace": "dual-evpn",
+    "hostname": "leaf04", "vrf": "default", "peer": "swp1", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65104, "peerAsn":
+    65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0,
+    "timestamp": 1616644823113}, {"namespace": "dual-evpn", "hostname": "leaf04",
+    "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 65104, "peerAsn": 65000, "pfxRx": 36, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp": 1616644823113},
+    {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "peer": "swp1",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 65102, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1616644608000.0, "timestamp": 1616644823117}, {"namespace": "dual-evpn", "hostname":
+    "leaf02", "vrf": "default", "peer": "swp2", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65102, "peerAsn": 65000,
+    "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000.0, "timestamp":
+    1616644823117}]'

--- a/tests/integration/sqcmds/cumulus-samples/topology.yml
+++ b/tests/integration/sqcmds/cumulus-samples/topology.yml
@@ -2208,7 +2208,7 @@ tests:
 - command: topology unique --vrf='default' --format=json --namespace=ospf-ibgp --columns=area
   data-directory: tests/data/parquet/
   marks: topology unique cumulus
-  output: '[{"area": ""}, {"area": "0.0.0.0"}]'
+  output: '[{"area": "0.0.0.0"}]'
 - command: topology unique --vrf='evpn-vrf' --format=json --namespace=ospf-ibgp --columns=asn
   data-directory: tests/data/parquet/
   marks: topology unique cumulus
@@ -2269,228 +2269,59 @@ tests:
 - command: topology show --area=0.0.0.0 --format=json --namespace=ospf-ibgp
   data-directory: tests/data/parquet/
   marks: topology show cumulus
-  output: '[{"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine01",
-    "ifname": "swp1", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 65000.0, "peerAsn": 65000.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname":
-    "spine01", "ifname": "swp1", "vrf": "default", "lldp": true, "arpndBidir": true,
-    "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0, "bgp": true, "area": "0.0.0.0",
-    "ospf": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit01",
-    "peerHostname": "spine01", "ifname": "swp1", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
-    "exit01", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default", "lldp":
-    true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit01", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit01", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit02", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": "", "peerAsn": "", "bgp":
-    "", "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit02", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": "", "peerAsn": "", "bgp":
-    "", "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit02", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit02", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "exit02", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf03", "ifname": "swp3", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf03", "ifname": "swp3", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf03", "ifname": "swp3", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf04", "ifname": "swp4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf04", "ifname": "swp4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf04", "ifname": "swp4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "exit02", "ifname": "swp5", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "exit02", "ifname": "swp5", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "exit02", "ifname": "swp5", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "exit01", "ifname": "swp6", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "exit01", "ifname": "swp6", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "exit01", "ifname": "swp6", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine01", "peerHostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "peerHostname": "spine01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "peerHostname": "spine02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "exit02", "ifname": "swp5", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": "", "peerAsn": "", "bgp":
-    "", "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "exit02", "ifname": "swp5", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": "", "peerAsn": "", "bgp":
-    "", "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf01", "ifname": "swp1", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf02", "ifname": "swp2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf03", "ifname": "swp3", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf03", "ifname": "swp3", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf03", "ifname": "swp3", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf04", "ifname": "swp4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf04", "ifname": "swp4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "leaf04", "ifname": "swp4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "exit01", "ifname": "swp6", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "exit01", "ifname": "swp6", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "ospf-ibgp",
-    "hostname": "spine02", "peerHostname": "exit01", "ifname": "swp6", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 65000.0, "peerAsn": 65000.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}]'
+  output: '[{"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "exit02",
+    "ifname": "swp5", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf04",
+    "ifname": "swp4", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf03",
+    "ifname": "swp3", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "peerHostname": "spine02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "peerHostname": "spine01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "exit01",
+    "ifname": "swp6", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "peerHostname": "spine02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "peerHostname": "spine02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "peerHostname": "spine01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "exit02", "peerHostname": "spine02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "exit02", "peerHostname": "spine01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "peerHostname": "spine01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "leaf04",
+    "ifname": "swp4", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "leaf03",
+    "ifname": "swp3", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "leaf02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "leaf01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "exit01",
+    "ifname": "swp6", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "exit02",
+    "ifname": "swp5", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "peerHostname": "spine02",
+    "ifname": "swp2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "peerHostname": "spine01",
+    "ifname": "swp1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}]'
 - command: topology summarize --area=0.0.0.0 --format=json --namespace=ospf-ibgp
   data-directory: tests/data/parquet/
   marks: topology show cumulus
-  output: '{"ospf-ibgp": {"arpnd_center": ["spine01", "spine02"], "arpnd_degree_histogram":
-    "...", "arpnd_is_fully_connected": true, "arpnd_number_of_disjoint_sets": 1, "arpnd_number_of_edges":
-    12, "arpnd_number_of_nodes": 8, "arpnd_self_loops": [], "bgp_center": ["spine01"],
-    "bgp_degree_histogram": "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets":
-    1, "bgp_number_of_edges": 11, "bgp_number_of_nodes": 8, "bgp_self_loops": [],
-    "lldp_center": ["spine01", "spine02"], "lldp_degree_histogram": "...", "lldp_is_fully_connected":
-    true, "lldp_number_of_disjoint_sets": 1, "lldp_number_of_edges": 12, "lldp_number_of_nodes":
-    8, "lldp_self_loops": [], "ospf_center": ["spine01", "spine02"], "ospf_degree_histogram":
+  output: '{"ospf-ibgp": {"ospf_center": ["spine01", "spine02"], "ospf_degree_histogram":
     "...", "ospf_is_fully_connected": true, "ospf_number_of_disjoint_sets": 1, "ospf_number_of_edges":
     12, "ospf_number_of_nodes": 8, "ospf_self_loops": []}}'
 - command: topology show --via=ospf --area=0.0.0.1 --format=json --namespace=ospf-ibgp
@@ -2503,3 +2334,211 @@ tests:
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
     {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
     "spine01"}, {"hostname": "spine02"}]'
+- command: topology show --afiSafi='ipv4 unicast' --format=json --namespace=ospf-ibgp
+  data-directory: tests/data/parquet/
+  marks: topology show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "edge01", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65530, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "peerHostname": "exit01", "vrf":
+    "default", "asn": 65530, "peerAsn": 65001, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "edge01", "peerHostname": "exit02", "vrf": "default",
+    "asn": 65530, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "edge01", "peerHostname": "exit02", "vrf": "default", "asn": 65530,
+    "peerAsn": 65001, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "exit01", "peerHostname": "internet", "vrf": "internet-vrf", "asn": 65001, "peerAsn":
+    25253, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "peerHostname": "edge01", "vrf": "internet-vrf", "asn": 65001, "peerAsn": 65530,
+    "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "peerHostname": "edge01", "vrf": "evpn-vrf", "asn": 65000, "peerAsn": 65530, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname":
+    "edge01", "vrf": "default", "asn": 65000, "peerAsn": 65530, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine02",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine01", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "peerHostname": "internet", "vrf": "internet-vrf",
+    "asn": 65001, "peerAsn": 25253, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "peerHostname": "edge01", "vrf": "evpn-vrf", "asn": 65000,
+    "peerAsn": 65530, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "exit02", "peerHostname": "edge01", "vrf": "default", "asn": 65000, "peerAsn":
+    65530, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "peerHostname": "spine01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit02", "peerHostname":
+    "edge01", "vrf": "internet-vrf", "asn": 65001, "peerAsn": 65530, "bgp": true,
+    "polled": true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname":
+    "exit01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "exit02",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "internet", "peerHostname": "exit02", "vrf":
+    "default", "asn": 25253, "peerAsn": 65001, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "internet", "peerHostname": "exit01", "vrf": "default",
+    "asn": 25253, "peerAsn": 65001, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "peerHostname": "exit01", "vrf": "default", "asn": 65000,
+    "peerAsn": 65000, "bgp": true, "polled": true}]'
+- command: topology show --afiSafi='l2vpn evpn' --format=json --namespace=ospf-ibgp
+  data-directory: tests/data/parquet/
+  marks: topology show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine02",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine01", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "peerHostname": "spine02", "vrf": "default",
+    "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default", "asn": 65000,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf02", "peerHostname": "spine02", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "peerHostname": "spine01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "exit02", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf03", "vrf": "default",
+    "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 65000,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "peerHostname": "leaf02", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "peerHostname": "spine02", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "peerHostname": "spine01", "vrf": "default",
+    "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "peerHostname": "leaf01", "vrf": "default", "asn": 65000,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "peerHostname": "leaf02", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname":
+    "leaf04", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}]'
+- command: topology show --afiSafi='l2vpn evpn' --format=json --namespace=dual-bgp
+  data-directory: tests/data/parquet/
+  marks: topology show cumulus
+  output: '[]'
+- command: topology show --afiSafi='l2vpn evpn' --format=json --namespace=dual-evpn
+  data-directory: tests/data/parquet/
+  marks: topology show cumulus
+  output: '[{"namespace": "dual-evpn", "hostname": "spine02", "peerHostname": "leaf01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65101, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "spine02", "peerHostname": "leaf02", "vrf":
+    "default", "asn": 65000, "peerAsn": 65102, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "spine02", "peerHostname": "leaf04", "vrf": "default",
+    "asn": 65000, "peerAsn": 65104, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "peerHostname": "exit02", "vrf": "default", "asn": 65000,
+    "peerAsn": 65202, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "spine02", "peerHostname": "leaf03", "vrf": "default", "asn": 65000, "peerAsn":
+    65103, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "spine02",
+    "peerHostname": "exit01", "vrf": "default", "asn": 65000, "peerAsn": 65201, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 65000, "peerAsn": 65102, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "spine01", "peerHostname": "leaf03",
+    "vrf": "default", "asn": 65000, "peerAsn": 65103, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "spine01", "peerHostname": "leaf04", "vrf":
+    "default", "asn": 65000, "peerAsn": 65104, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "spine01", "peerHostname": "exit02", "vrf": "default",
+    "asn": 65000, "peerAsn": 65202, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 65000,
+    "peerAsn": 65201, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "spine01", "peerHostname": "leaf01", "vrf": "default", "asn": 65000, "peerAsn":
+    65101, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "exit01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 65201, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "exit01", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65201, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "exit02", "peerHostname": "spine01",
+    "vrf": "default", "asn": 65202, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "exit02", "peerHostname": "spine02", "vrf":
+    "default", "asn": 65202, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 65103, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "leaf03", "peerHostname": "spine02", "vrf": "default", "asn": 65103,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "leaf01", "peerHostname": "spine02", "vrf": "default", "asn": 65101, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "leaf01",
+    "peerHostname": "spine01", "vrf": "default", "asn": 65101, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "leaf04", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65104, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "leaf04", "peerHostname": "spine02",
+    "vrf": "default", "asn": 65104, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "leaf02", "peerHostname": "spine01", "vrf":
+    "default", "asn": 65102, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "leaf02", "peerHostname": "spine02", "vrf": "default",
+    "asn": 65102, "peerAsn": 65000, "bgp": true, "polled": true}]'
+- command: topology show --afiSafi='ipv4 unicast' --format=json --namespace=dual-evpn
+  data-directory: tests/data/parquet/
+  marks: topology show cumulus
+  output: '[{"namespace": "dual-evpn", "hostname": "edge01", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65530, "peerAsn": 65201, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "edge01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 65530, "peerAsn": 65202, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "spine02", "peerHostname": "leaf02", "vrf": "default",
+    "asn": 65000, "peerAsn": 65102, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default", "asn": 65000,
+    "peerAsn": 65103, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 65000, "peerAsn":
+    65104, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "spine02",
+    "peerHostname": "leaf01", "vrf": "default", "asn": 65000, "peerAsn": 65101, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "spine02", "peerHostname":
+    "exit02", "vrf": "default", "asn": 65000, "peerAsn": 65202, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "spine02", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65201, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "spine01", "peerHostname": "leaf01", "vrf":
+    "default", "asn": 65000, "peerAsn": 65101, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "spine01", "peerHostname": "leaf03", "vrf": "default",
+    "asn": 65000, "peerAsn": 65103, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 65000,
+    "peerAsn": 65104, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "spine01", "peerHostname": "exit02", "vrf": "default", "asn": 65000, "peerAsn":
+    65202, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "spine01",
+    "peerHostname": "exit01", "vrf": "default", "asn": 65000, "peerAsn": 65201, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 65000, "peerAsn": 65102, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "exit01", "peerHostname": "internet",
+    "vrf": "internet-vrf", "asn": 65201, "peerAsn": 25253, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "exit01", "peerHostname": "edge01",
+    "vrf": "internet-vrf", "asn": 65201, "peerAsn": 65530, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "exit01", "peerHostname": "edge01",
+    "vrf": "evpn-vrf", "asn": 65201, "peerAsn": 65530, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "exit01", "peerHostname": "edge01", "vrf":
+    "default", "asn": 65201, "peerAsn": 65530, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "exit01", "peerHostname": "spine02", "vrf": "default",
+    "asn": 65201, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "exit01", "peerHostname": "spine01", "vrf": "default", "asn": 65201,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 65202, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "exit02",
+    "peerHostname": "edge01", "vrf": "default", "asn": 65202, "peerAsn": 65530, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "exit02", "peerHostname":
+    "edge01", "vrf": "evpn-vrf", "asn": 65202, "peerAsn": 65530, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "exit02", "peerHostname": "edge01",
+    "vrf": "internet-vrf", "asn": 65202, "peerAsn": 65530, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "exit02", "peerHostname": "spine02",
+    "vrf": "default", "asn": 65202, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "exit02", "peerHostname": "internet", "vrf":
+    "internet-vrf", "asn": 65202, "peerAsn": 25253, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "leaf03", "peerHostname": "spine02", "vrf":
+    "default", "asn": 65103, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 65103, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "internet", "peerHostname": "exit01", "vrf": "default", "asn": 25253,
+    "peerAsn": 65201, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname":
+    "internet", "peerHostname": "exit02", "vrf": "default", "asn": 25253, "peerAsn":
+    65202, "bgp": true, "polled": true}, {"namespace": "dual-evpn", "hostname": "leaf01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 65101, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "dual-evpn", "hostname": "leaf01", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65101, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "dual-evpn", "hostname": "leaf04", "peerHostname": "spine01",
+    "vrf": "default", "asn": 65104, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "dual-evpn", "hostname": "leaf04", "peerHostname": "spine02", "vrf":
+    "default", "asn": 65104, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "dual-evpn", "hostname": "leaf02", "peerHostname": "spine01", "vrf": "default",
+    "asn": 65102, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "dual-evpn",
+    "hostname": "leaf02", "peerHostname": "spine02", "vrf": "default", "asn": 65102,
+    "peerAsn": 65000, "bgp": true, "polled": true}]'

--- a/tests/integration/sqcmds/eos-samples/bgp.yml
+++ b/tests/integration/sqcmds/eos-samples/bgp.yml
@@ -1182,3 +1182,242 @@ tests:
     "0.65522"}, {"hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
     "state": "Established", "asn": 65534, "peerAsn": 65522, "asndot": "0.65534", "peerAsndot":
     "0.65522"}]'
+- command: bgp show --afiSafi='ipv4 unicast' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show nxos filter
+  output: '[{"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677975569.0, "timestamp": 1623025175569}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp":
+    1623025175569}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 2, "estdTime": 1622920775571.0, "timestamp": 1623025175571},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14",
+    "peerHostname": "leaf04", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677975571.0, "timestamp": 1623025175571}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp":
+    1623025175571}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677975571.0, "timestamp": 1623025175571}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp":
+    1623025175571}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "peer":
+    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1620677975797.0, "timestamp": 1623025175797}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677975797.0, "timestamp":
+    1623025175797}, {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer":
+    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1620677976019.0, "timestamp": 1623025176019}, {"namespace": "eos",
+    "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp":
+    1623025176019}, {"namespace": "eos", "hostname": "exit02", "vrf": "evpn-vrf",
+    "peer": "169.254.253.6", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65521, "peerAsn": 65533, "pfxRx": 7,
+    "pfxTx": 3, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65522, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime":
+    1620677976020.0, "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65520, "peerAsn":
+    65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0,
+    "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp": 1623025176020},
+    {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976020.0, "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn":
+    65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer":
+    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1622920776021.0, "timestamp": 1623025176021}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65522, "peerAsn": 65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime":
+    1622920776021.0, "timestamp": 1623025176021}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65521, "peerAsn":
+    65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    1623025176021}, {"namespace": "eos", "hostname": "exit01", "vrf": "default", "peer":
+    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1622920776021.0, "timestamp": 1623025176021}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "peer": "169.254.254.2", "peerHostname":
+    "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn":
+    65520, "peerAsn": 65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1622920776021.0, "timestamp": 1623025176021}, {"namespace": "eos", "hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0", "peerHostname": "dcedge01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn":
+    65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp":
+    1623025176021}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.13",
+    "peerHostname": "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976023.0, "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 2, "estdTime": 1622920776023.0, "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1620677976023.0, "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "peer":
+    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1620677976024.0, "timestamp": 1623025176024}, {"namespace": "eos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "firewall01", "vrf": "default",
+    "peer": "eth2.4", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65533, "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges":
+    3, "estdTime": 1620677000000.0, "timestamp": 1623025176025}, {"namespace": "eos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.3", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65521, "pfxRx": 3, "pfxTx": 10, "numChanges": 3, "estdTime": 1620677000000.0,
+    "timestamp": 1623025176025}, {"namespace": "eos", "hostname": "firewall01", "vrf":
+    "default", "peer": "eth2.2", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0,
+    "pfxTx": 10, "numChanges": 3, "estdTime": 1620677000000.0, "timestamp": 1623025176025},
+    {"namespace": "eos", "hostname": "firewall01", "vrf": "default", "peer": "eth1.4",
+    "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65533, "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 5, "estdTime":
+    1622918156000.0, "timestamp": 1623025176025}, {"namespace": "eos", "hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521,
+    "pfxRx": 3, "pfxTx": 10, "numChanges": 5, "estdTime": 1622918155000.0, "timestamp":
+    1623025176025}, {"namespace": "eos", "hostname": "firewall01", "vrf": "default",
+    "peer": "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0, "pfxTx": 10, "numChanges":
+    5, "estdTime": 1622918156000.0, "timestamp": 1623025176025}, {"namespace": "eos",
+    "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534,
+    "peerAsn": 65522, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1620676999989.0,
+    "timestamp": 1623025177989}, {"namespace": "eos", "hostname": "dcedge01", "vrf":
+    "default", "peer": "169.254.127.1", "peerHostname": "exit01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65534, "peerAsn": 65522, "pfxRx": 4,
+    "pfxTx": 6, "numChanges": 2, "estdTime": 1622918156989.0, "timestamp": 1623025177989}]'
+- command: bgp show --afiSafi='l2vpn evpn' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show eos filter
+  output: '[{"namespace": "eos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1620677975569.0, "timestamp": 1623025175569}, {"namespace": "eos", "hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677975569.0, "timestamp":
+    1623025175569}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
+    42, "numChanges": 2, "estdTime": 1622920775571.0, "timestamp": 1623025175571},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.14",
+    "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime":
+    1620677975571.0, "timestamp": 1623025175571}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp":
+    1623025175571}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    44, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp": 1623025175571},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 1, "estdTime":
+    1620677975571.0, "timestamp": 1623025175571}, {"namespace": "eos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677975571.0, "timestamp":
+    1623025175571}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "peer":
+    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1620677975797.0, "timestamp": 1623025175797}, {"namespace": "eos",
+    "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677975797.0,
+    "timestamp": 1623025175797}, {"namespace": "eos", "hostname": "leaf04", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1620677976019.0, "timestamp": 1623025176019},
+    {"namespace": "eos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1620677976019.0, "timestamp": 1623025176019}, {"namespace": "eos", "hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1620677976020.0, "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "vrf": "default", "peer":
+    "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx": 10, "numChanges":
+    1, "estdTime": 1620677976020.0, "timestamp": 1623025176020}, {"namespace": "eos",
+    "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1622920776021.0,
+    "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01", "vrf":
+    "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
+    10, "numChanges": 1, "estdTime": 1622920776021.0, "timestamp": 1623025176021},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+    "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime":
+    1620677976023.0, "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31",
+    "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 2, "estdTime":
+    1622920776023.0, "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.32", "peerHostname": "exit02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
+    42, "numChanges": 1, "estdTime": 1620677976023.0, "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1620677976024.0, "timestamp": 1623025176024}, {"namespace": "eos", "hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 44, "pfxTx": 8, "numChanges": 1, "estdTime": 1620677976024.0, "timestamp":
+    1623025176024}]'

--- a/tests/integration/sqcmds/eos-samples/topology.yml
+++ b/tests/integration/sqcmds/eos-samples/topology.yml
@@ -1237,7 +1237,7 @@ tests:
 - command: topology unique --vrf='default' --format=json --namespace=eos --columns=area
   data-directory: tests/data/parquet/
   marks: topology unique eos
-  output: '[{"area": ""}, {"area": "0.0.0.0"}]'
+  output: '[{"area": "0.0.0.0"}]'
 - command: topology unique --vrf='evpn-vrf' --format=json --namespace=eos --columns=asn
   data-directory: tests/data/parquet/
   marks: topology unique eos
@@ -1295,93 +1295,58 @@ tests:
 - command: topology show --area=0.0.0.0 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: topology show eos
-  output: '[{"namespace": "eos", "hostname": "leaf01", "peerHostname": "spine02",
-    "ifname": "Ethernet2", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "eos", "hostname": "leaf01", "peerHostname":
-    "spine01", "ifname": "Ethernet1", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
-    "peerHostname": "spine01", "ifname": "Ethernet1", "vrf": "default", "lldp": true,
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname":
-    "leaf02", "peerHostname": "spine02", "ifname": "Ethernet2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos",
-    "hostname": "spine01", "peerHostname": "leaf01", "ifname": "Ethernet1", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "eos", "hostname": "spine01", "peerHostname": "leaf03", "ifname": "Ethernet3",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
+  output: '[{"namespace": "eos", "hostname": "spine01", "peerHostname": "leaf01",
+    "ifname": "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "leaf03", "ifname":
+    "Ethernet3", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
     {"namespace": "eos", "hostname": "spine01", "peerHostname": "leaf02", "ifname":
-    "Ethernet2", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "leaf04",
-    "ifname": "Ethernet4", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
-    "exit01", "ifname": "Ethernet5", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
-    "peerHostname": "exit02", "ifname": "Ethernet6", "vrf": "default", "lldp": true,
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname":
-    "leaf03", "peerHostname": "spine02", "ifname": "Ethernet2", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos",
-    "hostname": "leaf03", "peerHostname": "spine01", "ifname": "Ethernet1", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "eos", "hostname": "spine02", "peerHostname": "leaf02", "ifname": "Ethernet2",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit02", "ifname":
+    "Ethernet6", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine01", "peerHostname": "leaf04", "ifname":
+    "Ethernet4", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit01", "ifname":
+    "Ethernet5", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf02", "peerHostname": "spine02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf02", "peerHostname": "spine01", "ifname":
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "ifname":
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
     {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf03", "ifname":
-    "Ethernet3", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf01",
-    "ifname": "Ethernet1", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
-    "exit02", "ifname": "Ethernet6", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
-    "peerHostname": "exit01", "ifname": "Ethernet5", "vrf": "default", "lldp": true,
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname":
-    "spine02", "peerHostname": "leaf04", "ifname": "Ethernet4", "vrf": "default",
-    "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0,
-    "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos",
-    "hostname": "exit02", "peerHostname": "spine01", "ifname": "Ethernet1", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "eos", "hostname": "exit02", "peerHostname": "spine02", "ifname": "Ethernet2",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
+    "Ethernet3", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf01", "ifname":
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "exit02", "ifname":
+    "Ethernet6", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "exit01", "ifname":
+    "Ethernet5", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf04", "ifname":
+    "Ethernet4", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "exit02", "peerHostname": "spine01", "ifname":
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "exit02", "peerHostname": "spine02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
     {"namespace": "eos", "hostname": "exit01", "peerHostname": "spine01", "ifname":
-    "Ethernet1", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname": "spine02",
-    "ifname": "Ethernet2", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
-    "spine01", "ifname": "Ethernet1", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "eos", "hostname": "leaf04",
-    "peerHostname": "spine02", "ifname": "Ethernet2", "vrf": "default", "lldp": true,
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}]'
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "exit01", "peerHostname": "spine02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf01", "peerHostname": "spine01", "ifname":
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf01", "peerHostname": "spine02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "ifname":
+    "Ethernet1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine02", "ifname":
+    "Ethernet2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled": true}]'
 - command: topology summarize --area=0.0.0.0 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: topology show eos
-  output: '{"eos": {"arpnd_center": ["spine02", "spine01"], "arpnd_degree_histogram":
-    "...", "arpnd_is_fully_connected": true, "arpnd_number_of_disjoint_sets": 1, "arpnd_number_of_edges":
-    12, "arpnd_number_of_nodes": 8, "arpnd_self_loops": [], "bgp_center": ["spine02",
-    "spine01"], "bgp_degree_histogram": "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets":
-    1, "bgp_number_of_edges": 12, "bgp_number_of_nodes": 8, "bgp_self_loops": [],
-    "lldp_center": ["spine02", "spine01"], "lldp_degree_histogram": "...", "lldp_is_fully_connected":
-    true, "lldp_number_of_disjoint_sets": 1, "lldp_number_of_edges": 12, "lldp_number_of_nodes":
-    8, "lldp_self_loops": [], "ospf_center": ["spine02", "spine01"], "ospf_degree_histogram":
+  output: '{"eos": {"ospf_center": ["spine01", "spine02"], "ospf_degree_histogram":
     "...", "ospf_is_fully_connected": true, "ospf_number_of_disjoint_sets": 1, "ospf_number_of_edges":
     12, "ospf_number_of_nodes": 8, "ospf_self_loops": []}}'
 - command: topology show --via=ospf --area=0.0.0.1 --format=json --namespace=eos
@@ -1394,3 +1359,127 @@ tests:
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
     {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
     "spine01"}, {"hostname": "spine02"}]'
+- command: topology show --afiSafi='ipv4 unicast' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: topology show eos
+  output: '[{"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine01", "peerHostname": "leaf02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf02", "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
+    "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit02", "peerHostname": "firewall01", "vrf": "evpn-vrf",
+    "asn": 65521, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "exit02", "peerHostname": "dcedge01", "vrf": "internet-vrf", "asn":
+    65522, "peerAsn": 65534, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit02", "peerHostname": "firewall01", "vrf": "default", "asn": 65520, "peerAsn":
+    65533, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "exit02", "peerHostname":
+    "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "exit02", "peerHostname": "firewall01",
+    "vrf": "internet-vrf", "asn": 65522, "peerAsn": 65533, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "exit01", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit01", "peerHostname": "firewall01", "vrf": "internet-vrf",
+    "asn": 65522, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "exit01", "peerHostname": "firewall01", "vrf": "evpn-vrf", "asn":
+    65521, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit01", "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01",
+    "peerHostname": "firewall01", "vrf": "default", "asn": 65520, "peerAsn": 65533,
+    "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname":
+    "dcedge01", "vrf": "internet-vrf", "asn": 65522, "peerAsn": 65534, "bgp": true,
+    "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine02", "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
+    "peerHostname": "exit02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf01", "peerHostname": "spine02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "leaf01", "peerHostname": "spine01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "firewall01", "peerHostname": "exit02", "vrf": "default", "asn": 65533, "peerAsn":
+    65522, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "firewall01",
+    "peerHostname": "exit02", "vrf": "default", "asn": 65533, "peerAsn": 65521, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "firewall01", "peerHostname":
+    "exit02", "vrf": "default", "asn": 65533, "peerAsn": 65520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "firewall01", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65533, "peerAsn": 65522, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "firewall01", "peerHostname": "exit01", "vrf":
+    "default", "asn": 65533, "peerAsn": 65521, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "firewall01", "peerHostname": "exit01", "vrf": "default", "asn":
+    65533, "peerAsn": 65520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "dcedge01", "peerHostname": "exit02", "vrf": "default", "asn": 65534, "peerAsn":
+    65522, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "dcedge01",
+    "peerHostname": "exit01", "vrf": "default", "asn": 65534, "peerAsn": 65522, "bgp":
+    true, "polled": true}]'
+- command: topology show --afiSafi='l2vpn evpn' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: topology show eos
+  output: '[{"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine01", "peerHostname": "leaf01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit02", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname":
+    "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
+    "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "leaf01", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf01", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}]'

--- a/tests/integration/sqcmds/junos-samples/bgp.yml
+++ b/tests/integration/sqcmds/junos-samples/bgp.yml
@@ -422,3 +422,127 @@ tests:
     "0.64520"}, {"hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "state":
     "Established", "asn": 64520, "peerAsn": 64520, "asndot": "0.64520", "peerAsndot":
     "0.64520"}]'
+- command: bgp show --afiSafi='ipv4 unicast' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show junos filter
+  output: '[{"namespace": "junos", "hostname": "firewall01", "vrf": "default", "peer":
+    "eth1.3", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65533, "peerAsn": 64520, "pfxRx": 3, "pfxTx": 9, "numChanges":
+    1, "estdTime": 1622998918000.0, "timestamp": 1623025795301}, {"namespace": "junos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 64520, "pfxRx": 5, "pfxTx": 9, "numChanges": 1, "estdTime": 1622999486000.0,
+    "timestamp": 1623025795301}, {"namespace": "junos", "hostname": "firewall01",
+    "vrf": "default", "peer": "eth2.3", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 9, "numChanges": 1, "estdTime": 1622999478000.0, "timestamp": 1623025795301},
+    {"namespace": "junos", "hostname": "firewall01", "vrf": "default", "peer": "eth2.2",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65533, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 9, "numChanges": 1, "estdTime":
+    1622999471000.0, "timestamp": 1623025795301}, {"namespace": "junos", "hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.4", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 64520,
+    "pfxRx": 5, "pfxTx": 9, "numChanges": 1, "estdTime": 1622998918000.0, "timestamp":
+    1623025795301}, {"namespace": "junos", "hostname": "firewall01", "vrf": "default",
+    "peer": "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65533, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 9, "numChanges":
+    1, "estdTime": 1622998918000.0, "timestamp": 1623025795301}, {"namespace": "junos",
+    "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534,
+    "peerAsn": 64520, "pfxRx": 3, "pfxTx": 6, "numChanges": 0, "estdTime": 1622999270026.0,
+    "timestamp": 1623025798026}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "peer": "169.254.254.2", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 0, "estdTime": 1622998918026.0, "timestamp": 1623025798026},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 65533, "pfxRx": 9, "pfxTx": 5, "numChanges": 0, "estdTime":
+    1622998919026.0, "timestamp": 1623025798026}, {"namespace": "junos", "hostname":
+    "exit01", "vrf": "evpn-vrf", "peer": "169.254.254.6", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 0, "pfxTx": 3, "numChanges": 0, "estdTime": 1622998918026.0, "timestamp":
+    1623025798026}, {"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf",
+    "peer": "169.254.127.0", "peerHostname": "dcedge01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx":
+    3, "numChanges": 0, "estdTime": 1622999270026.0, "timestamp": 1623025798026},
+    {"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.3",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65534, "peerAsn": 64520, "pfxRx": 3, "pfxTx": 6, "numChanges": 0, "estdTime":
+    1622999494026.0, "timestamp": 1623025798026}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 0, "estdTime": 1622999478028.0, "timestamp":
+    1623025798028}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "peer": "169.254.253.2", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 0, "estdTime": 1622999470028.0, "timestamp": 1623025798028},
+    {"namespace": "junos", "hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.127.2",
+    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 3, "numChanges": 0, "estdTime":
+    1622999494028.0, "timestamp": 1623025798028}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 9, "pfxTx": 5, "numChanges": 0, "estdTime": 1622999486028.0, "timestamp":
+    1623025798028}]'
+- command: bgp show --afiSafi='l2vpn evpn' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show junos filter
+  output: '[{"namespace": "junos", "hostname": "leaf01", "vrf": "default", "peer":
+    "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx": 0, "numChanges":
+    0, "estdTime": 1622998781432.0, "timestamp": 1623025797432}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn":
+    64520, "pfxRx": 12, "pfxTx": 0, "numChanges": 0, "estdTime": 1622998775432.0,
+    "timestamp": 1623025797432}, {"namespace": "junos", "hostname": "leaf02", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx":
+    0, "numChanges": 0, "estdTime": 1622998778434.0, "timestamp": 1623025797434},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx": 0, "numChanges": 0, "estdTime":
+    1622998778434.0, "timestamp": 1623025797434}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.32", "peerHostname": "exit02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 2, "pfxTx": 24, "numChanges": 137, "estdTime": 1623025778800.0, "timestamp":
+    1623025797800}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 2, "pfxTx":
+    24, "numChanges": 216, "estdTime": 1623025762800.0, "timestamp": 1623025797800},
+    {"namespace": "junos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.12",
+    "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx": 15, "numChanges": 0, "estdTime":
+    1622998778800.0, "timestamp": 1623025797800}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 11, "pfxTx": 15, "numChanges": 0, "estdTime": 1622998774800.0, "timestamp":
+    1623025797800}, {"namespace": "junos", "hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 12, "pfxTx":
+    0, "numChanges": 168, "estdTime": 1623021267026.0, "timestamp": 1623025798026},
+    {"namespace": "junos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 216, "estdTime":
+    1623025762026.0, "timestamp": 1623025798026}, {"namespace": "junos", "hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 281, "estdTime": 1623025725028.0, "timestamp":
+    1623025798028}, {"namespace": "junos", "hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 137, "estdTime": 1623025778028.0, "timestamp": 1623025798028},
+    {"namespace": "junos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+    "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx": 15, "numChanges": 0, "estdTime":
+    1622998778030.0, "timestamp": 1623025798030}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 2, "pfxTx": 24, "numChanges": 168, "estdTime": 1623021266030.0, "timestamp":
+    1623025798030}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 11, "pfxTx":
+    15, "numChanges": 0, "estdTime": 1622998781030.0, "timestamp": 1623025798030},
+    {"namespace": "junos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 2, "pfxTx": 24, "numChanges": 282, "estdTime":
+    1623025725030.0, "timestamp": 1623025798030}]'

--- a/tests/integration/sqcmds/junos-samples/topology.yml
+++ b/tests/integration/sqcmds/junos-samples/topology.yml
@@ -892,7 +892,7 @@ tests:
 - command: topology unique --vrf='default' --format=json --namespace=junos --columns=area
   data-directory: tests/data/parquet/
   marks: topology unique junos
-  output: '[{"area": ""}, {"area": "0.0.0.0"}]'
+  output: '[{"area": "0.0.0.0"}]'
 - command: topology unique --vrf='evpn-vrf' --format=json --namespace=junos --columns=asn
   data-directory: tests/data/parquet/
   marks: topology unique junos
@@ -951,72 +951,45 @@ tests:
 - command: topology show --area=0.0.0.0 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology show junos
-  output: '[{"namespace": "junos", "hostname": "spine01", "peerHostname": "leaf01",
-    "ifname": "xe-0/0/0.0", "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "junos", "hostname": "spine01", "peerHostname":
-    "exit01", "ifname": "xe-0/0/2.0", "vrf": "default", "lldp": "", "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "junos", "hostname": "spine01",
-    "peerHostname": "leaf02", "ifname": "xe-0/0/1.0", "vrf": "default", "lldp": "",
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "junos",
-    "hostname": "spine01", "peerHostname": "exit02", "ifname": "xe-0/0/3.0", "vrf":
-    "default", "lldp": "", "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "junos", "hostname": "exit01", "peerHostname": "spine01", "ifname": "xe-0/0/0.0",
-    "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "junos", "hostname": "exit01", "peerHostname": "spine02", "ifname":
-    "xe-0/0/1.0", "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "junos", "hostname": "spine02", "peerHostname":
-    "leaf01", "ifname": "xe-0/0/0.0", "vrf": "default", "lldp": "", "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "junos", "hostname": "spine02",
-    "peerHostname": "leaf02", "ifname": "xe-0/0/1.0", "vrf": "default", "lldp": "",
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "junos",
-    "hostname": "spine02", "peerHostname": "exit02", "ifname": "xe-0/0/3.0", "vrf":
-    "default", "lldp": "", "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "junos", "hostname": "spine02", "peerHostname": "exit01", "ifname": "xe-0/0/2.0",
-    "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "junos", "hostname": "leaf01", "peerHostname": "spine02", "ifname":
-    "xe-0/0/1.0", "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "junos", "hostname": "leaf01", "peerHostname":
-    "spine01", "ifname": "xe-0/0/0.0", "vrf": "default", "lldp": "", "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "junos", "hostname": "leaf02",
-    "peerHostname": "spine01", "ifname": "xe-0/0/0.0", "vrf": "default", "lldp": "",
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "junos",
-    "hostname": "leaf02", "peerHostname": "spine02", "ifname": "xe-0/0/1.0", "vrf":
-    "default", "lldp": "", "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "junos", "hostname": "exit02", "peerHostname": "spine02", "ifname": "xe-0/0/1.0",
-    "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "junos", "hostname": "exit02", "peerHostname": "spine01", "ifname":
-    "xe-0/0/0.0", "vrf": "default", "lldp": "", "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}]'
+  output: '[{"namespace": "junos", "hostname": "leaf02", "peerHostname": "spine01",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "leaf02", "peerHostname": "spine02",
+    "ifname": "xe-0/0/1.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine01", "peerHostname": "exit02",
+    "ifname": "xe-0/0/3.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine01", "peerHostname": "exit01",
+    "ifname": "xe-0/0/2.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine01", "peerHostname": "leaf02",
+    "ifname": "xe-0/0/1.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine01", "peerHostname": "leaf01",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "exit01", "peerHostname": "spine02",
+    "ifname": "xe-0/0/1.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "exit01", "peerHostname": "spine01",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "leaf01", "peerHostname": "spine01",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "leaf01", "peerHostname": "spine02",
+    "ifname": "xe-0/0/1.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "exit02", "peerHostname": "spine02",
+    "ifname": "xe-0/0/1.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "exit02", "peerHostname": "spine01",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine02", "peerHostname": "exit01",
+    "ifname": "xe-0/0/2.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine02", "peerHostname": "leaf01",
+    "ifname": "xe-0/0/0.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine02", "peerHostname": "leaf02",
+    "ifname": "xe-0/0/1.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine02", "peerHostname": "exit02",
+    "ifname": "xe-0/0/3.0", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}]'
 - command: topology summarize --area=0.0.0.0 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology show junos
-  output: '{"junos": {"arpnd_center": ["spine01", "spine02"], "arpnd_degree_histogram":
-    [0, 0, 4, 0, 2], "arpnd_is_fully_connected": true, "arpnd_number_of_disjoint_sets":
-    1, "arpnd_number_of_edges": 8, "arpnd_number_of_nodes": 6, "arpnd_self_loops":
-    [], "bgp_center": ["spine01", "spine02"], "bgp_degree_histogram": [0, 0, 4, 0,
-    2], "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
-    8, "bgp_number_of_nodes": 6, "bgp_self_loops": [], "lldp_center": null, "lldp_degree_histogram":
-    null, "lldp_is_fully_connected": null, "lldp_number_of_disjoint_sets": null, "lldp_number_of_edges":
-    null, "lldp_number_of_nodes": null, "lldp_self_loops": null, "ospf_center": ["spine01",
-    "spine02"], "ospf_degree_histogram": [0, 0, 4, 0, 2], "ospf_is_fully_connected":
-    true, "ospf_number_of_disjoint_sets": 1, "ospf_number_of_edges": 8, "ospf_number_of_nodes":
-    6, "ospf_self_loops": []}}'
+  output: '{"junos": {"ospf_center": ["spine01", "spine02"], "ospf_degree_histogram":
+    [0, 0, 4, 0, 2], "ospf_is_fully_connected": true, "ospf_number_of_disjoint_sets":
+    1, "ospf_number_of_edges": 8, "ospf_number_of_nodes": 6, "ospf_self_loops": []}}'
 - command: topology show --via=ospf --area=0.0.0.1 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology show junos
@@ -1026,3 +999,127 @@ tests:
   marks: topology show junos
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
     {"hostname": "leaf02"}, {"hostname": "spine01"}, {"hostname": "spine02"}]'
+- command: topology show --afiSafi='ipv4 unicast' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: topology show eos
+  output: '[{"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine01", "peerHostname": "leaf02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf02", "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
+    "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit02", "peerHostname": "firewall01", "vrf": "evpn-vrf",
+    "asn": 65521, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "exit02", "peerHostname": "dcedge01", "vrf": "internet-vrf", "asn":
+    65522, "peerAsn": 65534, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit02", "peerHostname": "firewall01", "vrf": "default", "asn": 65520, "peerAsn":
+    65533, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "exit02", "peerHostname":
+    "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "exit02", "peerHostname": "firewall01",
+    "vrf": "internet-vrf", "asn": 65522, "peerAsn": 65533, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "exit01", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit01", "peerHostname": "firewall01", "vrf": "internet-vrf",
+    "asn": 65522, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "exit01", "peerHostname": "firewall01", "vrf": "evpn-vrf", "asn":
+    65521, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit01", "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01",
+    "peerHostname": "firewall01", "vrf": "default", "asn": 65520, "peerAsn": 65533,
+    "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname":
+    "dcedge01", "vrf": "internet-vrf", "asn": 65522, "peerAsn": 65534, "bgp": true,
+    "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine02", "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
+    "peerHostname": "exit02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf01", "peerHostname": "spine02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "leaf01", "peerHostname": "spine01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "firewall01", "peerHostname": "exit02", "vrf": "default", "asn": 65533, "peerAsn":
+    65522, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "firewall01",
+    "peerHostname": "exit02", "vrf": "default", "asn": 65533, "peerAsn": 65521, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "firewall01", "peerHostname":
+    "exit02", "vrf": "default", "asn": 65533, "peerAsn": 65520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "firewall01", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65533, "peerAsn": 65522, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "firewall01", "peerHostname": "exit01", "vrf":
+    "default", "asn": 65533, "peerAsn": 65521, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "firewall01", "peerHostname": "exit01", "vrf": "default", "asn":
+    65533, "peerAsn": 65520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "dcedge01", "peerHostname": "exit02", "vrf": "default", "asn": 65534, "peerAsn":
+    65522, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "dcedge01",
+    "peerHostname": "exit01", "vrf": "default", "asn": 65534, "peerAsn": 65522, "bgp":
+    true, "polled": true}]'
+- command: topology show --afiSafi='l2vpn evpn' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: topology show eos
+  output: '[{"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine01", "peerHostname": "leaf01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit02", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname":
+    "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
+    "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "leaf01", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf01", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}]'

--- a/tests/integration/sqcmds/nxos-samples/bgp.yml
+++ b/tests/integration/sqcmds/nxos-samples/bgp.yml
@@ -876,3 +876,244 @@ tests:
     "0.64520"}, {"hostname": "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10",
     "state": "Established", "asn": 64520, "peerAsn": 65533, "asndot": "0.64520", "peerAsndot":
     "0.65533"}]'
+- command: bgp show --afiSafi='ipv4 unicast' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show nxos filter
+  output: '[{"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "peer":
+    "eth2.2", "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi":
+    "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0, "pfxTx": 10, "numChanges":
+    5, "estdTime": 1619110453000.0, "timestamp": 1619275256921}, {"namespace": "nxos",
+    "hostname": "firewall01", "vrf": "default", "peer": "eth2.4", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533,
+    "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 5, "estdTime": 1619110466000.0,
+    "timestamp": 1619275256921}, {"namespace": "nxos", "hostname": "firewall01", "vrf":
+    "default", "peer": "eth2.3", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521, "pfxRx": 3,
+    "pfxTx": 10, "numChanges": 5, "estdTime": 1619110462000.0, "timestamp": 1619275256921},
+    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "peer": "eth1.4",
+    "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65533, "peerAsn": 65522, "pfxRx": 6, "pfxTx": 10, "numChanges": 7, "estdTime":
+    1619117517000.0, "timestamp": 1619275256921}, {"namespace": "nxos", "hostname":
+    "firewall01", "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65533, "peerAsn": 65521,
+    "pfxRx": 3, "pfxTx": 10, "numChanges": 15, "estdTime": 1619110462000.0, "timestamp":
+    1619275256921}, {"namespace": "nxos", "hostname": "firewall01", "vrf": "default",
+    "peer": "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
+    "safi": "unicast", "asn": 65533, "peerAsn": 65520, "pfxRx": 0, "pfxTx": 10, "numChanges":
+    5, "estdTime": 1619110455000.0, "timestamp": 1619275256921}, {"namespace": "nxos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32", "peerHostname":
+    "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 10, "pfxTx": 0, "numChanges": 3, "estdTime": 1619110444329.0,
+    "timestamp": 1619275258329}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 3, "estdTime": 1619044327329.0, "timestamp": 1619275258329},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12",
+    "peerHostname": "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime":
+    1619044327329.0, "timestamp": 1619275258329}, {"namespace": "nxos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp":
+    1619275258329}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
+    0, "numChanges": 3, "estdTime": 1619110443329.0, "timestamp": 1619275258329},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.14",
+    "peerHostname": "leaf04", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime":
+    1619044328329.0, "timestamp": 1619275258329}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1619044328347.0, "timestamp":
+    1619275258347}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1619044326347.0, "timestamp": 1619275258347},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1619044326542.0, "timestamp": 1619275258542}, {"namespace": "nxos", "hostname":
+    "leaf01", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1619044326542.0, "timestamp":
+    1619275258542}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    10, "numChanges": 1, "estdTime": 1619110439986.0, "timestamp": 1619275258986},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 10, "numChanges": 1, "estdTime":
+    1619110442986.0, "timestamp": 1619275258986}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "peer": "169.254.254.2", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1619110460986.0,
+    "timestamp": 1619275258986}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "evpn-vrf", "peer": "169.254.254.6", "peerHostname": "firewall01", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65533, "pfxRx": 7,
+    "pfxTx": 3, "numChanges": 1, "estdTime": 1619110468986.0, "timestamp": 1619275258986},
+    {"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.127.0",
+    "peerHostname": "dcedge01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx": 4, "numChanges": 1, "estdTime":
+    1619116288986.0, "timestamp": 1619275258986}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 3, "estdTime": 1619117522986.0, "timestamp":
+    1619275258986}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 0, "numChanges": 3, "estdTime":
+    1619110441180.0, "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 10, "pfxTx": 0, "numChanges": 3, "estdTime": 1619110440180.0, "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 3, "estdTime": 1619044325180.0, "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "dcedge01", "vrf": "default", "peer": "169.254.127.1",
+    "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 65534, "peerAsn": 65522, "pfxRx": 4, "pfxTx": 6, "numChanges": 0, "estdTime":
+    1619116284180.0, "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.11", "peerHostname": "leaf01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "vrf": "default",
+    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 1, "estdTime": 1619044329180.0, "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1619044325180.0, "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "dcedge01", "vrf": "default", "peer": "169.254.127.3", "peerHostname": "exit02",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65534, "peerAsn":
+    65522, "pfxRx": 4, "pfxTx": 6, "numChanges": 0, "estdTime": 1619116288180.0, "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.12", "peerHostname": "leaf02", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx":
+    0, "numChanges": 3, "estdTime": 1619044326180.0, "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1619044328186.0, "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1619044326186.0, "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "exit02", "vrf": "internet-vrf",
+    "peer": "169.254.127.2", "peerHostname": "dcedge01", "state": "Established", "afi":
+    "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 65534, "pfxRx": 6, "pfxTx":
+    4, "numChanges": 1, "estdTime": 1619116293384.0, "timestamp": 1619275259384},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "evpn-vrf", "peer": "169.254.253.6",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 65533, "pfxRx": 7, "pfxTx": 3, "numChanges": 1, "estdTime":
+    1619110469384.0, "timestamp": 1619275259384}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "peer": "169.254.253.2", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1619110459384.0,
+    "timestamp": 1619275259384}, {"namespace": "nxos", "hostname": "exit02", "vrf":
+    "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 10, "numChanges": 1, "estdTime": 1619110444384.0, "timestamp": 1619275259384},
+    {"namespace": "nxos", "hostname": "exit02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 10, "numChanges": 1, "estdTime":
+    1619110441384.0, "timestamp": 1619275259384}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "internet-vrf", "peer": "169.254.253.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn":
+    65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1619110472384.0, "timestamp":
+    1619275259384}]'
+- command: bgp show --afiSafi='l2vpn evpn' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: bgp show nxos filter
+  output: '[{"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer":
+    "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges":
+    3, "estdTime": 1619044327329.0, "timestamp": 1619275258329}, {"namespace": "nxos",
+    "hostname": "spine02", "vrf": "default", "peer": "10.0.0.12", "peerHostname":
+    "leaf02", "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520,
+    "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044327329.0,
+    "timestamp": 1619275258329}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "peer": "10.0.0.13", "peerHostname": "leaf03", "state": "Established",
+    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    44, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp": 1619275258329},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 3, "estdTime":
+    1619110444329.0, "timestamp": 1619275258329}, {"namespace": "nxos", "hostname":
+    "spine02", "vrf": "default", "peer": "10.0.0.14", "peerHostname": "leaf04", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044328329.0, "timestamp":
+    1619275258329}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
+    "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
+    42, "numChanges": 3, "estdTime": 1619110443329.0, "timestamp": 1619275258329},
+    {"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1619044328347.0, "timestamp": 1619275258347}, {"namespace": "nxos", "hostname":
+    "leaf03", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime": 1619044326347.0, "timestamp":
+    1619275258347}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "default",
+    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1619044326542.0, "timestamp": 1619275258542},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1619044326542.0, "timestamp": 1619275258542}, {"namespace": "nxos", "hostname":
+    "exit01", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110442986.0, "timestamp":
+    1619275258986}, {"namespace": "nxos", "hostname": "exit01", "vrf": "default",
+    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
+    10, "numChanges": 1, "estdTime": 1619110439986.0, "timestamp": 1619275258986},
+    {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.32",
+    "peerHostname": "exit02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges": 3, "estdTime":
+    1619110441180.0, "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 10, "pfxTx": 42, "numChanges": 3, "estdTime": 1619110440180.0, "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.14", "peerHostname": "leaf04", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    44, "numChanges": 3, "estdTime": 1619044325180.0, "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "spine01", "vrf": "default", "peer": "10.0.0.13",
+    "peerHostname": "leaf03", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime":
+    1619044327180.0, "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "vrf": "default", "peer": "10.0.0.12", "peerHostname": "leaf02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 8, "pfxTx": 44, "numChanges": 3, "estdTime": 1619044326180.0, "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "spine01", "vrf": "default",
+    "peer": "10.0.0.11", "peerHostname": "leaf01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 8, "pfxTx":
+    44, "numChanges": 3, "estdTime": 1619044327180.0, "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "vrf": "default", "peer": "10.0.0.22",
+    "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1619044329180.0, "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "vrf": "default", "peer": "10.0.0.21", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime": 1619044325180.0, "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "vrf": "default",
+    "peer": "10.0.0.22", "peerHostname": "spine02", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx":
+    8, "numChanges": 1, "estdTime": 1619044328186.0, "timestamp": 1619275259186},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "default", "peer": "10.0.0.21",
+    "peerHostname": "spine01", "state": "Established", "afi": "l2vpn", "safi": "evpn",
+    "asn": 64520, "peerAsn": 64520, "pfxRx": 36, "pfxTx": 8, "numChanges": 1, "estdTime":
+    1619044326186.0, "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "exit02", "vrf": "default", "peer": "10.0.0.22", "peerHostname": "spine02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520,
+    "pfxRx": 42, "pfxTx": 10, "numChanges": 1, "estdTime": 1619110444384.0, "timestamp":
+    1619275259384}, {"namespace": "nxos", "hostname": "exit02", "vrf": "default",
+    "peer": "10.0.0.21", "peerHostname": "spine01", "state": "Established", "afi":
+    "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 42, "pfxTx":
+    10, "numChanges": 1, "estdTime": 1619110441384.0, "timestamp": 1619275259384}]'

--- a/tests/integration/sqcmds/nxos-samples/topology.yml
+++ b/tests/integration/sqcmds/nxos-samples/topology.yml
@@ -1240,7 +1240,7 @@ tests:
 - command: topology unique --vrf='default' --format=json --namespace=nxos --columns=area
   data-directory: tests/data/parquet/
   marks: topology unique nxos
-  output: '[{"area": ""}, {"area": "0.0.0.0"}]'
+  output: '[{"area": "0.0.0.0"}]'
 - command: topology unique --vrf='evpn-vrf' --format=json --namespace=nxos --columns=asn
   data-directory: tests/data/parquet/
   marks: topology unique nxos
@@ -1299,94 +1299,59 @@ tests:
 - command: topology show --area=0.0.0.0 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: topology show nxos
-  output: '[{"namespace": "nxos", "hostname": "spine02", "peerHostname": "exit02",
-    "ifname": "Ethernet1/6", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname":
-    "leaf04", "ifname": "Ethernet1/4", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos", "hostname": "spine02",
-    "peerHostname": "leaf03", "ifname": "Ethernet1/3", "vrf": "default", "lldp": true,
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos",
-    "hostname": "spine02", "peerHostname": "leaf02", "ifname": "Ethernet1/2", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "nxos", "hostname": "spine02", "peerHostname": "leaf01", "ifname": "Ethernet1/1",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "nxos", "hostname": "spine02", "peerHostname": "exit01", "ifname":
-    "Ethernet1/5", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "nxos", "hostname": "exit02", "peerHostname": "spine02",
-    "ifname": "Ethernet1/2", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "nxos", "hostname": "exit02", "peerHostname":
-    "spine01", "ifname": "Ethernet1/1", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos", "hostname": "leaf01",
-    "peerHostname": "spine01", "ifname": "Ethernet1/1", "vrf": "default", "lldp":
-    true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos",
-    "hostname": "leaf01", "peerHostname": "spine02", "ifname": "Ethernet1/2", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "nxos", "hostname": "leaf04", "peerHostname": "spine02", "ifname": "Ethernet1/2",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "nxos", "hostname": "leaf04", "peerHostname": "spine01", "ifname":
-    "Ethernet1/1", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname": "spine01",
-    "ifname": "Ethernet1/1", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd":
-    true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf":
-    true, "polled": true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname":
-    "spine02", "ifname": "Ethernet1/2", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos", "hostname": "leaf02",
-    "peerHostname": "spine02", "ifname": "Ethernet1/2", "vrf": "default", "lldp":
-    true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos",
-    "hostname": "leaf02", "peerHostname": "spine01", "ifname": "Ethernet1/1", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "nxos", "hostname": "leaf03", "peerHostname": "spine01", "ifname": "Ethernet1/1",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "nxos", "hostname": "leaf03", "peerHostname": "spine02", "ifname":
-    "Ethernet1/2", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname":
-    "leaf04", "ifname": "Ethernet1/4", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos", "hostname": "spine01",
-    "peerHostname": "exit01", "ifname": "Ethernet1/5", "vrf": "default", "lldp": true,
-    "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp":
-    true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace": "nxos",
-    "hostname": "spine01", "peerHostname": "exit02", "ifname": "Ethernet1/6", "vrf":
-    "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0, "peerAsn":
-    64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true}, {"namespace":
-    "nxos", "hostname": "spine01", "peerHostname": "leaf02", "ifname": "Ethernet1/2",
-    "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true, "asn": 64520.0,
-    "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true, "polled": true},
-    {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf01", "ifname":
-    "Ethernet1/1", "vrf": "default", "lldp": true, "arpndBidir": true, "arpnd": true,
-    "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area": "0.0.0.0", "ospf": true,
-    "polled": true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname":
-    "leaf03", "ifname": "Ethernet1/3", "vrf": "default", "lldp": true, "arpndBidir":
-    true, "arpnd": true, "asn": 64520.0, "peerAsn": 64520.0, "bgp": true, "area":
-    "0.0.0.0", "ospf": true, "polled": true}]'
+  output: '[{"namespace": "nxos", "hostname": "leaf03", "peerHostname": "spine02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf03", "peerHostname": "spine01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "exit02",
+    "ifname": "Ethernet1/6", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "exit01",
+    "ifname": "Ethernet1/5", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "leaf04",
+    "ifname": "Ethernet1/4", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "leaf03",
+    "ifname": "Ethernet1/3", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "leaf02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "leaf01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname": "spine01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname": "spine02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf01", "peerHostname": "spine02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf01", "peerHostname": "spine01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "exit02", "peerHostname": "spine02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "exit02", "peerHostname": "spine01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf04", "peerHostname": "spine01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf04", "peerHostname": "spine02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "exit01",
+    "ifname": "Ethernet1/5", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf04",
+    "ifname": "Ethernet1/4", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf03",
+    "ifname": "Ethernet1/3", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "exit02",
+    "ifname": "Ethernet1/6", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf02", "peerHostname": "spine02",
+    "ifname": "Ethernet1/2", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf02", "peerHostname": "spine01",
+    "ifname": "Ethernet1/1", "vrf": "default", "area": "0.0.0.0", "ospf": true, "polled":
+    true}]'
 - command: topology summarize --area=0.0.0.0 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: topology show nxos
-  output: '{"nxos": {"arpnd_center": ["spine02", "spine01"], "arpnd_degree_histogram":
-    "...", "arpnd_is_fully_connected": true, "arpnd_number_of_disjoint_sets": 1, "arpnd_number_of_edges":
-    12, "arpnd_number_of_nodes": 8, "arpnd_self_loops": [], "bgp_center": ["spine02",
-    "spine01"], "bgp_degree_histogram": "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets":
-    1, "bgp_number_of_edges": 12, "bgp_number_of_nodes": 8, "bgp_self_loops": [],
-    "lldp_center": ["spine02", "spine01"], "lldp_degree_histogram": "...", "lldp_is_fully_connected":
-    true, "lldp_number_of_disjoint_sets": 1, "lldp_number_of_edges": 12, "lldp_number_of_nodes":
-    8, "lldp_self_loops": [], "ospf_center": ["spine02", "spine01"], "ospf_degree_histogram":
+  output: '{"nxos": {"ospf_center": ["spine02", "spine01"], "ospf_degree_histogram":
     "...", "ospf_is_fully_connected": true, "ospf_number_of_disjoint_sets": 1, "ospf_number_of_edges":
     12, "ospf_number_of_nodes": 8, "ospf_self_loops": []}}'
 - command: topology show --via=ospf --area=0.0.0.1 --format=json --namespace=nxos
@@ -1399,3 +1364,133 @@ tests:
   output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
     {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
     "spine01"}, {"hostname": "spine02"}]'
+- command: topology show --afiSafi='ipv4 unicast' --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  marks: topology show nxos
+  output: '[{"namespace": "nxos", "hostname": "firewall01", "peerHostname": "exit02",
+    "vrf": "default", "asn": 65533, "peerAsn": 65520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "firewall01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 65533, "peerAsn": 65522, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "firewall01", "peerHostname": "exit02", "vrf": "default",
+    "asn": 65533, "peerAsn": 65521, "bgp": true, "polled": true}, {"namespace": "nxos",
+    "hostname": "firewall01", "peerHostname": "exit01", "vrf": "default", "asn": 65533,
+    "peerAsn": 65522, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "firewall01", "peerHostname": "exit01", "vrf": "default", "asn": 65533, "peerAsn":
+    65521, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "firewall01",
+    "peerHostname": "exit01", "vrf": "default", "asn": 65533, "peerAsn": 65520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname":
+    "exit02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname": "leaf01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "spine02", "peerHostname": "leaf02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "spine02", "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "spine02",
+    "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "leaf03", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf03", "peerHostname": "spine01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "leaf01", "peerHostname": "spine02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "leaf01", "peerHostname": "spine01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "exit01", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "exit01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname":
+    "firewall01", "vrf": "default", "asn": 64520, "peerAsn": 65533, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname": "firewall01",
+    "vrf": "evpn-vrf", "asn": 64520, "peerAsn": 65533, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "exit01", "peerHostname": "dcedge01", "vrf":
+    "internet-vrf", "asn": 64520, "peerAsn": 65534, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "exit01", "peerHostname": "firewall01", "vrf":
+    "internet-vrf", "asn": 64520, "peerAsn": 65533, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf03", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "spine01", "peerHostname": "exit02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "spine01",
+    "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "dcedge01", "peerHostname":
+    "exit01", "vrf": "default", "asn": 65534, "peerAsn": 65522, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "leaf04", "peerHostname": "spine02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "leaf04", "peerHostname": "spine01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "dcedge01", "peerHostname": "exit02", "vrf": "default", "asn": 65534, "peerAsn":
+    65522, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "spine01",
+    "peerHostname": "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "leaf02", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf02", "peerHostname": "spine01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "exit02", "peerHostname": "dcedge01", "vrf":
+    "internet-vrf", "asn": 64520, "peerAsn": 65534, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "exit02", "peerHostname": "firewall01", "vrf":
+    "evpn-vrf", "asn": 64520, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "exit02", "peerHostname": "firewall01", "vrf": "default",
+    "asn": 64520, "peerAsn": 65533, "bgp": true, "polled": true}, {"namespace": "nxos",
+    "hostname": "exit02", "peerHostname": "spine02", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "exit02",
+    "peerHostname": "firewall01", "vrf": "internet-vrf", "asn": 64520, "peerAsn":
+    65533, "bgp": true, "polled": true}]'
+- command: topology show --afiSafi='l2vpn evpn' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  marks: topology show nxos
+  output: '[{"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine01", "peerHostname": "leaf01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit02", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname":
+    "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
+    "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "leaf01", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf01", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}]'
+- command: topology show --afiSafi='l2vpn evpn' --area='0.0.0.0' --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Cannot provide asn/afiSafi and area at the same time"}]'
+  marks: topology show nxos


### PR DESCRIPTION
This has 3 patches, unrelated to each other, but here so all tests pass again.

* The addition of the filter keyword afiSafi to BGP and topology. 
* The fixing of the ospf help message
* The fixing of the sqpoller describe failure because it thinks the user has provided an argument.