### PR TITLE
assert in GUI xplore page fix

### DIFF
--- a/suzieq/gui/stlit/guiutils.py
+++ b/suzieq/gui/stlit/guiutils.py
@@ -180,7 +180,7 @@ def sq_gui_style(df, table, is_assert=False):
 
     if is_assert:
         if not df.empty:
-            return df.style.apply(color_row, axis=1, field='status',
+            return df.style.apply(color_row, axis=1, field='result',
                                   fieldval=['fail'], bgcolor='darkred',
                                   color='white')
         else:

--- a/suzieq/gui/stlit/xplore.py
+++ b/suzieq/gui/stlit/xplore.py
@@ -613,8 +613,8 @@ class XplorePage(SqGuiPage):
         stime = kwargs.pop('start_time', '')
         etime = kwargs.pop('end_time', '')
         df = sqobject(start_time=stime, end_time=etime) \
-            .aver(status="fail", **kwargs)
+            .aver(result="fail", **kwargs)
         if not df.empty:
-            df.rename(columns={'assert': 'status'},
+            df.rename(columns={'assert': 'result'},
                       inplace=True, errors='ignore')
         return df


### PR DESCRIPTION
This PR fixes a problem related to renaming of the column for the result of an assertion from `status` to ·`result` that causes GUI assertions to fail