### PR TITLE
Add the functionality to use an env variable for REST API key

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -78,5 +78,6 @@ markers =
     controller_manager_static
     controller_inventory
     recursive
+    sq_config
 
 xfail_strict = True

--- a/suzieq/cli/sq_nubia_context.py
+++ b/suzieq/cli/sq_nubia_context.py
@@ -55,7 +55,6 @@ class NubiaSuzieqContext(context.Context):
         if ret:
             raise exceptions.CommandError("Failed starting interactive mode")
         # dispatch the on connected message
-        self.registry.dispatch_message(eventbus.Message.CONNECTED)
 
     def change_engine(self, engine: str):
         '''Change the backend engine'''

--- a/suzieq/poller/controller/credential_loader/static.py
+++ b/suzieq/poller/controller/credential_loader/static.py
@@ -5,8 +5,8 @@ from pydantic import Field, validator
 
 from suzieq.poller.controller.credential_loader.base_credential_loader import \
     CredentialLoader, CredentialLoaderModel, check_credentials
-from suzieq.poller.controller.utils.inventory_utils import get_sensitive_data
-from suzieq.shared.exceptions import InventorySourceError
+from suzieq.shared.utils import get_sensitive_data
+from suzieq.shared.exceptions import SensitiveLoadError, InventorySourceError
 
 
 class StaticModel(CredentialLoaderModel):
@@ -27,7 +27,7 @@ class StaticModel(CredentialLoaderModel):
                 # the field is valid, but I cannot ask here the value
                 return field
             return get_sensitive_data(field)
-        except InventorySourceError as e:
+        except SensitiveLoadError as e:
             raise ValueError(e)
 
 
@@ -62,7 +62,7 @@ class StaticLoader(CredentialLoader):
                 self._data.password = get_sensitive_data(
                     self._data.password,
                     f'{self.name} Password to login to device: ')
-            except InventorySourceError as e:
+            except SensitiveLoadError as e:
                 raise InventorySourceError(f'{self.name} {e}')
 
         if self._data.ssh_passphrase == 'ask':
@@ -71,7 +71,7 @@ class StaticLoader(CredentialLoader):
                     self._data.ssh_passphrase,
                     f'{self.name} Passphrase to decode private key file: '
                 )
-            except InventorySourceError as e:
+            except SensitiveLoadError as e:
                 raise InventorySourceError(f'{self.name} {e}')
 
         if self._data.enable_password == 'ask':
@@ -80,7 +80,7 @@ class StaticLoader(CredentialLoader):
                     self._data.enable_password,
                     f'{self.name} Insert enable password: '
                 )
-            except InventorySourceError as e:
+            except SensitiveLoadError as e:
                 raise InventorySourceError(f'{self.name} {e}')
 
     def load(self, inventory: Dict[str, Dict]):

--- a/suzieq/poller/controller/source/netbox.py
+++ b/suzieq/poller/controller/source/netbox.py
@@ -20,8 +20,8 @@ import aiohttp
 from suzieq.poller.controller.inventory_async_plugin import \
     InventoryAsyncPlugin
 from suzieq.poller.controller.source.base_source import Source, SourceModel
-from suzieq.poller.controller.utils.inventory_utils import get_sensitive_data
-from suzieq.shared.exceptions import InventorySourceError
+from suzieq.shared.utils import get_sensitive_data
+from suzieq.shared.exceptions import InventorySourceError, SensitiveLoadError
 
 _DEFAULT_PORTS = {'http': 80, 'https': 443}
 
@@ -92,7 +92,7 @@ class NetboxSourceModel(SourceModel):
             if token == 'ask':
                 return token
             return get_sensitive_data(token)
-        except InventorySourceError as e:
+        except SensitiveLoadError as e:
             raise ValueError(e)
 
 

--- a/suzieq/poller/controller/utils/inventory_utils.py
+++ b/suzieq/poller/controller/utils/inventory_utils.py
@@ -3,12 +3,10 @@ This module contains the logic needed to parse the Suzieq native inventory
 file
 """
 
-import getpass
 import re
 import sys
 from dataclasses import dataclass
 from ipaddress import ip_address
-from os import getenv
 from pathlib import Path
 from typing import Dict, List
 
@@ -283,41 +281,6 @@ def copy_inventory_item(orig: Dict, dest: Dict) -> Dict:
     if 'copy' in dest:
         dest.pop('copy')
     return dest
-
-
-def get_sensitive_data(input_method: str, ask_message: str = '') -> str:
-    """This function is used by the inventory to specify sensitive data
-
-    The valid methods are:
-        - 'plain:' (default): copy the content of input (can be omitted)
-        - 'env:': get the information from an environment variable
-        - 'ask': write the information on the stdin
-
-    Args:
-        input_method (str): string with info for the sensitive value
-        ask_message (str): message to prompt for the 'ask' method
-
-    Raises:
-        InventorySourceError: environment variable not found
-
-    Returns:
-        str: sensitive data
-    """
-    if not input_method:
-        return input_method
-    sens_data = input_method
-    if input_method.startswith('env:'):
-        input_method = input_method.split('env:')[1].strip()
-        sens_data = getenv(input_method, '')
-        if not sens_data:
-            raise InventorySourceError(
-                f'No environment variable called '
-                f"'{input_method}'")
-    elif input_method.startswith('plain:'):
-        sens_data = input_method.split("plain:")[1].strip()
-    elif input_method.startswith('ask'):
-        sens_data = getpass.getpass(ask_message)
-    return sens_data
 
 
 def validate_hostname(in_hostname: str) -> bool:

--- a/suzieq/shared/exceptions.py
+++ b/suzieq/shared/exceptions.py
@@ -39,3 +39,7 @@ class InventorySourceError(Exception):
 
 class PollingError(Exception):
     """Exception raised every time there is an error while polling"""
+
+
+class SensitiveLoadError(Exception):
+    """Sensitive informarmation isn't loaded correctly"""

