### PR TITLE
Fix xplore page filters

### DIFF
--- a/suzieq/gui/stlit/xplore.py
+++ b/suzieq/gui/stlit/xplore.py
@@ -129,8 +129,6 @@ class XplorePage(SqGuiPage):
             col_ok = st.sidebar.checkbox('Column Selection Done',
                                          key='xplore_col_done',
                                          value=col_sel_val)
-            if not col_ok:
-                columns = ['default']
         else:
             col_ok = True
             columns = ['default']


### PR DESCRIPTION
In the xplore page, if the user adds his filters in the sidebar, toggles and untoggles the checkbox to apply them, the filters are reset. This small PR fixes this problem