### PR TITLE
Update test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![integration-tests](https://github.com/netenglabs/suzieq/workflows/integration-tests/badge.svg)](https://github.com/netenglabs/suzieq/actions/workflows/integration-tests.yml)
+[![integration-tests](https://github.com/netenglabs/suzieq/workflows/integration-tests/badge.svg?branch=master)](https://github.com/netenglabs/suzieq/actions/workflows/integration-tests.yml)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/netenglabs/suzieq?logo=github&color=success)](https://github.com/netenglabs/suzieq/releases/latest)
 [![GitHub](https://img.shields.io/github/license/netenglabs/suzieq?logo=github&color=success)](LICENSE)
 [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/netenglabs/suzieq?logo=docker&color=blue)](https://hub.docker.com/r/netenglabs/suzieq/tags?page=1&ordering=last_updated)


### PR DESCRIPTION
Since we are going to have `develop` as default branch, this PR updates the badge in the README so that it points to the release branch (`master`).