### PR TITLE
Ospf and bgp small assert fix

### DIFF
--- a/suzieq/engines/pandas/bgp.py
+++ b/suzieq/engines/pandas/bgp.py
@@ -267,8 +267,7 @@ class BgpObj(SqPandasEngine):
 
             failed_df['assertReason'] += failed_df.apply(
                 lambda x: ["asn mismatch"]
-                if (x['peerHostname'] and ((x["asn"] != x["peerAsn_y"]) or
-                                           (x['asn_y'] != x['peerAsn'])))
+                if (x['peerHostname'] and (x["asn"] != x['peerAsn']))
                 else [], axis=1)
 
             failed_df['assertReason'] += failed_df.apply(

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -310,7 +310,9 @@ class OspfObj(SqPandasEngine):
             return self._create_aver_result([pasv_df, ifdown_df, failed_df],
                                             result)
 
-        peer_df["assertReason"] = [[] for _ in range(len(peer_df))]
+        peer_df = peer_df.rename(columns={
+            'assertReason_x': 'assertReason'
+        }).drop(columns=['assertReason_y'])
 
         # Now start comparing the various parameters
         peer_df["assertReason"] += peer_df.apply(


### PR DESCRIPTION
This PR contains:
- a fix for ospf which was deleting the first assertions found in ospf_df
- a fix for bgp assertion with unexistent columns. We found this bug thanks to Claudio's hypotesis tests. Our tests never enter in that specific piece of code