### PR TITLE
Fix top

### DIFF
--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -458,12 +458,10 @@ class SqPandasEngine(SqEngineObj):
         if df.empty or ('error' in df.columns):
             return df
 
-        if reverse:
-            return df.nsmallest(sqTopCount, columns=what, keep="all") \
-                     .head(sqTopCount)
-        else:
-            return df.nlargest(sqTopCount, columns=what, keep="all") \
-                     .head(sqTopCount)
+        columns_by = [what] + self.schema.key_fields()
+
+        return df.sort_values(by=columns_by, ascending=reverse) \
+                 .head(sqTopCount)
 
     def lpm(self, **kwargs):
         '''Default implementation to return not supported'''

--- a/tests/integration/sqcmds/cumulus-samples/interface.yml
+++ b/tests/integration/sqcmds/cumulus-samples/interface.yml
@@ -2255,16 +2255,16 @@ tests:
     "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
     9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
     "statusChangeTimestamp": 1616677646390, "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState":
-    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "statusChangeTimestamp": 1616677646340, "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02",
-    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
-    1616677646340, "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave",
-    "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList":
-    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582391}]'
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1616677646340, "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582523}]'
 - command: interface assert --result=pass --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/cumulus-samples/network.yml
+++ b/tests/integration/sqcmds/cumulus-samples/network.yml
@@ -193,8 +193,8 @@ tests:
   data-directory: tests/data/parquet
   marks: network find cumulus
   output: '[{"namespace": "ospf-single", "hostname": "spine01", "vrf": "default",
-    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:00:00:50", "ifname":
-    "swp3", "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616352402479},
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:00:00:54", "ifname":
+    "swp1", "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616352402479},
     {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ipAddress":
     "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:e5:e3:d4", "ifname": "swp5", "bondMembers":
     "", "type": "routed", "l2miss": false, "timestamp": 1616681581179}]'
@@ -248,17 +248,17 @@ tests:
     "ipAddress": "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname":
     "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821712},
     {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "ipAddress":
-    "fe80::4639:39ff:feff:13", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821713},
+    "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13",
+    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821713},
     {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "ipAddress":
-    "fe80::4639:39ff:feff:13", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
+    "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13",
+    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
+    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "ipAddress":
+    "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13",
+    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
     {"namespace": "dual-evpn", "hostname": "server101", "vrf": "default", "ipAddress":
     "172.16.1.1", "vlan": "0", "macaddr": "44:39:39:ff:00:13", "ifname": "bond0",
     "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "ipAddress":
-    "fe80::4639:39ff:feff:13", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
     {"namespace": "ospf-ibgp", "hostname": "server103", "vrf": "default", "ipAddress":
     "172.16.1.1", "vlan": "0", "macaddr": "44:39:39:ff:00:13", "ifname": "bond0",
     "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616681581179},

--- a/tests/integration/sqcmds/cumulus-samples/top.yml
+++ b/tests/integration/sqcmds/cumulus-samples/top.yml
@@ -11,16 +11,16 @@ tests:
     "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
     9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
     "statusChangeTimestamp": 1616677646390, "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState":
-    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "statusChangeTimestamp": 1616677646340, "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02",
-    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
-    1616677646340, "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave",
-    "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList":
-    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582391}]'
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1616677646340, "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582523}]'
 - command: interface top --what=statusChangeTimestamp --namespace=ospf-ibgp --format=json
   data-directory: tests/data/parquet/
   marks: interface top statusChangeTimestamp
@@ -31,16 +31,16 @@ tests:
     "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
     9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
     "statusChangeTimestamp": 1616677646390, "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState":
-    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "statusChangeTimestamp": 1616677646340, "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02",
-    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
-    1616677646340, "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave",
-    "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList":
-    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582391}]'
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1616677646340, "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582523}]'
 - command: interface top --what="statusChangeTimestamp" --namespace=ospf-ibgp --columns="hostname
     ifname state mtu" --format=json
   data-directory: tests/data/parquet/
@@ -52,35 +52,35 @@ tests:
     "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
     9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
     "statusChangeTimestamp": 1616677646390, "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState":
-    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "statusChangeTimestamp": 1616677646340, "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02",
-    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
-    1616677646340, "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave",
-    "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList":
-    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582391}]'
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1616677646340, "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582523}]'
 - command: interface top --what=numChanges --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: interface top numChanges
-  output: '[{"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond02", "state":
-    "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
-    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822941},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond01", "state":
-    "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
-    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822941},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond02", "state":
+  output: '[{"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond02", "state":
     "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
     "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822983},
     {"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond01", "state":
     "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
     "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822983},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "ifname": "bond02", "state":
+    {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond02", "state":
     "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
-    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644823051}]'
+    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822941},
+    {"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond01", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822941},
+    {"namespace": "dual-evpn", "hostname": "leaf02", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644823147}]'
 - command: bgp top --what="estdTime" --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -89,131 +89,131 @@ tests:
     "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi":
     "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges":
     1, "estdTime": 1616681052000, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000, "timestamp":
-    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default",
-    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
-    1, "estdTime": 1616681051000, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
     "hostname": "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
     "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
     65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681051000, "timestamp":
-    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default",
+    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default",
     "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 6, "numChanges":
-    1, "estdTime": 1616681050000, "timestamp": 1616681582980}]'
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681051000, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000, "timestamp":
+    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp2", "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681050000, "timestamp": 1616681583504}]'
 - command: bgp top --what="estdTime" --namespace="dual-evpn" --format=json
   data-directory: tests/data/parquet/
   marks: bgp top estdTime
   output: '[{"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
-    "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65000, "peerAsn": 65101, "pfxRx": 2, "pfxTx": 0, "numChanges":
+    "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx": 0, "numChanges":
     1, "estdTime": 1616644609000, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
     "hostname": "spine01", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65101, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644609000, "timestamp":
-    1616644822861}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
-    "peer": "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}, {"namespace": "dual-evpn",
-    "hostname": "edge01", "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65201, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000, "timestamp":
-    1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
-    "peer": "eth1.4", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 4, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}]'
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65101, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644609000, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp6", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65201, "pfxRx": 7, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp5", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65202, "pfxRx": 10, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "timestamp": 1616644822793}]'
 - command: bgp top --what="estdTime" --namespace="dual-evpn" --columns="hostname peer"
     --format=json
   data-directory: tests/data/parquet/
   marks: bgp top statusChangeTimestamp
   output: '[{"namespace": "dual-evpn", "hostname": "spine01", "vrf": "default", "peer":
-    "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65000, "peerAsn": 65101, "pfxRx": 2, "pfxTx": 0, "numChanges":
+    "swp1", "peerHostname": "leaf01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx": 0, "numChanges":
     1, "estdTime": 1616644609000, "timestamp": 1616644822861}, {"namespace": "dual-evpn",
     "hostname": "spine01", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65101, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644609000, "timestamp":
-    1616644822861}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
-    "peer": "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}, {"namespace": "dual-evpn",
-    "hostname": "edge01", "vrf": "default", "peer": "eth1.3", "peerHostname": "exit01",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65201, "pfxRx": 3, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000, "timestamp":
-    1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
-    "peer": "eth1.4", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 4, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}]'
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65101, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644609000, "timestamp":
+    1616644822861}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp6", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "timestamp": 1616644822793}, {"namespace": "dual-evpn",
+    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65201, "pfxRx": 7, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp5", "peerHostname": "exit02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65202, "pfxRx": 10, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "timestamp": 1616644822793}]'
 - command: bgp top --what="updatesRx" --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp top
-  output: '[{"namespace": "dual-evpn", "hostname": "exit01", "vrf": "default", "peer":
+  output: '[{"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer":
     "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi":
-    "evpn", "asn": 65201, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1616644608000, "updatesRx": 55, "timestamp": 1616644822941}, {"namespace":
-    "dual-evpn", "hostname": "exit01", "vrf": "default", "peer": "swp2", "peerHostname":
-    "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65201,
-    "peerAsn": 65000, "pfxRx": 8, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000,
-    "updatesRx": 55, "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname":
-    "exit01", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
-    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65201, "peerAsn": 65000,
-    "pfxRx": 38, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "updatesRx":
-    55, "timestamp": 1616644822941}, {"namespace": "dual-evpn", "hostname": "exit01",
+    "evpn", "asn": 65104, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "updatesRx": 55, "timestamp": 1616644823113}, {"namespace":
+    "dual-evpn", "hostname": "leaf04", "vrf": "default", "peer": "swp2", "peerHostname":
+    "spine02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65104,
+    "peerAsn": 65000, "pfxRx": 13, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000,
+    "updatesRx": 55, "timestamp": 1616644823113}, {"namespace": "dual-evpn", "hostname":
+    "leaf04", "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65104, "peerAsn": 65000,
+    "pfxRx": 36, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "updatesRx":
+    55, "timestamp": 1616644823113}, {"namespace": "dual-evpn", "hostname": "leaf04",
     "vrf": "default", "peer": "swp1", "peerHostname": "spine01", "state": "Established",
-    "afi": "ipv4", "safi": "unicast", "asn": 65201, "peerAsn": 65000, "pfxRx": 8,
+    "afi": "ipv4", "safi": "unicast", "asn": 65104, "peerAsn": 65000, "pfxRx": 13,
     "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "updatesRx": 55, "timestamp":
-    1616644822941}, {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "default",
-    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65202, "peerAsn": 65000, "pfxRx": 12, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1616644607000, "updatesRx": 55, "timestamp": 1616644822972}]'
+    1616644823113}, {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default",
+    "peer": "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65103, "peerAsn": 65000, "pfxRx": 36, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "updatesRx": 55, "timestamp": 1616644822983}]'
 - command: bgp top --what="updatesTx" --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp top
   output: '[{"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer":
-    "swp2", "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn", "safi":
-    "evpn", "asn": 65000, "peerAsn": 65102, "pfxRx": 8, "pfxTx": 0, "numChanges":
-    1, "estdTime": 1616644607000, "updatesTx": 55, "timestamp": 1616644822793}, {"namespace":
-    "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp2", "peerHostname":
-    "leaf02", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
-    "peerAsn": 65102, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644607000,
+    "swp6", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "updatesTx": 55, "timestamp": 1616644822793}, {"namespace":
+    "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname":
+    "exit01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000,
+    "peerAsn": 65201, "pfxRx": 7, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000,
     "updatesTx": 55, "timestamp": 1616644822793}, {"namespace": "dual-evpn", "hostname":
-    "spine02", "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state":
-    "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65101,
-    "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "updatesTx":
+    "spine02", "vrf": "default", "peer": "swp5", "peerHostname": "exit02", "state":
+    "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65202,
+    "pfxRx": 10, "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "updatesTx":
     55, "timestamp": 1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02",
-    "vrf": "default", "peer": "swp1", "peerHostname": "leaf01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn": 65101, "pfxRx": 8, "pfxTx":
-    0, "numChanges": 1, "estdTime": 1616644608000, "updatesTx": 55, "timestamp": 1616644822793},
-    {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default", "peer": "swp3",
-    "peerHostname": "leaf03", "state": "Established", "afi": "ipv4", "safi": "unicast",
-    "asn": 65000, "peerAsn": 65103, "pfxRx": 2, "pfxTx": 0, "numChanges": 1, "estdTime":
-    1616644608000, "updatesTx": 55, "timestamp": 1616644822793}]'
+    "vrf": "default", "peer": "swp5", "peerHostname": "exit02", "state": "Established",
+    "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn": 65202, "pfxRx": 8,
+    "pfxTx": 0, "numChanges": 1, "estdTime": 1616644608000, "updatesTx": 55, "timestamp":
+    1616644822793}, {"namespace": "dual-evpn", "hostname": "spine02", "vrf": "default",
+    "peer": "swp4", "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65104, "pfxRx": 8, "pfxTx": 0, "numChanges":
+    1, "estdTime": 1616644608000, "updatesTx": 55, "timestamp": 1616644822793}]'
 - command: bgp top --what="numChanges" --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp top numChanges
