### PR TITLE
Fix load_sq_config calls in worker tests

### DIFF
--- a/tests/integration/test_rest_http.py
+++ b/tests/integration/test_rest_http.py
@@ -21,7 +21,7 @@ def test_server_exec():
     port = randint(9000, 10000)
     # We need to change the port used to avoid conflicts
     cfgfile = create_dummy_config_file()
-    sqcfg = load_sq_config(cfgfile)
+    sqcfg = load_sq_config(config_file=cfgfile)
 
     if 'rest' not in sqcfg:
         sqcfg['rest'] = {'port': port}

--- a/tests/integration/test_update_data.py
+++ b/tests/integration/test_update_data.py
@@ -46,7 +46,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
 def create_config(t_dir, suzieq_dir):
     '''Create dummy config'''
     # We need to create a tempfile to hold the config
-    tmpconfig = load_sq_config(conftest.create_dummy_config_file())
+    tmpconfig = load_sq_config(config_file=conftest.create_dummy_config_file())
     tmpconfig['data-directory'] = f"{t_dir}/parquet"
     tmpconfig['service-directory'] = \
         f"{suzieq_dir}/{tmpconfig['service-directory']}"
@@ -453,7 +453,8 @@ def _test_data(topology, proto, scenario, testvar):
     # pylint: disable=redefined-outer-name
     name = f'{topology}_{proto}_{scenario}'
     testvar['data-directory'] = f"{parquet_dir}/{name}/parquet-out"
-    dummy_config = load_sq_config(conftest.create_dummy_config_file())
+    dummy_config = load_sq_config(
+        config_file=conftest.create_dummy_config_file())
     _test_sqcmds(dummy_config, testvar)
 
 

--- a/tests/unit/poller/controller/manager/test_static_manager.py
+++ b/tests/unit/poller/controller/manager/test_static_manager.py
@@ -43,7 +43,7 @@ def manager_cfg():
     """
     args = {}
     args['config'] = create_dummy_config_file()
-    args['config-dict'] = load_sq_config(args['config'])
+    args['config-dict'] = load_sq_config(config_file=args['config'])
     yield args
     os.remove(args['config'])
 

--- a/tests/unit/poller/controller/test_controller.py
+++ b/tests/unit/poller/controller/test_controller.py
@@ -14,7 +14,7 @@ from suzieq.poller.controller.manager.static import StaticManager
 from suzieq.poller.controller.source.native import SqNativeFile
 from suzieq.poller.controller.source.netbox import Netbox
 from suzieq.shared.exceptions import InventorySourceError, SqPollerConfError
-from suzieq.shared.utils import load_sq_config, sq_get_config_file
+from suzieq.shared.utils import load_sq_config
 from tests.conftest import create_dummy_config_file, get_async_task_mock
 
 # pylint: disable=protected-access
@@ -184,7 +184,7 @@ _INVALID_ARGS = [
 
 
 def generate_controller(args: Dict, inv_file: str = None,
-                        conf_file: str = '') -> Controller:
+                        conf_file: str = None) -> Controller:
     """Generate a Controller object
 
     Args:
