### PR TITLE
Fix gui custom config file

### DIFF
--- a/suzieq/gui/sq_gui.py
+++ b/suzieq/gui/sq_gui.py
@@ -5,7 +5,7 @@ from importlib.util import find_spec
 from pathlib import Path
 
 from colorama import init, Fore, Style
-from suzieq.shared.utils import print_version
+from suzieq.shared.utils import load_sq_config, print_version
 
 
 def gui_main(*args):
@@ -54,6 +54,9 @@ def gui_main(*args):
 
     if userargs.config:
         thisprog += f' -c {userargs.config}'
+
+    # validate the config file before starting the gui
+    load_sq_config(config_file=userargs.config)
 
     init()
     with subprocess.Popen(['streamlit', 'run', thisprog,

--- a/suzieq/gui/sq_gui.py
+++ b/suzieq/gui/sq_gui.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import subprocess
 import argparse
@@ -52,11 +53,11 @@ def gui_main(*args):
                 'stlit' / 'suzieq-gui.py'
             thisprog = str(thisprog)
 
-    if userargs.config:
-        thisprog += f' -c {userargs.config}'
-
     # validate the config file before starting the gui
     load_sq_config(config_file=userargs.config)
+
+    # write the sq_config file path inside an environment variable
+    os.environ['SQ_GUI_CONFIG_FILE'] = userargs.config or ''
 
     init()
     with subprocess.Popen(['streamlit', 'run', thisprog,

--- a/suzieq/gui/stlit/guiutils.py
+++ b/suzieq/gui/stlit/guiutils.py
@@ -53,13 +53,16 @@ def display_help_icon(url: str):
 
 @st.cache(ttl=90, allow_output_mutation=True, show_spinner=False,
           max_entries=20)
-def gui_get_df(table: str, verb: str = 'get', **kwargs) -> pd.DataFrame:
+def gui_get_df(table: str,
+               config_file: str,
+               verb: str = 'get', **kwargs) -> pd.DataFrame:
     """Get the cached value of the table provided
 
     The only verbs supported are get and find.
 
     Args:
         table ([str]): The table for which to get the data
+        config_file ([str]): The config file for the sqobject
         verb (str, optional): . Defaults to 'get'.
 
     Returns:
@@ -73,7 +76,8 @@ def gui_get_df(table: str, verb: str = 'get', **kwargs) -> pd.DataFrame:
     stime = kwargs.pop('start_time', '')
     etime = kwargs.pop('end_time', '')
 
-    sqobject = get_sqobject(table)(view=view, start_time=stime, end_time=etime)
+    sqobject = get_sqobject(table)(view=view, start_time=stime, end_time=etime,
+                                   config_file=config_file)
     if columns == ['all']:
         columns = ['*']
     if verb == 'get':

--- a/suzieq/gui/stlit/path.py
+++ b/suzieq/gui/stlit/path.py
@@ -35,6 +35,7 @@ class PathPage(SqGuiPage):
     _failed_dfs = {}
     _pathobj = None
     _path_df: pd.DataFrame = None
+    _config_file: str = st.session_state.get('config_file', '')
 
     @property
     def add_to_menu(self) -> bool:
@@ -71,7 +72,8 @@ class PathPage(SqGuiPage):
     def _create_sidebar(self) -> None:
 
         state = self._state
-        devdf = gui_get_df('device', columns=['namespace'])
+        devdf = gui_get_df('device', config_file=self._config_file,
+                           columns=['namespace'])
         if devdf.empty:
             st.error('Unable to retrieve any namespace info')
             st.stop()
@@ -147,7 +149,7 @@ class PathPage(SqGuiPage):
 
         layout['pgbar'].progress(0)
         self._pathobj = get_sqobject(
-            'path')(config_file=st.session_state.config_file,
+            'path')(config_file=self._config_file,
                     start_time=state.start_time,
                     end_time=state.end_time)
         try:
@@ -278,7 +280,8 @@ class PathPage(SqGuiPage):
                 {'name': 'ospf', 'query': 'adjState == "other"'},
                 {'name': 'bgp', 'query': 'state == "NotEstd"'}
         ]):
-            df = gui_get_df(entry['name'], namespace=[namespace])
+            df = gui_get_df(entry['name'], config_file=self._config_file,
+                            namespace=[namespace])
             if not df.empty and (entry.get('query', '')):
                 df = df.query(entry['query']).reset_index(drop=True)
                 self._failed_dfs[entry['name']] = df

--- a/suzieq/gui/stlit/search.py
+++ b/suzieq/gui/stlit/search.py
@@ -29,6 +29,7 @@ class SearchPage(SqGuiPage):
     '''Page for Path trace page'''
     _title: str = SuzieqMainPages.SEARCH.value
     _state = SearchSessionState()
+    _config_file = st.session_state.get('config_file', '')
 
     @property
     def add_to_menu(self):
@@ -44,7 +45,8 @@ class SearchPage(SqGuiPage):
     def _create_sidebar(self) -> None:
 
         state = self._state
-        devdf = gui_get_df('device', columns=['namespace', 'hostname'])
+        devdf = gui_get_df('device', self._config_file,
+                           columns=['namespace', 'hostname'])
         if devdf.empty:
             st.error('Unable to retrieve any namespace info')
             st.stop()
@@ -124,12 +126,14 @@ When specifying a table, you can specify multiple addresses to look for by
         if query_str:
             if state.table == "network":
                 df = gui_get_df(state.table,
+                                self._config_file,
                                 verb='find',
                                 namespace=query_ns,
                                 view="latest", columns=columns,
                                 address=query_str.split())
             else:
                 df = gui_get_df(state.table,
+                                self._config_file,
                                 namespace=query_ns, query_str=query_str,
                                 view="latest", columns=columns)
                 if not df.empty:
@@ -143,7 +147,7 @@ When specifying a table, you can specify multiple addresses to look for by
 
         elif uniq_dict:
             columns = ['namespace'] + uniq_dict['column']
-            df = gui_get_df(uniq_dict['table'],
+            df = gui_get_df(uniq_dict['table'], self._config_file,
                             namespace=query_ns, view='latest', columns=columns)
             if not df.empty:
                 df = df.groupby(by=columns).first().reset_index()

--- a/suzieq/gui/stlit/status.py
+++ b/suzieq/gui/stlit/status.py
@@ -20,6 +20,7 @@ class StatusPage(SqGuiPage):
     '''Page for Main status page'''
     _title: str = SuzieqMainPages.STATUS.value
     _state: StatusSessionState = StatusSessionState()
+    _config_file: str = st.session_state.get('config_file', '')
 
     @property
     def add_to_menu(self):
@@ -36,7 +37,8 @@ class StatusPage(SqGuiPage):
 
         do_refresh = st.sidebar.button('Refresh')
 
-        devdf = gui_get_df('device', columns=['namespace', 'hostname'])
+        devdf = gui_get_df('device', self._config_file,
+                           columns=['namespace', 'hostname'])
         if devdf.empty:
             st.error('Unable to retrieve any namespace info')
             st.stop()
@@ -116,7 +118,8 @@ __Caching is enabled by default for 90 secs on all pages__. You can clear the
     def _chart_dev(self, layout: dict, ns_list: List[str]) -> None:
         '''Chart the devices table status'''
 
-        dev_df = gui_get_df('device', namespace=ns_list, columns=['*'])
+        dev_df = gui_get_df('device', self._config_file,
+                            namespace=ns_list, columns=['*'])
         if dev_df.empty:
             layout['dev_chart'].warning('No device info found')
             return
@@ -141,7 +144,8 @@ __Caching is enabled by default for 90 secs on all pages__. You can clear the
     def _chart_interface(self, layout: dict, ns_list: List[str]) -> None:
         '''Chart the interfaces table status'''
 
-        if_df = gui_get_df('interfaces', namespace=ns_list,
+        if_df = gui_get_df('interfaces', self._config_file,
+                           namespace=ns_list,
                            columns=['default'])
         if if_df.empty:
             layout['if_chart'].warning('No Interface info found')
@@ -170,7 +174,8 @@ __Caching is enabled by default for 90 secs on all pages__. You can clear the
     def _chart_bgp(self, layout: dict, ns_list: List[str]) -> None:
         '''Chart the BGP table status'''
 
-        bgp_df = gui_get_df('bgp', namespace=ns_list, columns=['default'])
+        bgp_df = gui_get_df('bgp', self._config_file,
+                            namespace=ns_list, columns=['default'])
 
         if bgp_df.empty:
             return
@@ -195,7 +200,8 @@ __Caching is enabled by default for 90 secs on all pages__. You can clear the
     def _chart_ospf(self, layout: dict, ns_list: List[str]) -> None:
         '''Chart OSPF status'''
 
-        ospf_df = gui_get_df('ospf', namespace=ns_list, columns=['default'])
+        ospf_df = gui_get_df('ospf', self._config_file,
+                             namespace=ns_list, columns=['default'])
         if ospf_df.empty:
             return
 
@@ -224,6 +230,7 @@ __Caching is enabled by default for 90 secs on all pages__. You can clear the
         '''Display poller status'''
 
         sqdf = gui_get_df('sqPoller',
+                          self._config_file,
                           columns=['namespace', 'hostname', 'timestamp'],
                           service='device', namespace=ns_list)
         if sqdf.empty:

--- a/suzieq/gui/stlit/suzieq-gui.py
+++ b/suzieq/gui/stlit/suzieq-gui.py
@@ -1,5 +1,5 @@
+import os
 import sys
-import argparse
 from collections import defaultdict
 import base64
 from typing import Dict
@@ -155,15 +155,8 @@ def apprun(*args):
     if not args:
         args = sys.argv
 
-    parser = argparse.ArgumentParser(args)
-    parser.add_argument(
-        "-c",
-        "--config",
-        type=str, help="alternate config file",
-        default=None
-    )
-    userargs = parser.parse_args()
-    config_file = sq_get_config_file(userargs.config)
+    config_file = os.environ.get('SQ_GUI_CONFIG_FILE', '')
+    config_file = sq_get_config_file(config_file)
 
     state = st.session_state
     state.config_file = config_file


### PR DESCRIPTION
In the current version of the GUI, passing a config file to the GUI causes a bad crash because streamlit doesn't allow the usage of additional parameters and the `-c` used to pass the config caused the crash.
In this PR I'm using an environment variable to store the config file path.
Moreover, the config file is now added as parameter to all the sqobject calls