-  output: '[{"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer":
-    "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}, {"namespace": "dual-evpn",
-    "hostname": "edge01", "vrf": "default", "peer": "eth2.4", "peerHostname": "exit02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65202, "pfxRx": 4, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000, "timestamp":
-    1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
-    "peer": "eth2.3", "peerHostname": "exit02", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65530, "peerAsn": 65202, "pfxRx": 2, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}, {"namespace": "dual-evpn",
-    "hostname": "edge01", "vrf": "default", "peer": "eth2.2", "peerHostname": "exit02",
-    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65530, "peerAsn":
-    65202, "pfxRx": 9, "pfxTx": 16, "numChanges": 1, "estdTime": 1616644608000, "timestamp":
-    1616644822492}, {"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default",
-    "peer": "eth1.4", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 4, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}]'
+  output: '[{"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer":
+    "swp6", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681049000, "timestamp": 1616681583504}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "peer": "swp6", "peerHostname": "exit01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 13, "pfxTx": 13, "numChanges": 1, "estdTime": 1616681049000, "timestamp":
+    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp4", "peerHostname": "leaf04", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681051000, "timestamp": 1616681583504}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "peer": "swp3", "peerHostname": "leaf03",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681049000, "timestamp":
+    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp2", "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681050000, "timestamp": 1616681583504}]'
 - command: device top --what="bootupTimestamp" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -227,31 +227,31 @@ tests:
     "hostname": "exit02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus",
     "architecture": "x86_64", "status": "alive", "address": "192.168.123.136", "bootupTimestamp":
     1616681015000, "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname":
-    "edge01", "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture":
-    "x86-64", "status": "alive", "address": "192.168.123.180", "bootupTimestamp":
-    1616681014000, "timestamp": 1616681581705}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf04", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
-    "x86_64", "status": "alive", "address": "192.168.123.202", "bootupTimestamp":
-    1616681014000, "timestamp": 1616681582726}]'
+    "spine02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.16", "bootupTimestamp": 1616681014000,
+    "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.135", "bootupTimestamp": 1616681014000,
+    "timestamp": 1616681582844}]'
 - command: device top --what="bootupTimestamp" --reverse=True --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: device top uptime
-  output: '[{"namespace": "ospf-single", "hostname": "server101", "model": "vm", "version":
+  output: '[{"namespace": "ospf-single", "hostname": "server103", "model": "vm", "version":
     "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "10.255.2.78", "bootupTimestamp": 1616351831000, "timestamp": 1616352402606},
-    {"namespace": "ospf-single", "hostname": "server104", "model": "vm", "version":
-    "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "10.255.2.219", "bootupTimestamp": 1616351815000, "timestamp": 1616352402611},
-    {"namespace": "ospf-single", "hostname": "edge01", "model": "vm", "version": "16.04.6
-    LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive", "address":
-    "10.255.2.109", "bootupTimestamp": 1616351812000, "timestamp": 1616352402798},
+    "address": "10.255.2.182", "bootupTimestamp": 1616351788000, "timestamp": 1616352402601},
     {"namespace": "ospf-single", "hostname": "internet", "model": "VX", "version":
     "4.3.0", "vendor": "Cumulus", "architecture": "x86_64", "status": "alive", "address":
     "10.255.2.239", "bootupTimestamp": 1616351807000, "timestamp": 1616352403840},
-    {"namespace": "ospf-single", "hostname": "server103", "model": "vm", "version":
+    {"namespace": "ospf-single", "hostname": "edge01", "model": "vm", "version": "16.04.6
+    LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive", "address":
+    "10.255.2.109", "bootupTimestamp": 1616351812000, "timestamp": 1616352402798},
+    {"namespace": "ospf-single", "hostname": "server104", "model": "vm", "version":
     "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "10.255.2.182", "bootupTimestamp": 1616351788000, "timestamp": 1616352402601}]'
+    "address": "10.255.2.219", "bootupTimestamp": 1616351815000, "timestamp": 1616352402611},
+    {"namespace": "ospf-single", "hostname": "server101", "model": "vm", "version":
+    "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "10.255.2.78", "bootupTimestamp": 1616351831000, "timestamp": 1616352402606}]'
 - command: device top --what="bootupTimestamp" --namespace=ospf-ibgp --format=json
   data-directory: tests/data/parquet/
   marks: device top uptime
@@ -264,53 +264,53 @@ tests:
     "hostname": "exit02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus",
     "architecture": "x86_64", "status": "alive", "address": "192.168.123.136", "bootupTimestamp":
     1616681015000, "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname":
-    "edge01", "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture":
-    "x86-64", "status": "alive", "address": "192.168.123.180", "bootupTimestamp":
-    1616681014000, "timestamp": 1616681581705}, {"namespace": "ospf-ibgp", "hostname":
-    "exit01", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
-    "x86_64", "status": "alive", "address": "192.168.123.188", "bootupTimestamp":
-    1616681014000, "timestamp": 1616681582726}]'
+    "spine02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.16", "bootupTimestamp": 1616681014000,
+    "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.135", "bootupTimestamp": 1616681014000,
+    "timestamp": 1616681582844}]'
 - command: device top --what="bootupTimestamp" --namespace=ospf-ibgp --reverse=True
     --columns='hostname vendor version' --format=json
   data-directory: tests/data/parquet/
   marks: device top bootupTimestamp
-  output: '[{"namespace": "ospf-ibgp", "hostname": "edge01", "model": "vm", "version":
+  output: '[{"namespace": "ospf-ibgp", "hostname": "server101", "model": "vm", "version":
     "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "192.168.123.180", "bootupTimestamp": 1616681014000, "timestamp": 1616681581705},
-    {"namespace": "ospf-ibgp", "hostname": "server104", "model": "vm", "version":
-    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "192.168.123.197", "bootupTimestamp": 1616680858000, "timestamp": 1616681581652},
-    {"namespace": "ospf-ibgp", "hostname": "server103", "model": "vm", "version":
-    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "192.168.123.150", "bootupTimestamp": 1616680845000, "timestamp": 1616681581595},
+    "address": "192.168.123.184", "bootupTimestamp": 1616680816000, "timestamp": 1616681581632},
     {"namespace": "ospf-ibgp", "hostname": "server102", "model": "vm", "version":
     "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
     "address": "192.168.123.134", "bootupTimestamp": 1616680827000, "timestamp": 1616681581705},
-    {"namespace": "ospf-ibgp", "hostname": "server101", "model": "vm", "version":
+    {"namespace": "ospf-ibgp", "hostname": "server103", "model": "vm", "version":
     "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
-    "address": "192.168.123.184", "bootupTimestamp": 1616680816000, "timestamp": 1616681581632}]'
+    "address": "192.168.123.150", "bootupTimestamp": 1616680845000, "timestamp": 1616681581595},
+    {"namespace": "ospf-ibgp", "hostname": "server104", "model": "vm", "version":
+    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "192.168.123.197", "bootupTimestamp": 1616680858000, "timestamp": 1616681581652},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "model": "vm", "version": "16.04.7
+    LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive", "address":
+    "192.168.123.180", "bootupTimestamp": 1616681014000, "timestamp": 1616681581705}]'
 - command: ospf top --what="lastChangeTime" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   ignore-columns: lastChangeTime timestamp
   marks: ospf top lastChangeTime
