### PR TITLE
DB: Fix time handling

### DIFF
--- a/suzieq/engines/rest/engineobj.py
+++ b/suzieq/engines/rest/engineobj.py
@@ -70,8 +70,9 @@ class SqRestEngine(SqEngineObj):
         cmd_params = {'start_time': self.iobj.start_time,
                       'end_time': self.iobj.end_time,
                       'view': self.iobj.view,
-                      'namespace': self.iobj.namespace,
-                      'hostname': self.iobj.hostname}
+                      'namespace': kwargs.get('namespace',
+                                              self.iobj.namespace),
+                      'hostname': kwargs.get('hostname', self.iobj.hostname)}
         kwargs.update(cmd_params)
         kwargs = {k: v for k, v in kwargs.items() if v}
 


### PR DESCRIPTION
The DB is optimized to provide constant query times independent of the
time window specified. The code to read the set of files given the
variety of user inputs was buggy and read a lot more files than
necessary. This reduced the time to respond to user queries. This patch
addresses this.

Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>