### PR TITLE
Fix coalescer period and tz docs in config file

### DIFF
--- a/suzieq/config/etc/suzieq-cfg.yml
+++ b/suzieq/config/etc/suzieq-cfg.yml
@@ -49,10 +49,14 @@ poller:
   #   policy: sequential
 
 coalescer:
-  # valid suffixes are h for hour, d for day and w for week
-  # 1h is 1 hour, 2w is 2 weeks and so on. y for year and m for month
-  # don't make sense because those are not fixed units. We don't yet support
-  # periods less than an hour.
+  # The coalescer has the role to group the single parquet files into a bigger
+  # one which represent a snapshot of the entire network, which is performed at
+  # every coalescing period. This value can be expressed using the following
+  # notation <value><m,h,d,w>, where:
+  # m: minutes (i.e. 30m )
+  # h: hours (i.e. 12h )
+  # d: days (i.e. 1d )
+  # w: weeks (i.e. 3w )
   period: 1h
   # Comment the next line if you don't want the archive directory. This dir is
   # purely to save the uncoalesced data in raw format to avoid data loss in case

--- a/suzieq/config/etc/suzieq-cfg.yml
+++ b/suzieq/config/etc/suzieq-cfg.yml
@@ -73,4 +73,6 @@ analyzer:
   # this line if you want the analyzer (CLI/GUI/REST) to display the time
   # in a different timezone than the local time. The timestamp stored in
   # the database is always in UTC.
+  # Check all the supported values at the "TZ database name" columns of the
+  # table at this link: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 #  timezone: America/Los_Angeles


### PR DESCRIPTION
This PR introduces some fixes of the documentation of the configuration file:
- Coalescing period: the docs about the format of the coalescing period was out of date, reporting hours as the minimum granularity. However, this has been solved long time ago [here](https://github.com/netenglabs/suzieq/commit/466b49aaf1a97524bc32c3499694428caa3cb1a6)
- The docs of the timezone didn't give any hint about the supported values. Added a Wikipedia reference with the accepted values.