-  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default", "ifname":
-    "swp2", "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.21", "numChanges": 5.0, "lastChangeTime":
-    1616681064000, "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf02", "vrf": "default", "ifname": "swp2", "peerHostname": "spine02", "area":
-    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.21",
-    "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "ifname": "swp2",
-    "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0,
-    "adjState": "full", "peerIP": "10.0.0.21", "numChanges": 5.0, "lastChangeTime":
-    1616681064000, "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "vrf": "default", "ifname": "swp1", "peerHostname": "leaf01", "area":
-    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.11",
+  output: '[{"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
+    "swp6", "peerHostname": "exit01", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.101", "numChanges": 5.0, "lastChangeTime":
+    1616681064000, "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "ifname": "swp4", "peerHostname": "leaf04", "area":
+    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.14",
     "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581441},
     {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
-    "swp2", "peerHostname": "leaf02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.12", "numChanges": 5.0, "lastChangeTime":
+    "swp3", "peerHostname": "leaf03", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.13", "numChanges": 5.0, "lastChangeTime":
+    1616681064000, "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "ifname": "swp2", "peerHostname": "leaf02", "area":
+    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.12",
+    "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581441},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
+    "swp1", "peerHostname": "leaf01", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.11", "numChanges": 5.0, "lastChangeTime":
     1616681064000, "timestamp": 1616681581441}]'
 - command: ospf top --what="lastChangeTime" --namespace="ospf-single" --format=json
   data-directory: tests/data/parquet/
@@ -320,79 +320,79 @@ tests:
     "ifname": "swp6", "peerHostname": "exit01", "area": "0.0.0.0", "ifState": "up",
     "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.101", "numChanges": 5.0,
     "lastChangeTime": 1616352030000, "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "spine02", "vrf": "default", "ifname": "swp4", "peerHostname": "leaf04",
+    "hostname": "spine02", "vrf": "default", "ifname": "swp5", "peerHostname": "exit02",
     "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP":
-    "10.0.0.14", "numChanges": 4.0, "lastChangeTime": 1616352030000, "timestamp":
+    "10.0.0.102", "numChanges": 5.0, "lastChangeTime": 1616352030000, "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "spine02", "vrf": "default",
-    "ifname": "swp3", "peerHostname": "leaf03", "area": "0.0.0.0", "ifState": "up",
-    "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.13", "numChanges": 4.0,
+    "ifname": "swp4", "peerHostname": "leaf04", "area": "0.0.0.0", "ifState": "up",
+    "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.14", "numChanges": 4.0,
     "lastChangeTime": 1616352030000, "timestamp": 1616352403216}, {"namespace": "ospf-single",
-    "hostname": "spine02", "vrf": "default", "ifname": "swp2", "peerHostname": "leaf02",
+    "hostname": "spine02", "vrf": "default", "ifname": "swp3", "peerHostname": "leaf03",
     "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP":
-    "10.0.0.12", "numChanges": 4.0, "lastChangeTime": 1616352030000, "timestamp":
+    "10.0.0.13", "numChanges": 4.0, "lastChangeTime": 1616352030000, "timestamp":
     1616352403216}, {"namespace": "ospf-single", "hostname": "spine02", "vrf": "default",
-    "ifname": "swp1", "peerHostname": "leaf01", "area": "0.0.0.0", "ifState": "up",
-    "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.11", "numChanges": 4.0,
+    "ifname": "swp2", "peerHostname": "leaf02", "area": "0.0.0.0", "ifState": "up",
+    "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.12", "numChanges": 4.0,
     "lastChangeTime": 1616352030000, "timestamp": 1616352403216}]'
 - command: ospf top --what="lastChangeTime" --columns="hostname ifname adjState" --format=json
     --namespace='ospf-single dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: ospf top
-  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default", "ifname":
-    "swp2", "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.21", "numChanges": 5.0, "lastChangeTime":
-    1616681064000, "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf02", "vrf": "default", "ifname": "swp2", "peerHostname": "spine02", "area":
-    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.21",
-    "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "ifname": "swp2",
-    "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0,
-    "adjState": "full", "peerIP": "10.0.0.21", "numChanges": 5.0, "lastChangeTime":
-    1616681064000, "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "vrf": "default", "ifname": "swp1", "peerHostname": "leaf01", "area":
-    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.11",
+  output: '[{"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
+    "swp6", "peerHostname": "exit01", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.101", "numChanges": 5.0, "lastChangeTime":
+    1616681064000, "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "ifname": "swp4", "peerHostname": "leaf04", "area":
+    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.14",
     "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581441},
     {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
-    "swp2", "peerHostname": "leaf02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.12", "numChanges": 5.0, "lastChangeTime":
+    "swp3", "peerHostname": "leaf03", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.13", "numChanges": 5.0, "lastChangeTime":
+    1616681064000, "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "ifname": "swp2", "peerHostname": "leaf02", "area":
+    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.12",
+    "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581441},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
+    "swp1", "peerHostname": "leaf01", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.11", "numChanges": 5.0, "lastChangeTime":
     1616681064000, "timestamp": 1616681581441}]'
 - command: evpnVni top --what=vni --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni top
-  output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 104001, "type":
-    "L3", "vlan": 0, "state": "down", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0,
-    "priVtepIp": "0.0.0.0", "secVtepIp": "", "timestamp": 1616644822033}, {"namespace":
-    "dual-evpn", "hostname": "leaf04", "vni": 104001, "type": "L3", "vlan": 0, "state":
-    "down", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp": "0.0.0.0", "secVtepIp":
-    "", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 104001, "type": "L3", "vlan": 0, "state": "down", "mcastGroup": "0.0.0.0",
-    "remoteVtepCnt": 0, "priVtepIp": "0.0.0.0", "secVtepIp": "", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vni": 104001, "type": "L3",
-    "vlan": 0, "state": "down", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp":
-    "0.0.0.0", "secVtepIp": "", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 104001, "type": "L3", "vlan": 0, "state": "down",
-    "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp": "0.0.0.0", "secVtepIp":
-    "", "timestamp": 1616644822169}]'
+  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 104001, "type":
+    "L3", "vlan": 4001, "state": "up", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0,
+    "priVtepIp": "10.0.0.134", "secVtepIp": "", "timestamp": 1616681582386}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "vni": 104001, "type": "L3", "vlan": 4001,
+    "state": "up", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp": "10.0.0.134",
+    "secVtepIp": "", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf02", "vni": 104001, "type": "L3", "vlan": 4001, "state": "up", "mcastGroup":
+    "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp": "10.0.0.112", "secVtepIp": "", "timestamp":
+    1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 104001,
+    "type": "L3", "vlan": 4001, "state": "up", "mcastGroup": "0.0.0.0", "remoteVtepCnt":
+    0, "priVtepIp": "10.0.0.112", "secVtepIp": "", "timestamp": 1616681582726}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "vni": 104001, "type": "L3", "vlan": 4001,
+    "state": "up", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp": "10.0.0.102",
+    "secVtepIp": "", "timestamp": 1616681582523}]'
 - command: network top --what=deviceCnt --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: network top
-  output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161298729}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt": 18,
+  output: '[{"namespace": "ospf-single", "deviceCnt": 14, "serviceCnt": 16, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161366022}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt": 18,
     "errSvcCnt": 0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag":
-    true, "lastUpdate": 1641830465167}, {"namespace": "ospf-single", "deviceCnt":
-    14, "serviceCnt": 16, "errSvcCnt": 0, "hasOspf": true, "hasBgp": false, "hasVxlan":
-    false, "hasMlag": false, "lastUpdate": 1639161366022}]'
+    true, "lastUpdate": 1641830465167}, {"namespace": "dual-evpn", "deviceCnt": 14,
+    "serviceCnt": 17, "errSvcCnt": 0, "hasOspf": false, "hasBgp": true, "hasVxlan":
+    true, "hasMlag": true, "lastUpdate": 1639161298729}]'
 - command: bgp top --what=numChanges --count=1 --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: bgp top
-  output: '[{"namespace": "dual-evpn", "hostname": "edge01", "vrf": "default", "peer":
-    "eth1.2", "peerHostname": "exit01", "state": "Established", "afi": "ipv4", "safi":
-    "unicast", "asn": 65530, "peerAsn": 65201, "pfxRx": 10, "pfxTx": 16, "numChanges":
-    1, "estdTime": 1616644608000, "timestamp": 1616644822492}]'
+  output: '[{"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "peer":
+    "swp6", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn", "safi":
+    "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 6, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681049000, "timestamp": 1616681583504}]'
 - command: ospf top --what=numChanges --count=1 --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -405,16 +405,16 @@ tests:
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   mark: interface top
-  output: '[{"namespace": "dual-evpn", "hostname": "leaf03", "ifname": "bond02", "state":
+  output: '[{"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond02", "state":
     "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
-    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822941}]'
+    "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822983}]'
 - command: network top --what=deviceCnt --count=1 --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: network top
-  output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161298729}]'
+  output: '[{"namespace": "ospf-single", "deviceCnt": 14, "serviceCnt": 16, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161366022}]'
 - command: ospf top --what=hostname --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -476,12 +476,12 @@ tests:
     "hostname": "exit02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus",
     "architecture": "x86_64", "status": "alive", "address": "192.168.123.136", "bootupTimestamp":
     1616681015000, "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname":
-    "edge01", "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture":
-    "x86-64", "status": "alive", "address": "192.168.123.180", "bootupTimestamp":
-    1616681014000, "timestamp": 1616681581705}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf04", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
-    "x86_64", "status": "alive", "address": "192.168.123.202", "bootupTimestamp":
-    1616681014000, "timestamp": 1616681582726}]'
+    "spine02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.16", "bootupTimestamp": 1616681014000,
+    "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.135", "bootupTimestamp": 1616681014000,
+    "timestamp": 1616681582844}]'
 - command: bgp top --what=estdTime --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -490,20 +490,20 @@ tests:
     "swp2", "peerHostname": "spine02", "state": "Established", "afi": "l2vpn", "safi":
     "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 22, "pfxTx": 8, "numChanges":
     1, "estdTime": 1616681052000, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
-    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
-    65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000, "timestamp":
-    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default",
-    "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
-    1, "estdTime": 1616681051000, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
     "hostname": "spine02", "vrf": "default", "peer": "swp4", "peerHostname": "leaf04",
     "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
     65000, "pfxRx": 8, "pfxTx": 38, "numChanges": 1, "estdTime": 1616681051000, "timestamp":
-    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default",
+    1616681583504}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "default",
     "peer": "swp1", "peerHostname": "spine01", "state": "Established", "afi": "l2vpn",
