### PR TITLE
Always retrieve engine from the config file

### DIFF
--- a/suzieq/cli/sq_nubia_context.py
+++ b/suzieq/cli/sq_nubia_context.py
@@ -12,9 +12,8 @@ from suzieq.shared.context import SqContext
 class NubiaSuzieqContext(context.Context):
     '''Suzieq Nubia context setup on CLI startup'''
 
-    def __init__(self, engine="pandas"):
-        self.ctxt = SqContext()
-        self.ctxt.engine = engine
+    def __init__(self):
+        self.ctxt = None
         super().__init__()
 
     def on_connected(self, *args, **kwargs):
@@ -22,29 +21,18 @@ class NubiaSuzieqContext(context.Context):
             print_version()
             sys.exit(0)
         if self._args.config:
-            self.ctxt.cfg = load_sq_config(validate=True,
-                                           config_file=self._args.config)
+            cfg = load_sq_config(validate=True,
+                                 config_file=self._args.config)
         else:
-            self.ctxt.cfg = load_sq_config(validate=True)
+            cfg = load_sq_config(validate=True)
 
-        if not self.ctxt.cfg:
+        if not cfg:
             print('ERROR: No suzieq configuration found')
             print('Create a suzieq-cfg.yml under the homedir or current dir')
             print('OR pass a path to the config file via -c argument')
             sys.exit(1)
+        self.ctxt = SqContext(cfg=cfg)
         self.ctxt.schemas = Schema(self.ctxt.cfg["schema-directory"])
-        cfg = self.ctxt.cfg
-        self.ctxt.engine = cfg.get('ux', {}).get('engine', 'pandas')
-        if self.ctxt.engine == 'rest':
-            # See if we can extract the REST info from the REST part
-            restcfg = cfg.get('rest', {})
-            self.ctxt.rest_server_ip = restcfg.get('address', '127.0.0.1')
-            self.ctxt.rest_server_port = restcfg.get('port', '80')
-            if restcfg.get('no-https', False):
-                self.ctxt.rest_transport = 'http'
-            else:
-                self.ctxt.rest_transport = 'https'
-            self.ctxt.rest_api_key = restcfg.get('API_KEY', '')
 
     def on_cli(self, cmd, args):
         # dispatch the on connected message

--- a/suzieq/engines/base_engine.py
+++ b/suzieq/engines/base_engine.py
@@ -8,6 +8,12 @@ class SqEngineObj(SqPlugin, ABC):
     def __init__(self):
         pass
 
+    @property
+    @abstractmethod
+    def name(self):
+        '''Get the name of the engine obj'''
+        raise NotImplementedError
+
     @abstractmethod
     def get(self, **kwargs):
         '''Retrieve the data given the constraints provided for the table'''

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -41,19 +41,23 @@ class SqPandasEngine(SqEngineObj):
         return self.ctxt.schemas
 
     @property
-    def schema(self) -> SchemaForTable:
-        '''Return schema for this table'''
-        return self.iobj.schema
-
-    @property
     def cfg(self):
         '''Return config dicttionary'''
         return self.iobj.cfg
 
     @property
+    def name(self):
+        return 'pandas'
+
+    @property
     def table(self):
         '''Table name'''
         return self.iobj.table
+
+    @property
+    def schema(self) -> SchemaForTable:
+        '''Return schema for this table'''
+        return self.iobj.schema
 
     def _get_ipvers(self, value: str) -> int:
         """Return the IP version in use"""
@@ -486,6 +490,7 @@ class SqPandasEngine(SqEngineObj):
         """
 
         return get_sqobject(table)(
+            engine_name=self.iobj.engine.name,
             context=self.ctxt,
             start_time=start_time or self.iobj.start_time,
             end_time=end_time or self.iobj.end_time,

--- a/suzieq/engines/rest/engineobj.py
+++ b/suzieq/engines/rest/engineobj.py
@@ -15,6 +15,10 @@ class SqRestEngine(SqEngineObj):
         self.ctxt = baseobj.ctxt
         self.iobj = baseobj
 
+    @property
+    def name(self):
+        return 'rest'
+
     def table_name(self):
         '''table name, retrieved from sqobject
 

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -808,7 +808,9 @@ def run_command_verb(command, verb, command_args, verb_args,
     """
     svc = get_svc(command)
     try:
-        svc_inst = svc(**command_args, config_file=app.cfg_file)
+        svc_inst = svc(**command_args,
+                       config_file=app.cfg_file,
+                       engine_name="pandas")
         df = getattr(svc_inst, verb)(**verb_args)
 
     except AttributeError as err:

