### PR TITLE
fix multi source bug

### DIFF
--- a/suzieq/poller/controller/source/base_source.py
+++ b/suzieq/poller/controller/source/base_source.py
@@ -1,7 +1,7 @@
 """Module containing base class for inventorySource plugins
 """
 import asyncio
-from copy import copy
+from copy import copy, deepcopy
 from os.path import isfile
 from pathlib import Path
 from typing import Dict, List
@@ -274,7 +274,9 @@ def _load_inventory(source_file: str) -> List[dict]:
         source = sources_dict.get(source_name)
 
         if ns.get('auth'):
-            auth = auths_dict.get(ns['auth'])
+            # this is only a temporary fix, in future releases I will move the
+            # credential loader initialization outside of this function.
+            auth = deepcopy(auths_dict.get(ns['auth']))
             auth_type = auth.get('type') or CredentialLoader.default_type()
             if "-" in auth_type:
                 auth_type = auth_type.replace("-", "_")

--- a/suzieq/poller/controller/source/base_source.py
+++ b/suzieq/poller/controller/source/base_source.py
@@ -261,14 +261,15 @@ def _load_inventory(source_file: str) -> List[dict]:
 
     inventory = read_inventory(source_file)
 
-    ns_dict = inventory.get('namespaces')
+    ns_list = inventory.get('namespaces')
     sources_dict = inventory.get('sources')
     auths_dict = inventory.get('auths', {})
     devs_dict = inventory.get('devices', {})
 
     sources = []
-    for namespace, ns in ns_dict.items():
+    for ns in ns_list:
         source_name = ns.get('source')
+        namespace = ns.get('name')
 
         source = sources_dict.get(source_name)
 

--- a/suzieq/poller/controller/utils/inventory_utils.py
+++ b/suzieq/poller/controller/utils/inventory_utils.py
@@ -199,7 +199,7 @@ def validate_raw_inventory(inventory: dict) -> Dict:
                              for name, g in global_specs.items()}
 
     # validate 'namespaces'
-    global_specs = {}
+    global_ns_specs = []
     for ns_specs in inv_model.namespaces:
         try:
             ns = NamespaceModel(**ns_specs)
@@ -232,8 +232,8 @@ def validate_raw_inventory(inventory: dict) -> Dict:
                     )
                 )
 
-        global_specs[ns.name] = ns.dict(by_alias=True)
-    new_inventory['namespaces'] = global_specs
+        global_ns_specs.append(ns.dict(by_alias=True))
+    new_inventory['namespaces'] = global_ns_specs
 
     if errors:
         output_inv_errors(errors)

--- a/tests/unit/poller/controller/data/exp-inventory.yaml
+++ b/tests/unit/poller/controller/data/exp-inventory.yaml
@@ -17,16 +17,14 @@ devices:
     port: null
     transport: ssh
 namespaces:
-  native-ns:
-    auth: auth0
-    device: dev0
-    name: native-ns
-    source: native0
-  netbox-ns:
-    auth: auth0
-    device: null
-    name: netbox-ns
-    source: netbox0
+- auth: auth0
+  device: dev0
+  name: native-ns
+  source: native0
+- auth: auth0
+  device: null
+  name: netbox-ns
+  source: netbox0
 sources:
   native0:
     hosts:


### PR DESCRIPTION
This PR fixes a bug which make the controller load only the last source when multiple namespaces with the same name and different sources were specified in the inventory
Moreover it fixes a bug when the enable-password was set and used on multiple namespaces.
Both bugs were introduced with the inventory validation with pydantic