### PR TITLE
ifname and hostname filter in interface assert

### DIFF
--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -206,6 +206,7 @@ class InterfacesObj(SqPandasEngine):
         state = kwargs.pop('state', '')
         iftype = kwargs.pop('type', [])
         ifname = kwargs.pop('ifname', [])
+        hostname = kwargs.pop('hostname', [])
 
         def _check_field(x, fld1, fld2, reason):
             if x.skipIfCheck or x.indexPeer < 0:
@@ -274,7 +275,6 @@ class InterfacesObj(SqPandasEngine):
         # can't pass all kwargs, because lldp acceptable arguements are
         # different than interface
         namespace = kwargs.get('namespace', [])
-        hostname = kwargs.get('hostname', [])
         lldp_df = lldpobj.get(namespace=namespace, hostname=hostname) \
                          .query('peerIfname != "-"')
 
@@ -341,6 +341,9 @@ class InterfacesObj(SqPandasEngine):
                            "mgmtIP", "description"]) \
             .dropna(subset=['hostname', 'ifname']) \
             .drop_duplicates(subset=['namespace', 'hostname', 'ifname'])
+
+        if not combined_df.empty and hostname:
+            combined_df = self._filter_hostname(combined_df, hostname)
 
         if not combined_df.empty and ifname:
             combined_df = combined_df.query(f'ifname.isin({ifname})')


### PR DESCRIPTION
## Description

This PR correctly filters out interfaces ifnames and hostnames from assertions.
- **ifname problem:** In the current version, for Junos interfaces we need to map subinterfaces to the parent interfaces to get the correct information from the interface. Using ifname filter, either subinterfaces or parent interfaces were filtered out resulting into wrong results.
- **hostname problem:** to get the peer information we need to have all the hosts. If we use the hostname filter, we may filter out the peer causing a wrong "No peer found" assert reason.
  To reproduce this problem try those 2 commands in develop branch: `interface assert namespace=junos` and `interface assert namespace=junos hostname=spine02`. You'll see that in the first case, `spine02.xe-0/0/1` assertion is passing. In the second command instead it says `No peer found`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

