### PR TITLE
Fix sqpoller state and poll_period_exceded filters

### DIFF
--- a/suzieq/cli/sqcmds/SqPollerCmd.py
+++ b/suzieq/cli/sqcmds/SqPollerCmd.py
@@ -42,10 +42,13 @@ class SqPollerCmd(SqCommand):
             query_str=query_str,
             sqobj=SqPollerObj,
         )
+
+        poll_period_exceeded = str(poll_period_exceeded)
         if poll_period_exceeded == "False":
             poll_period_exceeded = "0"
-        elif poll_period_exceeded == "True":
+        elif poll_period_exceeded:
             poll_period_exceeded = "!0"
+
         self.lvars = {
             'service': service.split(),
             'status': status,


### PR DESCRIPTION
This PR fixes two bugs related to the filtering on the sqpoller table. 
1. `state` and `poll_period_exceded` filtes were applied when data was retrieved from the database. This causes to have a wrong result, since the records might not be related to the very last poll for each node and service
2. Exception raised when filtering by `poll_period_exceded=True`