-    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 38, "pfxTx": 6, "numChanges":
-    1, "estdTime": 1616681050000, "timestamp": 1616681582980}]'
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 28, "pfxTx": 8, "numChanges":
+    1, "estdTime": 1616681051000, "timestamp": 1616681583393}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "vrf": "default", "peer": "swp2", "peerHostname": "spine02",
+    "state": "Established", "afi": "l2vpn", "safi": "evpn", "asn": 65000, "peerAsn":
+    65000, "pfxRx": 22, "pfxTx": 8, "numChanges": 1, "estdTime": 1616681051000, "timestamp":
+    1616681583330}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "peer": "swp2", "peerHostname": "leaf02", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 65000, "peerAsn": 65000, "pfxRx": 8, "pfxTx": 38, "numChanges":
+    1, "estdTime": 1616681050000, "timestamp": 1616681583504}]'
 - command: interface top --what=statusChangeTimestamp --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -515,58 +515,58 @@ tests:
     "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
     9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
     "statusChangeTimestamp": 1616677646390, "timestamp": 1616681582391}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState":
-    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "statusChangeTimestamp": 1616677646340, "timestamp":
-    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02",
-    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
-    1616677646340, "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave",
-    "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList":
-    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582391}]'
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1616677646340, "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1616677646330, "timestamp": 1616681582523}]'
 - command: ospf top --what=lastChangeTime --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: ospf top
-  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "default", "ifname":
-    "swp2", "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.21", "numChanges": 5.0, "lastChangeTime":
-    1616681064000, "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname":
-    "leaf02", "vrf": "default", "ifname": "swp2", "peerHostname": "spine02", "area":
-    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.21",
-    "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581440},
-    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "default", "ifname": "swp2",
-    "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0,
-    "adjState": "full", "peerIP": "10.0.0.21", "numChanges": 5.0, "lastChangeTime":
-    1616681064000, "timestamp": 1616681581440}, {"namespace": "ospf-ibgp", "hostname":
-    "spine02", "vrf": "default", "ifname": "swp1", "peerHostname": "leaf01", "area":
-    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.11",
+  output: '[{"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
+    "swp6", "peerHostname": "exit01", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.101", "numChanges": 5.0, "lastChangeTime":
+    1616681064000, "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "ifname": "swp4", "peerHostname": "leaf04", "area":
+    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.14",
     "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581441},
     {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
-    "swp2", "peerHostname": "leaf02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.12", "numChanges": 5.0, "lastChangeTime":
+    "swp3", "peerHostname": "leaf03", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.13", "numChanges": 5.0, "lastChangeTime":
+    1616681064000, "timestamp": 1616681581441}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "vrf": "default", "ifname": "swp2", "peerHostname": "leaf02", "area":
+    "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.12",
+    "numChanges": 5.0, "lastChangeTime": 1616681064000, "timestamp": 1616681581441},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ifname":
+    "swp1", "peerHostname": "leaf01", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.11", "numChanges": 5.0, "lastChangeTime":
     1616681064000, "timestamp": 1616681581441}]'
 - command: route top --what=numNexthops --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: route top
-  output: '[{"namespace": "ospf-single", "hostname": "spine01", "vrf": "default",
-    "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+  output: '[{"namespace": "ospf-single", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
     "10.0.0.14", "10.0.0.101", "10.0.0.102"], "oifs": ["swp1", "swp2", "swp3", "swp4",
     "swp6", "swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "numNexthops": 6, "timestamp": 1616352402846}, {"namespace":
-    "ospf-single", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    4, "action": "forward", "numNexthops": 6, "timestamp": 1616352402876}, {"namespace":
+    "ospf-single", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
     "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.101",
     "10.0.0.102"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp6", "swp5"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "numNexthops":
-    6, "timestamp": 1616352402876}, {"namespace": "ospf-ibgp", "hostname": "spine01",
-    "vrf": "default", "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
+    6, "timestamp": 1616352402846}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12",
     "10.0.0.13", "10.0.0.14", "10.0.0.101", "10.0.0.102"], "oifs": ["swp1", "swp2",
     "swp3", "swp4", "swp6", "swp5"], "protocol": "ospf", "source": "", "preference":
     20, "ipvers": 4, "action": "forward", "numNexthops": 6, "timestamp": 1616681581652},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14",
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14",
     "10.0.0.101", "10.0.0.102"], "oifs": ["swp1", "swp2", "swp3", "swp4", "swp6",
     "swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
     "forward", "numNexthops": 6, "timestamp": 1616681581652}, {"namespace": "dual-evpn",
@@ -577,39 +577,28 @@ tests:
 - command: mac top --what=moveCount --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top
-  output: '[{"namespace": "ospf-single", "hostname": "leaf02", "vlan": 10, "macaddr":
-    "00:03:00:22:22:02", "oif": "swp5", "remoteVtepIp": "", "bd": "", "flags": "",
-    "moveCount": 0, "timestamp": 1616352403916}, {"namespace": "ospf-single", "hostname":
-    "leaf02", "vlan": 0, "macaddr": "44:38:39:00:00:18", "oif": "swp5", "remoteVtepIp":
-    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1616352403916},
-    {"namespace": "ospf-single", "hostname": "leaf02", "vlan": 10, "macaddr": "44:38:39:00:00:18",
-    "oif": "bridge", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
-    0, "timestamp": 1616352403916}, {"namespace": "ospf-single", "hostname": "leaf04",
-    "vlan": 0, "macaddr": "44:38:39:00:00:2c", "oif": "swp5", "remoteVtepIp": "",
-    "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1616352403984}, {"namespace":
-    "ospf-single", "hostname": "leaf04", "vlan": 10, "macaddr": "44:38:39:00:00:2c",
-    "oif": "bridge", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
-    0, "timestamp": 1616352403984}]'
 - command: route top --what=prefixlen --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: route top
-  output: '[{"namespace": "ospf-single", "hostname": "leaf04", "vrf": "default", "prefix":
-    "10.0.0.102/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"],
-    "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward",
-    "prefixlen": 32, "timestamp": 1616352402798}, {"namespace": "ospf-single", "hostname":
-    "leaf04", "vrf": "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22"],
-    "oifs": ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
-    4, "action": "forward", "prefixlen": 32, "timestamp": 1616352402798}, {"namespace":
-    "ospf-single", "hostname": "leaf04", "vrf": "default", "prefix": "10.0.0.101/32",
-    "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["swp1", "swp2"], "protocol":
+  output: '[{"namespace": "ospf-single", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13",
+    "10.0.0.14", "10.0.0.101", "10.0.0.102"], "oifs": ["swp1", "swp2", "swp3", "swp4",
+    "swp6", "swp5"], "protocol": "ospf", "source": "", "preference": 20, "ipvers":
+    4, "action": "forward", "prefixlen": 32, "timestamp": 1616352402876}, {"namespace":
+    "ospf-single", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.14/32",
+    "nexthopIps": ["10.0.0.14"], "oifs": ["swp4"], "protocol": "ospf", "source": "",
+    "preference": 20, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp":
+    1616352402876}, {"namespace": "ospf-single", "hostname": "spine02", "vrf": "default",
+    "prefix": "10.0.0.13/32", "nexthopIps": ["10.0.0.13"], "oifs": ["swp3"], "protocol":
     "ospf", "source": "", "preference": 20, "ipvers": 4, "action": "forward", "prefixlen":
-    32, "timestamp": 1616352402798}, {"namespace": "ospf-single", "hostname": "exit02",
-    "vrf": "default", "prefix": "10.0.0.101/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["swp1", "swp2"], "protocol": "ospf", "source": "", "preference": 20,
-    "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1616352402798},
-    {"namespace": "ospf-single", "hostname": "exit02", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["10.0.0.22"], "oifs": ["swp2"], "protocol": "ospf",
-    "source": "", "preference": 20, "ipvers": 4, "action": "forward", "prefixlen":
-    32, "timestamp": 1616352402798}]'
+    32, "timestamp": 1616352402876}, {"namespace": "ospf-single", "hostname": "spine02",
+    "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps": ["10.0.0.12"], "oifs":
+    ["swp2"], "protocol": "ospf", "source": "", "preference": 20, "ipvers": 4, "action":
+    "forward", "prefixlen": 32, "timestamp": 1616352402876}, {"namespace": "ospf-single",
+    "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.11/32", "nexthopIps":
+    ["10.0.0.11"], "oifs": ["swp1"], "protocol": "ospf", "source": "", "preference":
+    20, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1616352402876}]'

--- a/tests/integration/sqcmds/eos-samples/interface.yml
+++ b/tests/integration/sqcmds/eos-samples/interface.yml
@@ -971,23 +971,23 @@ tests:
 - command: interface top --what=statusChangeTimestamp --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: interface top eos
-  output: '[{"namespace": "eos", "hostname": "dcedge01", "ifname": "dsc", "state":
-    "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master": "",
+  output: '[{"namespace": "eos", "hostname": "dcedge01", "ifname": "vtep", "state":
+    "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1623025179345,
     "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
-    "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan":
-    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
     1623025179345, "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
-    "ifname": "fti0", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
-    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    "ifname": "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 16385, "master": "", "ipAddressList": [], "ip6AddressList":
     [], "statusChangeTimestamp": 1623025179345, "timestamp": 1623025179345}, {"namespace":
-    "eos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState": "up",
-    "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [],
-    "ip6AddressList": [], "statusChangeTimestamp": 1623025179345, "timestamp": 1623025179345},
-    {"namespace": "eos", "hostname": "dcedge01", "ifname": "vtep", "state": "up",
-    "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
-    [], "ip6AddressList": [], "statusChangeTimestamp": 1623025179345, "timestamp":
-    1623025179345}]'
+    "eos", "hostname": "dcedge01", "ifname": "lo0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.41/32"], "ip6AddressList": ["fe80::205:860f:fc71:f000/128"], "statusChangeTimestamp":
+    1623025179345, "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1623025179345, "timestamp": 1623025179345}]'
 - command: interface show --type=vxlan --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: interface show eos filter

