### PR TITLE
Columns consistency

### DIFF
--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -446,10 +446,6 @@ class SqCommand(SqPlugin):
             for row in df.itertuples():
                 self._pager_print(row.config)
         else:
-            if (not (self.start_time or self.end_time) and
-                'timestamp' not in self.columns and not dont_strip_cols and
-                    'timestamp' in df.columns and 'timestamp' in cols):
-                cols.remove('timestamp')
             with pd.option_context('precision', 3,
                                    'display.max_colwidth', max_colwidth,
                                    'display.max_rows', 256):

--- a/suzieq/config/schema/arpnd.avsc
+++ b/suzieq/config/schema/arpnd.avsc
@@ -63,7 +63,7 @@
             "name": "timestamp",
             "type": "timestamp",
             "display": 7,
-            "description": "Unix epach When this record was created, in ms"
+            "description": "Unix epoch, when this record was created, in ms"
         },
         {
             "name": "active",

--- a/suzieq/config/schema/interfaces.avsc
+++ b/suzieq/config/schema/interfaces.avsc
@@ -179,8 +179,7 @@
         },
         {
             "name": "timestamp",
-            "type": "timestamp",
-            "display": 11
+            "type": "timestamp"
         },
         {
             "name": "active",

--- a/suzieq/config/schema/macs.avsc
+++ b/suzieq/config/schema/macs.avsc
@@ -84,8 +84,7 @@
         },
         {
             "name": "timestamp",
-            "type": "timestamp",
-            "display": 8
+            "type": "timestamp"
         },
         {
             "name": "active",

--- a/suzieq/config/schema/ospf.avsc
+++ b/suzieq/config/schema/ospf.avsc
@@ -192,8 +192,7 @@
         },
         {
             "name": "timestamp",
-            "type": "timestamp",
-            "display": 12
+            "type": "timestamp"
         },
         {
             "name": "active",

--- a/suzieq/config/schema/routes.avsc
+++ b/suzieq/config/schema/routes.avsc
@@ -156,8 +156,7 @@
         },
         {
             "name": "timestamp",
-            "type": "timestamp",
-            "display": 11
+            "type": "timestamp"
         },
         {
             "name": "active",

--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -145,6 +145,10 @@ class SqParquetDB(SqDB):
 
             avail_fields = list(filter(lambda x: x in master_schema.names,
                                        fields))
+
+            if 'timestamp' not in avail_fields:
+                avail_fields.append('timestamp')
+
             filters = self.build_ds_filters(
                 start, end, master_schema, merge_fields=merge_fields, **kwargs)
 

--- a/suzieq/engines/pandas/bgp.py
+++ b/suzieq/engines/pandas/bgp.py
@@ -254,7 +254,8 @@ class BgpObj(SqPandasEngine):
             namespace=failed_df.namespace.unique().tolist(),
             hostname=failed_df.hostname.unique().tolist(),
             ifname=failed_df.ifname.unique().tolist(),
-            columns=['namespace', 'hostname', 'ifname', 'state', 'adminState']
+            columns=['namespace', 'hostname', 'ifname', 'state', 'adminState',
+                     'timestamp']
         )
 
         failed_df['assertReason'] = [[] for _ in range(len(failed_df))]
@@ -297,7 +298,7 @@ class BgpObj(SqPandasEngine):
 
         result_df = df[['namespace', 'hostname', 'vrf', 'peer', 'asn',
                         'peerAsn', 'state', 'peerHostname', 'result',
-                        'assertReason', 'timestamp']] \
+                        'assertReason']] \
             .explode(column="assertReason") \
             .fillna({'assertReason': '-'})
 

--- a/suzieq/engines/pandas/devconfig.py
+++ b/suzieq/engines/pandas/devconfig.py
@@ -8,3 +8,14 @@ class DevconfigObj(SqPandasEngine):
     def table_name():
         '''Table name'''
         return 'devconfig'
+
+    def get(self, **kwargs):
+        columns = kwargs.pop('columns', ['default'])
+        user_query = kwargs.get('query_str', '')
+
+        fields = self.schema.get_display_fields(columns)
+        addnl_fields = self._get_user_query_cols(user_query)
+
+        df = super().get(columns=fields, addnl_fields=addnl_fields, **kwargs)
+
+        return df.reset_index(drop=True)[fields]

--- a/suzieq/engines/pandas/device.py
+++ b/suzieq/engines/pandas/device.py
@@ -16,6 +16,7 @@ class DeviceObj(SqPandasEngine):
         '''Table name'''
         return 'device'
 
+    # pylint: disable=too-many-statements
     def get(self, **kwargs):
         """Get the information requested"""
         view = kwargs.get('view', self.iobj.view)
@@ -41,6 +42,9 @@ class DeviceObj(SqPandasEngine):
         if 'uptime' in fields and 'bootupTimestamp' not in fields:
             addnl_fields.append('bootupTimestamp')
 
+        if 'timestamp' not in columns and columns not in [['*'], ['default']]:
+            addnl_fields.append('timestamp')
+
         user_query_cols = self._get_user_query_cols(user_query)
         addnl_fields += [x for x in user_query_cols if x not in addnl_fields]
 