--- a/suzieq/shared/context.py
+++ b/suzieq/shared/context.py
@@ -27,8 +27,20 @@ class SqContext:
     rest_transport: str = 'https'
 
     def __post_init__(self):
+        # If the engine has not been explicitly set in the context object,
+        # get it from the config file
         if not self.engine:
-            self.engine = 'pandas'
+            self.engine = self.cfg.get('ux', {}).get('engine', 'pandas')
+            if self.engine == 'rest':
+                # See if we can extract the REST info from the REST part
+                restcfg = self.cfg.get('rest', {})
+                self.rest_server_ip = restcfg.get('address', '127.0.0.1')
+                self.rest_server_port = restcfg.get('port', '80')
+                if restcfg.get('no-https', False):
+                    self.rest_transport = 'http'
+                else:
+                    self.rest_transport = 'https'
+                self.rest_api_key = restcfg.get('API_KEY', '')
 
         if self.engine not in SUPPORTED_ENGINES:
             raise ValueError(f'Engine {self.engine} not supported')

--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -54,13 +54,9 @@ class SqObject(SqPlugin):
         self.columns = columns or ['default']
         self._unique_def_column = ['hostname']
 
-        if engine_name and engine_name != '':
-            self.engine = get_sqengine(engine_name, self._table)(self)
-        elif self.ctxt.engine:
-            self.engine = get_sqengine(self.ctxt.engine, self._table)(self)
-
-        if not self.engine:
-            raise ValueError('Unknown analysis engine')
+        # Init the engine
+        engine_to_use = engine_name if engine_name else self.ctxt.engine
+        self.engine = get_sqengine(engine_to_use, self._table)(self)
 
         self.summarize_df = pd.DataFrame()
 

--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -54,28 +54,10 @@ class SqObject(SqPlugin):
         self.columns = columns or ['default']
         self._unique_def_column = ['hostname']
 
-        cfg_engine = self.ctxt.cfg.get('ux', {}).get('engine', 'pandas')
-
-        if not engine_name:
-            engine_name = cfg_engine
-
-        self.ctxt.engine = get_sqengine(cfg_engine, self._table)(self)
-
-        if engine_name == 'rest':
-            # Initialize the parameters needed for REST
-            restcfg = self.ctxt.cfg.get('rest', {})
-            self.ctxt.rest_server_ip = restcfg.get('address', '127.0.0.1')
-            self.ctxt.rest_server_port = restcfg.get('port', '8000')
-            self.ctxt.rest_api_key = restcfg.get('API_KEY', '')
-            if not self.ctxt.rest_api_key:
-                raise ValueError('Missing API_KEY value to use REST engine.'
-                                 ' Provide this in the config file')
-            if restcfg.get('no-https', False):
-                self.ctxt.rest_transport = 'http'
-            else:
-                self.ctxt.rest_transport = 'https'
-
-        self.engine = self.ctxt.engine
+        if engine_name and engine_name != '':
+            self.engine = get_sqengine(engine_name, self._table)(self)
+        elif self.ctxt.engine:
+            self.engine = get_sqengine(self.ctxt.engine, self._table)(self)
 
         if not self.engine:
             raise ValueError('Unknown analysis engine')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from suzieq.cli.sq_nubia_plugin import NubiaSuzieqPlugin
 from suzieq.cli.sq_nubia_context import NubiaSuzieqContext
 from suzieq.cli.sqcmds.command import SqCommand
 from suzieq.poller.worker.services.service_manager import ServiceManager
+from suzieq.shared.context import SqContext
 from suzieq.shared.schema import Schema
 from suzieq.shared.utils import load_sq_config
 from suzieq.sqobjects import get_sqobject, get_tables
@@ -159,7 +160,7 @@ def create_context():
     '''Create a SqContext object'''
     config = load_sq_config(config_file=create_dummy_config_file())
     context = NubiaSuzieqContext()
-    context.ctxt.cfg = config
+    context.ctxt = SqContext(cfg=config)
     context.ctxt.schemas = Schema(config["schema-directory"])
     return context
 


### PR DESCRIPTION
Currently, only the cli correctly retrieve the info about the engine to use from the configuration file. This PR solves this problem getting the engine from the configuration file, even when using only the API.
Additionally a bug causing the usage of the wrong engine has been resolved, for example when calling from cli:
```
device show engine=pandas
```
When the engine was rest, caused a part of the request to be forward to the rest api.