### PR TITLE
Add permissions warning when using container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ VOLUME [ "/home/$username/parquet" ]
  
 ENV PATH=/root/.local/bin:$PATH:/root/.local/lib/python3.7/site-packages/suzieq/cli/:/root/.local/lib/python3.7/site-packages/suzieq/poller/:/root/.local/lib/python3.7/site-packages/suzieq/restServer
 
+ENV SQENV=docker
+
 USER $username
 WORKDIR /home/$username
 ENTRYPOINT ["/bin/bash"]

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -68,7 +68,16 @@ def validate_sq_config(cfg):
 
     if (not os.path.isdir(ddir) or not (os.access(ddir, os.R_OK | os.W_OK |
                                                   os.EX_OK))):
-        return f'FATAL: Data directory {ddir} is not an acceesible dir'
+        if os.getenv('SQENV', None) == 'docker':
+            return f'FATAL: Data directory {ddir} is not an accessible ' \
+                'dir.\nIt looks like you are using docker, make sure that ' \
+                'the mounted volume has the proper permissions.\nYou can ' \
+                'update the permissions using the following command:\n\n' \
+                'docker run --user root -v samples_parquet-db:/home/suzieq'\
+                '/parquet --rm netenglabs/suzieq -c "chown -R ' \
+                '1000:1000 parquet"'
+        else:
+            return f'FATAL: Data directory {ddir} is not an accessible dir'
 
     # Locate the service and schema directories
     svcdir = cfg.get('service-directory', None)


### PR DESCRIPTION
This PR adds an environment variable in the docker container so that, in case of permission issues, we can display a helpful warning with a suggested command to solve the issue:

```
❯ sq-poller -I inventory.yml
ERROR: Invalid config file: ./suzieq-cfg.yml
FATAL: Data directory ./parquet/ is not an accessible dir.
It looks like you are using docker, make sure that the mounted volume has the proper permissions.
You can update the permissions using the following command:

docker run --user root -v samples_parquet-db:/home/suzieq/parquet --rm netenglabs/suzieq -c "chown -R 1000:1000 parquet"
```