--- a/tests/integration/sqcmds/eos-samples/ospf.yml
+++ b/tests/integration/sqcmds/eos-samples/ospf.yml
@@ -248,23 +248,24 @@ tests:
 - command: ospf top --what=numChanges --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: ospf top eos
-  output: '[{"namespace": "eos", "hostname": "spine01", "vrf": "default", "ifname":
+  output: '[{"namespace": "eos", "hostname": "spine02", "vrf": "default", "ifname":
     "Ethernet6", "peerHostname": "exit02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
     1.0, "adjState": "full", "peerIP": "10.0.0.32", "numChanges": 7.0, "lastChangeTime":
-    1620677012543, "timestamp": 1623025177058}, {"namespace": "eos", "hostname": "spine01",
-    "vrf": "default", "ifname": "Ethernet4", "peerHostname": "leaf04", "area": "0.0.0.0",
-    "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.14", "numChanges":
+    1620677015479, "timestamp": 1623025177290}, {"namespace": "eos", "hostname": "spine02",
+    "vrf": "default", "ifname": "Ethernet5", "peerHostname": "exit01", "area": "0.0.0.0",
+    "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.31", "numChanges":
+    7.0, "lastChangeTime": 1622918178487, "timestamp": 1623025177290}, {"namespace":
+    "eos", "hostname": "spine01", "vrf": "default", "ifname": "Ethernet6", "peerHostname":
+    "exit02", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
+    "peerIP": "10.0.0.32", "numChanges": 7.0, "lastChangeTime": 1620677012543, "timestamp":
+    1623025177058}, {"namespace": "eos", "hostname": "spine01", "vrf": "default",
+    "ifname": "Ethernet4", "peerHostname": "leaf04", "area": "0.0.0.0", "ifState":
+    "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.14", "numChanges":
     7.0, "lastChangeTime": 1620677087548, "timestamp": 1623025177058}, {"namespace":
-    "eos", "hostname": "leaf02", "vrf": "default", "ifname": "Ethernet1", "peerHostname":
-    "spine01", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
-    "peerIP": "10.0.0.21", "numChanges": 7.0, "lastChangeTime": 1620677081758, "timestamp":
-    1623025177152}, {"namespace": "eos", "hostname": "leaf03", "vrf": "default", "ifname":
-    "Ethernet2", "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
-    1.0, "adjState": "full", "peerIP": "10.0.0.22", "numChanges": 7.0, "lastChangeTime":
-    1620677086564, "timestamp": 1623025177253}, {"namespace": "eos", "hostname": "leaf03",
-    "vrf": "default", "ifname": "Ethernet1", "peerHostname": "spine01", "area": "0.0.0.0",
-    "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.21", "numChanges":
-    7.0, "lastChangeTime": 1620677083563, "timestamp": 1623025177253}]'
+    "eos", "hostname": "leaf04", "vrf": "default", "ifname": "Ethernet2", "peerHostname":
+    "spine02", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
+    "peerIP": "10.0.0.22", "numChanges": 7.0, "lastChangeTime": 1620677086930, "timestamp":
+    1623025177660}]'
 - command: ospf show --state='passive' --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: ospf show eos filter

--- a/tests/integration/sqcmds/eos-samples/top.yml
+++ b/tests/integration/sqcmds/eos-samples/top.yml
@@ -41,44 +41,44 @@ tests:
   data-directory: tests/data/parquet/
   marks: bgp top eos
   output: '[{"namespace": "eos", "hostname": "spine02", "vrf": "default", "peer":
-    "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi": "ipv4",
-    "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges":
+    "10.0.0.31", "peerHostname": "exit01", "state": "Established", "afi": "l2vpn",
+    "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx": 42, "numChanges":
     2, "estdTime": 1622920776023, "timestamp": 1623025176023}, {"namespace": "eos",
     "hostname": "spine02", "vrf": "default", "peer": "10.0.0.31", "peerHostname":
     "exit01", "state": "Established", "afi": "ipv6", "safi": "unicast", "asn": 64520,
     "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 2, "estdTime": 1622920776023,
     "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "vrf":
     "default", "peer": "10.0.0.31", "peerHostname": "exit01", "state": "Established",
-    "afi": "l2vpn", "safi": "evpn", "asn": 64520, "peerAsn": 64520, "pfxRx": 10, "pfxTx":
-    42, "numChanges": 2, "estdTime": 1622920776023, "timestamp": 1623025176023}, {"namespace":
-    "eos", "hostname": "exit01", "vrf": "default", "peer": "10.0.0.21", "peerHostname":
-    "spine01", "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 64520,
-    "peerAsn": 64520, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021,
-    "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01", "vrf":
-    "internet-vrf", "peer": "169.254.254.10", "peerHostname": "firewall01", "state":
-    "Established", "afi": "ipv6", "safi": "unicast", "asn": 65522, "peerAsn": 65533,
-    "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime": 1622920776021, "timestamp":
+    "afi": "ipv4", "safi": "unicast", "asn": 64520, "peerAsn": 64520, "pfxRx": 0,
+    "pfxTx": 0, "numChanges": 2, "estdTime": 1622920776023, "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "peer": "169.254.254.10",
+    "peerHostname": "firewall01", "state": "Established", "afi": "ipv6", "safi": "unicast",
+    "asn": 65522, "peerAsn": 65533, "pfxRx": 0, "pfxTx": 0, "numChanges": 1, "estdTime":
+    1622920776021, "timestamp": 1623025176021}, {"namespace": "eos", "hostname": "exit01",
+    "vrf": "internet-vrf", "peer": "169.254.254.10", "peerHostname": "firewall01",
+    "state": "Established", "afi": "ipv4", "safi": "unicast", "asn": 65522, "peerAsn":
+    65533, "pfxRx": 4, "pfxTx": 6, "numChanges": 1, "estdTime": 1622920776021, "timestamp":
     1623025176021}]'
 - command: interface top --what=statusChangeTimestamp --format=json --namespace='eos'
   data-directory: tests/data/parquet/
   marks: interface top eos
-  output: '[{"namespace": "eos", "hostname": "dcedge01", "ifname": "dsc", "state":
-    "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master": "",
+  output: '[{"namespace": "eos", "hostname": "dcedge01", "ifname": "vtep", "state":
+    "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1623025179345,
     "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
-    "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan":
-    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
     1623025179345, "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
-    "ifname": "fti0", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
-    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    "ifname": "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 16385, "master": "", "ipAddressList": [], "ip6AddressList":
     [], "statusChangeTimestamp": 1623025179345, "timestamp": 1623025179345}, {"namespace":
-    "eos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState": "up",
-    "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [],
-    "ip6AddressList": [], "statusChangeTimestamp": 1623025179345, "timestamp": 1623025179345},
-    {"namespace": "eos", "hostname": "dcedge01", "ifname": "vtep", "state": "up",
-    "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
-    [], "ip6AddressList": [], "statusChangeTimestamp": 1623025179345, "timestamp":
-    1623025179345}]'
+    "eos", "hostname": "dcedge01", "ifname": "lo0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.41/32"], "ip6AddressList": ["fe80::205:860f:fc71:f000/128"], "statusChangeTimestamp":
+    1623025179345, "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1623025179345, "timestamp": 1623025179345}]'
 - command: ospf top --what=lastChangeTime --format=json --namespace='eos'
   data-directory: tests/data/parquet/
   marks: ospf top eos
@@ -102,60 +102,49 @@ tests:
 - command: route top --what=numNexthops --format=json --namespace='eos'
   data-directory: tests/data/parquet/
   marks: route top eos
-  output: '[{"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14",
+  output: '[{"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix":
+    "10.0.0.21/32", "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14",
     "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4",
     "Ethernet5", "Ethernet6"], "protocol": "ospf", "source": "", "preference": 110,
-    "ipvers": 4, "action": "forward", "numNexthops": 6, "timestamp": 1623025174547},
-    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.21/32",
+    "ipvers": 4, "action": "forward", "numNexthops": 6, "timestamp": 1623025174549},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "prefix": "10.0.0.22/32",
     "nexthopIps": ["10.0.0.11", "10.0.0.12", "10.0.0.13", "10.0.0.14", "10.0.0.31",
     "10.0.0.32"], "oifs": ["Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5",
     "Ethernet6"], "protocol": "ospf", "source": "", "preference": 110, "ipvers": 4,
-    "action": "forward", "numNexthops": 6, "timestamp": 1623025174549}, {"namespace":
-    "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
-    ["10.0.0.31", "10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
+    "action": "forward", "numNexthops": 6, "timestamp": 1623025174547}, {"namespace":
+    "eos", "hostname": "leaf04", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
+    ["10.0.0.31", "10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
     "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
-    4, "action": "forward", "numNexthops": 3, "timestamp": 1623025174530}, {"namespace":
+    4, "action": "forward", "numNexthops": 3, "timestamp": 1623025174543}, {"namespace":
     "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "prefix": "172.16.1.0/24", "nexthopIps":
     ["10.0.0.31", "10.0.0.112", "10.0.0.112"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
     "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
     4, "action": "forward", "numNexthops": 3, "timestamp": 1623025174540}, {"namespace":
-    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
+    "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "172.16.2.0/24", "nexthopIps":
     ["10.0.0.31", "10.0.0.134", "10.0.0.134"], "oifs": ["_nexthopVrf:default", "_nexthopVrf:default",
     "_nexthopVrf:default"], "protocol": "ibgp", "source": "", "preference": 200, "ipvers":
-    4, "action": "forward", "numNexthops": 3, "timestamp": 1623025174542}]'
+    4, "action": "forward", "numNexthops": 3, "timestamp": 1623025174530}]'
 - command: mac top --what=moveCount --format=json --namespace='eos'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top eos
