### PR TITLE
sq-poller: fix crash when inventory is not mapping

### DIFF
--- a/suzieq/poller/controller/utils/inventory_utils.py
+++ b/suzieq/poller/controller/utils/inventory_utils.py
@@ -106,6 +106,11 @@ def validate_raw_inventory(inventory: dict) -> Dict:
     if not inventory:
         raise InventorySourceError('The inventory is empty')
 
+    if not isinstance(inventory, dict):
+        raise InventorySourceError(
+            'Expected mapping instead of list. Check the docs to know how to '
+            'build the inventory file')
+
     try:
         inv_model = InventoryModel(**inventory)
     except ValidationError as e:


### PR DESCRIPTION
## Description

When the inventory file is not valid, so for example, we are pass an inventory file of the previous format, which had a list of namespaces instead of the current mapping with the sections, the poller crashes.

## New Behavior

This PR solves this bug, raising an exception if the inventory file is not a dictionary.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)