@@ -195,7 +195,7 @@ def generate_controller(args: Dict, inv_file: str = None,
     Returns:
         Controller: the newly created Controller
     """
-    if conf_file == '':
+    if not conf_file:
         conf_file = create_dummy_config_file()
     config = load_sq_config(config_file=conf_file)
     args = update_args(args, inv_file, conf_file)
@@ -401,7 +401,7 @@ def test_missing_default_inventory(default_args):
     with patch.multiple(controller_module,
                         DEFAULT_INVENTORY_PATH='/not/a/path'):
         with pytest.raises(SqPollerConfError):
-            generate_controller(args=args, conf_file=None)
+            generate_controller(args=args)
 
 
 @pytest.mark.poller
@@ -416,11 +416,10 @@ def test_default_controller_config(default_args):
     with NamedTemporaryFile(suffix='yml') as tmpfile:
         with patch.multiple(controller_module,
                             DEFAULT_INVENTORY_PATH=tmpfile.name):
-            c = generate_controller(args=args, conf_file=None)
+            c = generate_controller(args=args)
             assert c._config['source']['path'] == tmpfile.name
             assert c._input_dir is None
             assert c._no_coalescer is False
-            assert c._config['manager']['config'] == sq_get_config_file(None)
             assert c._config['manager']['workers'] == 1
             assert c.period == 3600
             assert c._single_run_mode is None

--- a/tests/unit/poller/worker/services/test_service.py
+++ b/tests/unit/poller/worker/services/test_service.py
@@ -24,7 +24,7 @@ def service_for_diff():
     """Init the service for testing the get_diff() function
     """
     cfg_file = create_dummy_config_file()
-    cfg = load_sq_config(cfg_file)
+    cfg = load_sq_config(config_file=cfg_file)
     # Build the shema
     schema_dir = cfg['schema-directory']
     schema = Schema(schema_dir)

--- a/tests/unit/poller/worker/test_worker.py
+++ b/tests/unit/poller/worker/test_worker.py
@@ -82,7 +82,7 @@ async def run_worker_with_mocks(poller: Worker) -> Dict[str, MagicMock]:
 def test_worker_object_init_validation(poller_args):
     """Test Poller object user_args validation
     """
-    cfg = load_sq_config(poller_args.config)
+    cfg = load_sq_config(config_file=poller_args.config)
 
     # Test invalid ssh config file
     poller_args.ssh_config_file = 'invalid'
@@ -98,7 +98,7 @@ def test_worker_object_init_validation(poller_args):
 async def test_add_pop_worker_task(poller_args):
     """Test the methods for adding and removing the poller tasks
     """
-    cfg = load_sq_config(poller_args.config)
+    cfg = load_sq_config(config_file=poller_args.config)
     poller = Worker(poller_args, cfg)
     # Test add_poller_task()
     tasks = [asyncio.Future(), asyncio.Future()]
@@ -122,7 +122,7 @@ async def test_add_pop_worker_task(poller_args):
 async def test_poller_worker_run(poller_args):
     """Check if all the services are launched after calling Poller.run()
     """
-    cfg = load_sq_config(poller_args.config)
+    cfg = load_sq_config(config_file=poller_args.config)
     poller = Worker(poller_args, cfg)
 
     mks = await run_worker_with_mocks(poller)
@@ -138,7 +138,7 @@ async def test_poller_worker_run(poller_args):
 def test_worker_inventory_init(poller_args):
     """Test if all the parameters are correctly passed to the Inventory
     """
-    cfg = load_sq_config(poller_args.config)
+    cfg = load_sq_config(config_file=poller_args.config)
     poller_args.ssh_config_file = 'config/file'
     cfg['poller']['connect-timeout'] = 30
     with patch.multiple(Worker, _validate_worker_args=MagicMock()):
@@ -158,7 +158,7 @@ def test_worker_inventory_init_addnl_args(poller_args):
     """Test if all the additional params are actually passed to the
     Inventory class init function
     """
-    cfg = load_sq_config(poller_args.config)
+    cfg = load_sq_config(config_file=poller_args.config)
     poller_args.ssh_config_file = 'config/file'
     cfg['poller']['connect-timeout'] = 30
     dummy_inventory_class = MagicMock()
@@ -202,7 +202,7 @@ def test_worker_inventory_init_addnl_args(poller_args):
 def test_worker_service_manager_init(poller_args):
     """Test if all the parameters are correctly passed to the ServiceManager
     """
-    cfg = load_sq_config(poller_args.config)
+    cfg = load_sq_config(config_file=poller_args.config)
     poller_args.run_once = 'gather'
     cfg['poller']['period'] = 30
     poller = Worker(poller_args, cfg)

--- a/tests/unit/test_sqconfig_load.py
+++ b/tests/unit/test_sqconfig_load.py
@@ -56,7 +56,7 @@ def test_config_validation(monkeypatch):
     """Test the sq config validation
     """
 
-    base_cfg = load_sq_config(create_dummy_config_file())
+    base_cfg = load_sq_config(config_file=create_dummy_config_file())
 
     # not a dict
     cfg = []

--- a/tests/utilities/update_sqcmds.py
+++ b/tests/utilities/update_sqcmds.py
@@ -15,7 +15,7 @@ def create_config(testvar):
     if 'data-directory' in testvar:
         # We need to create a tempfile to hold the config
         tf = conftest.create_dummy_config_file()
-        tmpconfig = load_sq_config(tf)
+        tmpconfig = load_sq_config(config_file=tf)
         tmpconfig['data-directory'] = testvar['data-directory']
 
         with open(tf, 'w') as f:


### PR DESCRIPTION
## Description
This PR fixes some bugs in tests causing the configuration file in the default location to be used for testing:
- Some of the unit tests called the `load_sq_config()` with the wrong arguments, so these tests used the configuration file in the default location, instead of the generated dummy configuration file
- Some of the poller controller tests used the configuration file in the default location

## Type of change

- Bug fix (non-breaking change which fixes an issue)