-  output: '[{"namespace": "eos", "hostname": "server101", "vlan": 0, "macaddr": "33:33:00:00:00:01",
-    "oif": "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
-    0, "timestamp": 1623025174997}, {"namespace": "eos", "hostname": "server301",
-    "vlan": 0, "macaddr": "33:33:00:00:00:01", "oif": "eth2", "remoteVtepIp": "",
-    "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025174997}, {"namespace":
-    "eos", "hostname": "server301", "vlan": 0, "macaddr": "01:00:5e:00:00:01", "oif":
-    "eth2", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp":
-    1623025174997}, {"namespace": "eos", "hostname": "server301", "vlan": 0, "macaddr":
-    "33:33:ff:03:52:e7", "oif": "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent",
-    "moveCount": 0, "timestamp": 1623025174997}, {"namespace": "eos", "hostname":
-    "server301", "vlan": 0, "macaddr": "01:80:c2:00:00:0e", "oif": "eth1", "remoteVtepIp":
-    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025174997}]'
 - command: route top --what=prefixlen --format=json --namespace='eos'
   data-directory: tests/data/parquet/
   marks: route top eos
   output: '[{"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "prefix":
-    "fe80::205:860f:fc71:f000/128", "nexthopIps": [], "oifs": ["lo0.0"], "protocol":
-    "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward", "prefixlen":
-    128, "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "dcedge01",
-    "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol":
-    "inet6", "source": "", "preference": 0, "ipvers": 6, "action": "multirecv", "prefixlen":
-    128, "timestamp": 1623025176627}, {"namespace": "eos", "hostname": "leaf02", "vrf":
-    "default", "prefix": "10.0.0.32/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
-    "oifs": ["Ethernet1", "Ethernet2"], "protocol": "ospf", "source": "", "preference":
-    110, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1623025174530},
-    {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.112/32",
-    "nexthopIps": [], "oifs": ["Loopback1"], "protocol": "connected", "source": "",
-    "preference": 0, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp":
-    1623025174530}, {"namespace": "eos", "hostname": "leaf02", "vrf": "default", "prefix":
-    "10.0.0.22/32", "nexthopIps": [], "oifs": ["Ethernet2"], "protocol": "ospf", "source":
-    "", "preference": 0, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp":
-    1623025174530}]'
+    "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
+    "preference": 0, "ipvers": 6, "action": "multirecv", "prefixlen": 128, "timestamp":
+    1623025176627}, {"namespace": "eos", "hostname": "dcedge01", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:f000/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
+    "prefixlen": 128, "timestamp": 1623025176627}, {"namespace": "eos", "hostname":
+    "spine02", "vrf": "default", "prefix": "192.168.0.179/32", "nexthopIps": ["10.255.2.1"],
+    "oifs": ["Management1"], "protocol": "static", "source": "", "preference": 1,
+    "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1623025174549},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32",
+    "nexthopIps": [], "oifs": ["Ethernet6"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1623025174549},
+    {"namespace": "eos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": [], "oifs": ["Ethernet5"], "protocol": "ospf", "source": "", "preference":
+    0, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1623025174549}]'

--- a/tests/integration/sqcmds/junos-samples/interface.yml
+++ b/tests/integration/sqcmds/junos-samples/interface.yml
@@ -1699,22 +1699,20 @@ tests:
   output: '[{"namespace": "junos", "hostname": "spine01", "ifname": "vtep", "state":
     "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1623025803099,
-    "timestamp": 1623025803099}, {"namespace": "junos", "hostname": "leaf01", "ifname":
-    "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
-    65536, "vlan": 16385, "master": "", "ipAddressList": [], "ip6AddressList": [],
-    "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}, {"namespace":
-    "junos", "hostname": "spine01", "ifname": "bme0.0", "state": "up", "adminState":
-    "up", "type": "subinterface", "mtu": 1986, "vlan": 0, "master": "", "ipAddressList":
-    ["128.0.0.1/2", "128.0.0.4/2", "128.0.0.16/2", "128.0.0.63/2"], "ip6AddressList":
-    [], "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}, {"namespace":
-    "junos", "hostname": "spine01", "ifname": "jsrv.1", "state": "up", "adminState":
-    "up", "type": "subinterface", "mtu": 1514, "vlan": 1, "master": "", "ipAddressList":
-    ["128.0.0.127/2"], "ip6AddressList": [], "statusChangeTimestamp": 1623025803099,
     "timestamp": 1623025803099}, {"namespace": "junos", "hostname": "spine01", "ifname":
-    "lo0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
-    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList":
-    ["fe80::205:860f:fc71:2e00/128"], "statusChangeTimestamp": 1623025803099, "timestamp":
-    1623025803099}]'
+    "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1623025803099, "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+    "spine01", "ifname": "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 16385, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}, {"namespace":
+    "junos", "hostname": "spine01", "ifname": "lo0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.21/32"], "ip6AddressList": ["fe80::205:860f:fc71:2e00/128"], "statusChangeTimestamp":
+    1623025803099, "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+    "spine01", "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}]'
 - command: interface show --ifname="xe-0/0/1" --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: interface show junos

--- a/tests/integration/sqcmds/junos-samples/ospf.yml
+++ b/tests/integration/sqcmds/junos-samples/ospf.yml
@@ -161,22 +161,24 @@ tests:
 - command: ospf top --what=numChanges --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: ospf top junos
-  output: '[{"namespace": "junos", "hostname": "leaf02", "vrf": "default", "ifname":
-    "lo0.0", "peerHostname": "", "area": "0.0.0.0", "ifState": "up", "nbrCount": 0.0,
-    "adjState": "passive", "peerIP": "", "numChanges": 0.0, "lastChangeTime": 0, "timestamp":
-    1623025798026}, {"namespace": "junos", "hostname": "spine01", "vrf": "default",
+  output: '[{"namespace": "junos", "hostname": "spine02", "vrf": "default", "ifname":
+    "xe-0/0/3.0", "peerHostname": "exit02", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.32", "numChanges": 0.0, "lastChangeTime":
+    1622998701688, "timestamp": 1623025799761}, {"namespace": "junos", "hostname":
+    "spine02", "vrf": "default", "ifname": "xe-0/0/2.0", "peerHostname": "exit01",
+    "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP":
+    "10.0.0.31", "numChanges": 0.0, "lastChangeTime": 1622998711688, "timestamp":
+    1623025799761}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
+    "ifname": "xe-0/0/1.0", "peerHostname": "leaf02", "area": "0.0.0.0", "ifState":
+    "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.12", "numChanges":
+    0.0, "lastChangeTime": 1622998742688, "timestamp": 1623025799761}, {"namespace":
+    "junos", "hostname": "spine02", "vrf": "default", "ifname": "xe-0/0/0.0", "peerHostname":
+    "leaf01", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
+    "peerIP": "10.0.0.11", "numChanges": 0.0, "lastChangeTime": 1622998720688, "timestamp":
+    1623025799761}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
     "ifname": "lo0.0", "peerHostname": "", "area": "0.0.0.0", "ifState": "up", "nbrCount":
     0.0, "adjState": "passive", "peerIP": "", "numChanges": 0.0, "lastChangeTime":
-    0, "timestamp": 1623025798027}, {"namespace": "junos", "hostname": "exit01", "vrf":
-    "default", "ifname": "lo0.0", "peerHostname": "", "area": "0.0.0.0", "ifState":
-    "up", "nbrCount": 0.0, "adjState": "passive", "peerIP": "", "numChanges": 0.0,
-    "lastChangeTime": 0, "timestamp": 1623025798361}, {"namespace": "junos", "hostname":
-    "leaf01", "vrf": "default", "ifname": "lo0.0", "peerHostname": "", "area": "0.0.0.0",
-    "ifState": "up", "nbrCount": 0.0, "adjState": "passive", "peerIP": "", "numChanges":
-    0.0, "lastChangeTime": 0, "timestamp": 1623025798813}, {"namespace": "junos",
-    "hostname": "exit02", "vrf": "default", "ifname": "lo0.0", "peerHostname": "",
-    "area": "0.0.0.0", "ifState": "up", "nbrCount": 0.0, "adjState": "passive", "peerIP":
-    "", "numChanges": 0.0, "lastChangeTime": 0, "timestamp": 1623025799339}]'
+    0, "timestamp": 1623025799761}]'
 - command: ospf show --columns='hostname vrf ifname adjState area peerHostname' --namespace=junos
     --format=json
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/junos-samples/top.yml
+++ b/tests/integration/sqcmds/junos-samples/top.yml
@@ -65,22 +65,20 @@ tests:
   output: '[{"namespace": "junos", "hostname": "spine01", "ifname": "vtep", "state":
     "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1623025803099,
-    "timestamp": 1623025803099}, {"namespace": "junos", "hostname": "leaf01", "ifname":
-    "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
-    65536, "vlan": 16385, "master": "", "ipAddressList": [], "ip6AddressList": [],
-    "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}, {"namespace":
-    "junos", "hostname": "spine01", "ifname": "bme0.0", "state": "up", "adminState":
-    "up", "type": "subinterface", "mtu": 1986, "vlan": 0, "master": "", "ipAddressList":
-    ["128.0.0.1/2", "128.0.0.4/2", "128.0.0.16/2", "128.0.0.63/2"], "ip6AddressList":
-    [], "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}, {"namespace":
-    "junos", "hostname": "spine01", "ifname": "jsrv.1", "state": "up", "adminState":
-    "up", "type": "subinterface", "mtu": 1514, "vlan": 1, "master": "", "ipAddressList":
-    ["128.0.0.127/2"], "ip6AddressList": [], "statusChangeTimestamp": 1623025803099,
     "timestamp": 1623025803099}, {"namespace": "junos", "hostname": "spine01", "ifname":
-    "lo0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
-    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList":
-    ["fe80::205:860f:fc71:2e00/128"], "statusChangeTimestamp": 1623025803099, "timestamp":
-    1623025803099}]'
+    "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1623025803099, "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+    "spine01", "ifname": "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 16385, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}, {"namespace":
+    "junos", "hostname": "spine01", "ifname": "lo0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.21/32"], "ip6AddressList": ["fe80::205:860f:fc71:2e00/128"], "statusChangeTimestamp":
+    1623025803099, "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+    "spine01", "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "statusChangeTimestamp": 1623025803099, "timestamp": 1623025803099}]'
 - command: ospf top --what=lastChangeTime --format=json --namespace='junos'
   data-directory: tests/data/parquet/
   marks: ospf top junos