--- a/tests/unit/poller/controller/test_controller_inventory.py
+++ b/tests/unit/poller/controller/test_controller_inventory.py
@@ -1,8 +1,9 @@
 from typing import Dict
 import pytest
+from suzieq.shared.utils import get_sensitive_data
 from suzieq.poller.controller.utils.inventory_utils import (
     read_inventory, validate_raw_inventory,
-    get_sensitive_data, copy_inventory_item)
+    copy_inventory_item)
 from suzieq.shared.exceptions import InventorySourceError
 from tests.unit.poller.shared.utils import read_yaml_file
 # pylint: disable=redefined-outer-name

--- a/tests/unit/test_sqconfig_load.py
+++ b/tests/unit/test_sqconfig_load.py
@@ -1,0 +1,92 @@
+import re
+from tempfile import NamedTemporaryFile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from suzieq.shared.utils import (get_sq_install_dir, load_sq_config,
+                                 validate_sq_config)
+from tests.conftest import create_dummy_config_file
+
+
+@pytest.mark.sq_config
+def test_valid_sq_config():
+    """Test if the config is loaded correctly
+    """
+    cfg_file = create_dummy_config_file()
+
+    exp_cfg = {
+        'analyzer': {'timezone': 'GMT'},
+        'data-directory': './tests/data/parquet',
+        'logging-level': 'WARNING',
+        'rest': {'API_KEY': '68986cfafc9d5a2dc15b20e3e9f289eda2c79f40'},
+        'temp-directory': '/tmp/suzieq',
+        'service-directory': f'{get_sq_install_dir()}/config',
+        'schema-directory': f'{get_sq_install_dir()}/config/schema',
+        'poller': {'logging-level': 'WARNING'}}
+
+    cfg = load_sq_config(config_file=cfg_file)
+    cfg.pop('test_set', None)
+
+    assert cfg == exp_cfg, 'SqConfig not correctly loaded'
+
+
+@pytest.mark.sq_config
+def test_invalid_config_files(capsys):
+    """Test empty or invalid config files
+    """
+    cfg_file = './this-file-doesnt-exits'
+
+    try:
+        load_sq_config(config_file=cfg_file)
+        assert False, 'No error raised for an invalid config file'
+    except SystemExit:
+        error = capsys.readouterr().out
+        assert re.match('ERROR: Unable to open config file.*', error)
+
+    with NamedTemporaryFile(suffix='yml') as tmpfile:
+        try:
+            load_sq_config(config_file=tmpfile.name)
+        except SystemExit:
+            error = capsys.readouterr().out
+            assert re.match('ERROR: Empty config file.*', error)
+
+
+@pytest.mark.sq_config
+def test_config_validation(monkeypatch):
+    """Test the sq config validation
+    """
+
+    base_cfg = load_sq_config(create_dummy_config_file())
+
+    # not a dict
+    cfg = []
+    error = validate_sq_config(cfg)
+    assert error == "FATAL: Invalid config file format", 'Accepted an '\
+        'invalid format'
+
+    # no data-directory field
+    cfg = {}
+    error = validate_sq_config(cfg)
+    assert error == "FATAL: No data directory for output files specified", \
+        'Accepted config without "data-directory" parameter'
+
+    # no svc-directory
+    cfg['data-directory'] = base_cfg.get('data-directory')
+
+    with patch('suzieq.shared.utils.get_sq_install_dir', MagicMock()):
+        error = validate_sq_config(cfg)
+        assert error == 'FATAL: No service directory found', \
+            'Accepted config without a service directory set'
+
+    env_var = 'REST_KEY'
+    env_key = 'MY_KEY'
+    # wrong env variable
+    cfg['rest'] = {'API_KEY': f'env:{env_var}'}
+    error = validate_sq_config(cfg)
+    assert re.match('Cannot load REST API KEY.*', error), \
+        'Error not raised for an invalid REST key environment variable'
+
+    # correct env variable
+    monkeypatch.setenv(env_var, env_key)
+    error = validate_sq_config(cfg)
+    assert error is None, error


### PR DESCRIPTION
This PR contains:
- now it will be possible to specifiy the REST API key using an environment variable. Due to the fact that the loading of the configuration is done during the Nubia.on_connect, the user cannot write anything on the cli at that point, so I disabled the 'ask' for the REST api key
- Inside the sq_nubia_context.on_interactive function, there were 2 calls to self._on_connected() function. One at line 54 (implicit) and the other at line 58 (explicit). I removed the explicit call at line 58 to avoid the loading of the config file twice every time we start the cli