@@ -53,7 +57,7 @@ class DeviceObj(SqPandasEngine):
             namespace=kwargs.get('namespace', []),
             hostname=kwargs.get('hostname', []),
             service='device',
-            columns='namespace hostname status timestamp'.split())
+            columns=['namespace', 'hostname', 'status', 'timestamp'])
 
         if not poller_df.empty:
             # Identify the address to namespace/hostname mapping

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -176,7 +176,8 @@ class SqPandasEngine(SqEngineObj):
 
         aug_fields = sch.get_augmented_fields(fields)
 
-        if 'timestamp' not in fields:
+        if 'timestamp' not in fields and \
+                (self.iobj.start_time or self.iobj.end_time):
             fields.append('timestamp')
 
         if 'active' not in fields+addnl_fields:

--- a/suzieq/engines/pandas/fs.py
+++ b/suzieq/engines/pandas/fs.py
@@ -8,3 +8,14 @@ class FsObj(SqPandasEngine):
     def table_name():
         '''Table name'''
         return 'fs'
+
+    def get(self, **kwargs):
+        columns = kwargs.pop('columns', ['default'])
+        user_query = kwargs.get('query_str', '')
+
+        fields = self.schema.get_display_fields(columns)
+        addnl_fields = self._get_user_query_cols(user_query)
+
+        df = super().get(columns=fields, addnl_fields=addnl_fields, **kwargs)
+
+        return df.reset_index(drop=True)[fields]

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -467,7 +467,7 @@ class InterfacesObj(SqPandasEngine):
 
         return combined_df[['namespace', 'hostname', 'ifname', 'state',
                             'peerHostname', 'peerIfname', 'result',
-                            'assertReason', 'timestamp']]
+                            'assertReason']]
 
     def _add_portmode(self, df: pd.DataFrame):
         """Add the switchport-mode i.e. acceess/trunk/routed'''
@@ -552,7 +552,7 @@ class InterfacesObj(SqPandasEngine):
         # as a trunk port, as opposed to the access port mode of
         # the upto Cumulus 4.2.x Vxlan ports
         vxlan_ports = df.type == "vxlan"
-        df.loc[vxlan_ports, 'portmode'] = df.loc[vxlan_ports] \
+        df.loc[vxlan_ports, ['portmode']] = df.loc[vxlan_ports] \
             .apply(lambda x: 'trunk' if x['portmode'] == 'routed'
                    else x['portmode'], axis=1)
         return df.drop(columns=['portmode_y', 'vlan_y'],

--- a/suzieq/engines/pandas/lldp.py
+++ b/suzieq/engines/pandas/lldp.py
@@ -36,7 +36,8 @@ class LldpObj(SqPandasEngine):
 
         df = super().get(addnl_fields=addnl_fields, columns=cols, **kwargs)
         if df.empty or (not needed_fields and columns != ['*']):
-            return df
+            df = self._handle_user_query_str(df, query_str)
+            return df.reset_index(drop=True)[cols]
 
         macdf = df.query('subtype.isin(["", "mac address"])')
         if not macdf.empty:

--- a/suzieq/engines/pandas/mlag.py
+++ b/suzieq/engines/pandas/mlag.py
@@ -9,6 +9,17 @@ class MlagObj(SqPandasEngine):
         '''Table name'''
         return 'mlag'
 
+    def get(self, **kwargs):
+        columns = kwargs.pop('columns', ['default'])
+        user_query = kwargs.get('query_str', '')
+
+        fields = self.schema.get_display_fields(columns)
+        addnl_fields = self._get_user_query_cols(user_query)
+
+        df = super().get(columns=fields, addnl_fields=addnl_fields, **kwargs)
+
+        return df.reset_index(drop=True)[fields]
+
     def summarize(self, **kwargs):
         """Summarize MLAG info"""
 

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -374,7 +374,8 @@ class OspfObj(SqPandasEngine):
                     "adjState_x": "adjState",
                 },
             )[["namespace", "hostname", "ifname", "vrf", "adjState",
-               "assertReason", "timestamp"]]
+               "assertReason", "timestamp"]].explode(column='assertReason')
+            .fillna({'assertReason': ''})
         )
 
         return self._create_aver_result([pasv_df, ifdown_df, result_df],
@@ -485,5 +486,5 @@ class OspfObj(SqPandasEngine):
         return ospf_df[['namespace', 'hostname', 'vrf', 'ifname', 'adjState',
                         'assertReason', 'result']] \
             .explode('assertReason') \
-            .fillna('') \
+            .fillna('-') \
             .reset_index(drop=True)


### PR DESCRIPTION
This PR continues the work done in #624. Many things are done in this PR but we can choose to pick some elements if we don't think that everything is necessary.

1. get rid of adding the timestamp in any case if not specified
2. get rid of the logic of cleaning the timestamp if not in the columns in the cli
3. remove timestamp from the list of display fields in some tables (routes, ospf, macs, interfaces). In these tables we weren't already showing the timestamp in the output because of 2. and, to me, it seemed useless to show it by default.
4. enforce columns consistency in those engines which don't implement the `get()` method 

Tests still needs to be updated. A possible todo is allow the additional timestamp column in case the users is using `view=all` or `start_time` and/or `end_time`.