@@ -114,49 +112,38 @@ tests:
     "10.0.0.31", "10.0.0.32"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0", "xe-0/0/2.0",
     "xe-0/0/3.0"], "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4,
     "action": "forward", "numNexthops": 4, "timestamp": 1623025802890}, {"namespace":
-    "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.12/32", "nexthopIps":
+    "junos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
     ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol":
     "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward", "numNexthops":
-    2, "timestamp": 1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    2, "timestamp": 1623025802263}, {"namespace": "junos", "hostname": "leaf02", "vrf":
     "default", "prefix": "10.0.0.31/32", "nexthopIps": ["10.0.0.21", "10.0.0.22"],
     "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"], "protocol": "ospf", "source": "", "preference":
-    10, "ipvers": 4, "action": "forward", "numNexthops": 2, "timestamp": 1623025801173},
-    {"namespace": "junos", "hostname": "leaf01", "vrf": "default", "prefix": "10.0.0.32/32",
+    10, "ipvers": 4, "action": "forward", "numNexthops": 2, "timestamp": 1623025802263},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "default", "prefix": "10.0.0.11/32",
     "nexthopIps": ["10.0.0.21", "10.0.0.22"], "oifs": ["xe-0/0/0.0", "xe-0/0/1.0"],
     "protocol": "ospf", "source": "", "preference": 10, "ipvers": 4, "action": "forward",
-    "numNexthops": 2, "timestamp": 1623025801173}]'
+    "numNexthops": 2, "timestamp": 1623025802263}]'
 - command: mac top --what=moveCount --format=json --namespace='junos'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top junos
-  output: '[{"namespace": "junos", "hostname": "firewall01", "vlan": 0, "macaddr":
-    "01:00:5e:00:00:01", "oif": "eth0", "remoteVtepIp": "", "bd": "", "flags": "permanent",
-    "moveCount": 0, "timestamp": 1623025795510}, {"namespace": "junos", "hostname":
-    "firewall01", "vlan": 0, "macaddr": "33:33:00:00:00:01", "oif": "eth1.4", "remoteVtepIp":
-    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025795510},
-    {"namespace": "junos", "hostname": "firewall01", "vlan": 0, "macaddr": "33:33:00:00:00:01",
-    "oif": "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
-    0, "timestamp": 1623025795510}, {"namespace": "junos", "hostname": "firewall01",
-    "vlan": 0, "macaddr": "33:33:00:00:00:02", "oif": "eth1", "remoteVtepIp": "",
-    "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025795510}, {"namespace":
-    "junos", "hostname": "firewall01", "vlan": 0, "macaddr": "01:00:5e:00:00:01",
-    "oif": "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
-    0, "timestamp": 1623025795510}]'
 - command: route top --what=prefixlen --format=json --namespace='junos'
   data-directory: tests/data/parquet/
   marks: route top junos
-  output: '[{"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "prefix":
+  output: '[{"namespace": "junos", "hostname": "spine02", "vrf": "default", "prefix":
     "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "",
     "preference": 0, "ipvers": 6, "action": "multirecv", "prefixlen": 128, "timestamp":
-    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
-    "prefix": "ff02::2/128", "nexthopIps": [], "oifs": [], "protocol": "inet6", "source":
-    "", "preference": 0, "ipvers": 6, "action": "multirecv", "prefixlen": 128, "timestamp":
-    1623025801173}, {"namespace": "junos", "hostname": "leaf01", "vrf": "default",
-    "prefix": "fe80::205:860f:fc71:ad00/128", "nexthopIps": [], "oifs": ["lo0.0"],
+    1623025802688}, {"namespace": "junos", "hostname": "spine02", "vrf": "default",
+    "prefix": "fe80::205:860f:fc71:c600/128", "nexthopIps": [], "oifs": ["lo0.0"],
     "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
-    "prefixlen": 128, "timestamp": 1623025801173}, {"namespace": "junos", "hostname":
-    "leaf02", "vrf": "default", "prefix": "fe80::205:860f:fc71:5500/128", "nexthopIps":
-    [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference": 0, "ipvers":
-    6, "action": "forward", "prefixlen": 128, "timestamp": 1623025802263}, {"namespace":
-    "junos", "hostname": "leaf02", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps":
-    [], "oifs": [], "protocol": "inet6", "source": "", "preference": 0, "ipvers":
-    6, "action": "multirecv", "prefixlen": 128, "timestamp": 1623025802263}]'
+    "prefixlen": 128, "timestamp": 1623025802688}, {"namespace": "junos", "hostname":
+    "spine01", "vrf": "default", "prefix": "ff02::2/128", "nexthopIps": [], "oifs":
+    [], "protocol": "inet6", "source": "", "preference": 0, "ipvers": 6, "action":
+    "multirecv", "prefixlen": 128, "timestamp": 1623025802890}, {"namespace": "junos",
+    "hostname": "spine01", "vrf": "default", "prefix": "fe80::205:860f:fc71:2e00/128",
+    "nexthopIps": [], "oifs": ["lo0.0"], "protocol": "direct", "source": "", "preference":
+    0, "ipvers": 6, "action": "forward", "prefixlen": 128, "timestamp": 1623025802890},
+    {"namespace": "junos", "hostname": "leaf02", "vrf": "evpn-vrf", "prefix": "ff02::2/128",
+    "nexthopIps": [], "oifs": [], "protocol": "inet6", "source": "", "preference":
+    0, "ipvers": 6, "action": "multirecv", "prefixlen": 128, "timestamp": 1623025802263}]'

--- a/tests/integration/sqcmds/nxos-samples/interface.yml
+++ b/tests/integration/sqcmds/nxos-samples/interface.yml
@@ -2242,24 +2242,24 @@ tests:
 - command: interface top --what=statusChangeTimestamp --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: interface top nxos
-  output: '[{"namespace": "nxos", "hostname": "dcedge01", "ifname": "gr-0/0/0", "state":
-    "up", "adminState": "up", "type": "gre", "mtu": 65536, "vlan": 0, "master": "",
+  output: '[{"namespace": "nxos", "hostname": "dcedge01", "ifname": "vtep", "state":
+    "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985,
     "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
-    "lo0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
-    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList":
-    ["fe80::205:860f:fc71:3c00/128"], "statusChangeTimestamp": 1619275258985, "timestamp":
-    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "vtep",
-    "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master":
-    "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985,
-    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
-    "bme0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1986,
-    "vlan": 0, "master": "", "ipAddressList": ["128.0.0.1/2", "128.0.0.4/2", "128.0.0.16/2",
-    "128.0.0.63/2"], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985,
-    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
-    "jsrv.1", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1514,
-    "vlan": 1, "master": "", "ipAddressList": ["128.0.0.127/2"], "ip6AddressList":
-    [], "statusChangeTimestamp": 1619275258985, "timestamp": 1619275258985}]'
+    "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1619275258985, "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "lo0.16385", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 16385, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "statusChangeTimestamp": 1619275258985, "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "lo0.0", "state": "up",
+    "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList": ["fe80::205:860f:fc71:3c00/128"],
+    "statusChangeTimestamp": 1619275258985, "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985, "timestamp":
+    1619275258985}]'
 - command: interface show --ifname="Ethernet1/1" --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: interface show nxos

--- a/tests/integration/sqcmds/nxos-samples/ospf.yml
+++ b/tests/integration/sqcmds/nxos-samples/ospf.yml
@@ -258,24 +258,24 @@ tests:
 - command: ospf top --what=numChanges --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: ospf top nxos
-  output: '[{"namespace": "nxos", "hostname": "leaf03", "vrf": "default", "ifname":
-    "Ethernet1/2", "peerHostname": "spine02", "area": "0.0.0.0", "ifState": "up",
-    "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.22", "numChanges": 7.0,
-    "lastChangeTime": 1619045052091, "timestamp": 1619275260398}, {"namespace": "nxos",
-    "hostname": "leaf03", "vrf": "default", "ifname": "Ethernet1/1", "peerHostname":
-    "spine01", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
-    "peerIP": "10.0.0.21", "numChanges": 7.0, "lastChangeTime": 1619045052091, "timestamp":
-    1619275260398}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
-    "ifname": "Ethernet1/3", "peerHostname": "leaf03", "area": "0.0.0.0", "ifState":
-    "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.13", "numChanges":
-    7.0, "lastChangeTime": 1619014447056, "timestamp": 1619275260613}, {"namespace":
-    "nxos", "hostname": "spine02", "vrf": "default", "ifname": "Ethernet1/2", "peerHostname":
-    "leaf02", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
-    "peerIP": "10.0.0.12", "numChanges": 7.0, "lastChangeTime": 1619014447056, "timestamp":
+  output: '[{"namespace": "nxos", "hostname": "spine02", "vrf": "default", "ifname":
+    "Ethernet1/3", "peerHostname": "leaf03", "area": "0.0.0.0", "ifState": "up", "nbrCount":
+    1.0, "adjState": "full", "peerIP": "10.0.0.13", "numChanges": 7.0, "lastChangeTime":
+    1619014447056, "timestamp": 1619275260613}, {"namespace": "nxos", "hostname":
+    "spine02", "vrf": "default", "ifname": "Ethernet1/2", "peerHostname": "leaf02",
+    "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full", "peerIP":
+    "10.0.0.12", "numChanges": 7.0, "lastChangeTime": 1619014447056, "timestamp":
     1619275260613}, {"namespace": "nxos", "hostname": "spine02", "vrf": "default",
     "ifname": "Ethernet1/1", "peerHostname": "leaf01", "area": "0.0.0.0", "ifState":
     "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.11", "numChanges":
-    7.0, "lastChangeTime": 1619014447056, "timestamp": 1619275260613}]'
+    7.0, "lastChangeTime": 1619014447056, "timestamp": 1619275260613}, {"namespace":
+    "nxos", "hostname": "spine01", "vrf": "default", "ifname": "Ethernet1/3", "peerHostname":
+    "leaf03", "area": "0.0.0.0", "ifState": "up", "nbrCount": 1.0, "adjState": "full",
+    "peerIP": "10.0.0.13", "numChanges": 7.0, "lastChangeTime": 1619014444515, "timestamp":
+    1619275262040}, {"namespace": "nxos", "hostname": "leaf03", "vrf": "default",
+    "ifname": "Ethernet1/2", "peerHostname": "spine02", "area": "0.0.0.0", "ifState":
+    "up", "nbrCount": 1.0, "adjState": "full", "peerIP": "10.0.0.22", "numChanges":
+    7.0, "lastChangeTime": 1619045052091, "timestamp": 1619275260398}]'
 - command: ospf show --ifname=Ethernet1/2 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: ospf show nxos filter

--- a/tests/integration/sqcmds/nxos-samples/top.yml
+++ b/tests/integration/sqcmds/nxos-samples/top.yml
@@ -65,24 +65,24 @@ tests:
 - command: interface top --what=statusChangeTimestamp --format=json --namespace='nxos'
   data-directory: tests/data/parquet/
   marks: interface top nxos
-  output: '[{"namespace": "nxos", "hostname": "dcedge01", "ifname": "gr-0/0/0", "state":
-    "up", "adminState": "up", "type": "gre", "mtu": 65536, "vlan": 0, "master": "",
+  output: '[{"namespace": "nxos", "hostname": "dcedge01", "ifname": "vtep", "state":
+    "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985,
     "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
-    "lo0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
-    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList":
-    ["fe80::205:860f:fc71:3c00/128"], "statusChangeTimestamp": 1619275258985, "timestamp":
-    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "vtep",
-    "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master":
-    "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985,
-    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
-    "bme0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1986,
-    "vlan": 0, "master": "", "ipAddressList": ["128.0.0.1/2", "128.0.0.4/2", "128.0.0.16/2",
-    "128.0.0.63/2"], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985,
-    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
-    "jsrv.1", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1514,
-    "vlan": 1, "master": "", "ipAddressList": ["128.0.0.127/2"], "ip6AddressList":
-    [], "statusChangeTimestamp": 1619275258985, "timestamp": 1619275258985}]'
+    "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
+    1619275258985, "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "lo0.16385", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 16385, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "statusChangeTimestamp": 1619275258985, "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "lo0.0", "state": "up",
+    "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList": ["fe80::205:860f:fc71:3c00/128"],
+    "statusChangeTimestamp": 1619275258985, "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "statusChangeTimestamp": 1619275258985, "timestamp":
+    1619275258985}]'
 - command: ospf top --what=lastChangeTime --format=json --namespace='nxos'
   data-directory: tests/data/parquet/
   marks: ospf top nxos
@@ -117,33 +117,22 @@ tests:
     "10.0.0.14", "10.0.0.31", "10.0.0.32"], "oifs": ["Ethernet1/1", "Ethernet1/2",
     "Ethernet1/3", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "protocol": "ospf",
     "source": "", "preference": 110, "ipvers": 4, "action": "forward", "numNexthops":
-    6, "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "firewall01",
-    "vrf": "default", "prefix": "169.254.127.2/31", "nexthopIps": ["169.254.253.9",
-    "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200",
-    "preference": 20, "ipvers": 4, "action": "forward", "numNexthops": 2, "timestamp":
-    1619275256109}, {"namespace": "nxos", "hostname": "firewall01", "vrf": "default",
-    "prefix": "169.254.127.0/31", "nexthopIps": ["169.254.253.9", "169.254.254.9"],
-    "oifs": ["eth2.4", "eth1.4"], "protocol": "bgp", "source": "10.0.0.200", "preference":
-    20, "ipvers": 4, "action": "forward", "numNexthops": 2, "timestamp": 1619275256109},
-    {"namespace": "nxos", "hostname": "firewall01", "vrf": "default", "prefix": "169.254.0.0/24",
-    "nexthopIps": ["169.254.253.9", "169.254.254.9"], "oifs": ["eth2.4", "eth1.4"],
-    "protocol": "bgp", "source": "10.0.0.200", "preference": 20, "ipvers": 4, "action":
-    "forward", "numNexthops": 2, "timestamp": 1619275256109}]'
+    6, "timestamp": 1619275257467}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.22/32", "nexthopIps": ["10.0.0.22", "10.0.0.22"],
+    "oifs": ["Lo0", "Lo0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "numNexthops": 2, "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.134/32", "nexthopIps":
+    ["10.0.0.13", "10.0.0.14"], "oifs": ["Ethernet1/3", "Ethernet1/4"], "protocol":
+    "ospf", "source": "", "preference": 110, "ipvers": 4, "action": "forward", "numNexthops":
+    2, "timestamp": 1619275257123}, {"namespace": "nxos", "hostname": "spine02", "vrf":
+    "default", "prefix": "10.0.0.112/32", "nexthopIps": ["10.0.0.11", "10.0.0.12"],
+    "oifs": ["Ethernet1/1", "Ethernet1/2"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "numNexthops": 2, "timestamp": 1619275257123}]'
 - command: mac top --what=moveCount --format=json --namespace='nxos'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top nxos
-  output: '[{"namespace": "nxos", "hostname": "server101", "vlan": 0, "macaddr": "33:33:00:00:00:01",
-    "oif": "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
-    0, "timestamp": 1619275256085}, {"namespace": "nxos", "hostname": "server102",
-    "vlan": 0, "macaddr": "01:00:5e:00:00:01", "oif": "eth2", "remoteVtepIp": "",
-    "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1619275256085}, {"namespace":
-    "nxos", "hostname": "server102", "vlan": 0, "macaddr": "01:80:c2:00:00:02", "oif":
-    "eth2", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp":
-    1619275256085}, {"namespace": "nxos", "hostname": "server102", "vlan": 0, "macaddr":
-    "01:80:c2:00:00:00", "oif": "eth2", "remoteVtepIp": "", "bd": "", "flags": "permanent",
-    "moveCount": 0, "timestamp": 1619275256085}, {"namespace": "nxos", "hostname":
-    "server102", "vlan": 0, "macaddr": "01:80:c2:00:00:03", "oif": "eth2", "remoteVtepIp":
-    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1619275256085}]'
 - command: route top --what=prefixlen --format=json --namespace='nxos'
   data-directory: tests/data/parquet/
   marks: route top nxos
@@ -154,13 +143,13 @@ tests:
     "prefix": "fe80::205:860f:fc71:3c00/128", "nexthopIps": [], "oifs": ["lo0.0"],
     "protocol": "direct", "source": "", "preference": 0, "ipvers": 6, "action": "forward",
     "prefixlen": 128, "timestamp": 1619275257671}, {"namespace": "nxos", "hostname":
-    "server101", "vrf": "default", "prefix": "10.255.2.1/32", "nexthopIps": [""],
-    "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.204", "preference":
-    20, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1619275256085},
-    {"namespace": "nxos", "hostname": "server102", "vrf": "default", "prefix": "10.255.2.1/32",
-    "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp", "source": "10.255.2.39",
-    "preference": 20, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp":
-    1619275256085}, {"namespace": "nxos", "hostname": "server301", "vrf": "default",
-    "prefix": "10.255.2.1/32", "nexthopIps": [""], "oifs": ["eth0"], "protocol": "dhcp",
-    "source": "10.255.2.140", "preference": 20, "ipvers": 4, "action": "forward",
-    "prefixlen": 32, "timestamp": 1619275256093}]'
+    "spine02", "vrf": "management", "prefix": "10.255.2.120/32", "nexthopIps": ["10.255.2.120"],
+    "oifs": ["mgmt0"], "protocol": "local", "source": "", "preference": 0, "ipvers":
+    4, "action": "forward", "prefixlen": 32, "timestamp": 1619275257123}, {"namespace":
+    "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.32/32", "nexthopIps":
+    ["10.0.0.32"], "oifs": ["Ethernet1/6"], "protocol": "ospf", "source": "", "preference":
+    110, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp": 1619275257123},
+    {"namespace": "nxos", "hostname": "spine02", "vrf": "default", "prefix": "10.0.0.31/32",
+    "nexthopIps": ["10.0.0.31"], "oifs": ["Ethernet1/5"], "protocol": "ospf", "source":
+    "", "preference": 110, "ipvers": 4, "action": "forward", "prefixlen": 32, "timestamp":
+    1619275257123}]'

--- a/tests/integration/sqcmds/panos-samples/interface.yml
+++ b/tests/integration/sqcmds/panos-samples/interface.yml
@@ -893,7 +893,7 @@ tests:
     "panos", "hostname": "leaf02", "ifname": "bond01", "state": "up", "adminState":
     "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "bridge", "ipAddressList":
     [], "ip6AddressList": [], "statusChangeTimestamp": 1639466737190, "timestamp":
-    1639476254836}, {"namespace": "panos", "hostname": "leaf01", "ifname": "bond01",
+    1639476254836}, {"namespace": "panos", "hostname": "leaf01", "ifname": "bond02",
     "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master":
     "bridge", "ipAddressList": [], "ip6AddressList": [], "statusChangeTimestamp":
     1639466736510, "timestamp": 1639476254854}]'


### PR DESCRIPTION
This PR fixes the top output to return consistent result across different machine since it is possible that, when multiple rows have the same and highest value of the table, the top N result might differ because of a different indexin/ordering in the dataframe. To prevent this, we now sort the df by the required column and by key columns before picking the first N rows.

With this modification performance will decrease when used in tables with many rows (more than 1 million), so we may change the way we address the problem in the future.

Test data are also updated for top as well as for network find in a separate commit.