### PR TITLE
Remote CLI tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,9 @@ markers =
     rest
     service
 
+    # engines
+    rest_engine
+
     #  sqcmds
     assert
     command

--- a/suzieq/cli/sqcmds/DevconfigCmd.py
+++ b/suzieq/cli/sqcmds/DevconfigCmd.py
@@ -1,5 +1,4 @@
 from nubia import command
-import pandas as pd
 
 from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.devconfig import DevconfigObj
@@ -41,13 +40,3 @@ class DevconfigCmd(SqTableCommand):
         if not self.format or (self.format == 'text'):
             self.format = 'devconfig'
         return super().show()
-
-    @command("unique", help="Show unique information about columns")
-    def unique(self, **kwargs):  # pylint: disable=arguments-differ
-        """
-        Unique device config info
-        """
-
-        df = pd.DataFrame(
-            {'error': ['Unique not supported for Device Config']})
-        return self._gen_output(df)

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -17,7 +17,7 @@ from colorama import Fore, Style
 from suzieq.cli.nubia_patch import argument
 from suzieq.shared.sq_plugin import SqPlugin
 from suzieq.shared.exceptions import UserQueryError
-from suzieq.shared.utils import SUPPORTED_ENGINES
+from suzieq.shared.utils import DATA_FORMATS, SUPPORTED_ENGINES
 
 
 def colorize(x, color):
@@ -51,7 +51,7 @@ def colorize(x, color):
 @argument(
     "format",
     description="Select the pformat of the output",
-    choices=["text", "json", "csv", "markdown"],
+    choices=DATA_FORMATS,
 )
 @argument(
     "query_str",

--- a/suzieq/engines/pandas/tables.py
+++ b/suzieq/engines/pandas/tables.py
@@ -87,7 +87,7 @@ class TableObj(SqPandasEngine):
         if not what:
             return pd.DataFrame()
 
-        df = self.get(addnl_fields=self.iobj.addnl_fields, **kwargs)
+        df = self.get(**kwargs)
         if df.empty or ('error' in df.columns):
             return df
 

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -304,7 +304,7 @@ async def query_address(verb: CommonVerbs, request: Request,
                         ifname: List[str] = Query(None),
                         prefix: List[str] = Query(None),
                         ipvers: str = None, what: str = None,
-                        vrf: str = None, query_str: str = None,
+                        vrf: List[str] = None, query_str: str = None,
                         count: str = None, reverse: str = None,
                         ):
     function_name = inspect.currentframe().f_code.co_name

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -607,7 +607,7 @@ async def query_path(verb: CommonVerbs, request: Request,
                      columns: List[str] = Query(default=["default"]),
                      vrf: str = Query(None),
                      dest: str = Query(None),
-                     source: str = Query(None, alias='src'),
+                     src: str = Query(None),
                      query_str: str = None, what: str = None,
                      count: str = None, reverse: str = None,
                      ):
@@ -750,24 +750,19 @@ def create_filters(function_name, command, request, local_vars):
     all_cmd_args = ['namespace', 'hostname',
                     'start_time', 'end_time', 'view', 'columns', 'format']
     both_verb_and_command = ['namespace', 'hostname', 'columns']
-    alias_args = {'src': 'source'}
 
     query_ks = request.query_params
     for arg in query_ks.keys():
         if arg in remove_args:
             continue
-        if arg in alias_args:
-            tryarg = alias_args[arg]
-        else:
-            tryarg = arg
         if arg in all_cmd_args:
             if query_ks.get(arg) is not None:
-                command_args[tryarg] = local_vars.get(tryarg, None)
+                command_args[arg] = local_vars.get(arg, None)
                 if arg in both_verb_and_command:
-                    verb_args[tryarg] = command_args[arg]
+                    verb_args[arg] = command_args[arg]
         else:
             if query_ks.get(arg) is not None:
-                verb_args[arg] = local_vars.get(tryarg, None)
+                verb_args[arg] = local_vars.get(arg, None)
 
     return command_args, verb_args
 

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -538,18 +538,18 @@ async def query_mlag(verb: CommonVerbs, request: Request,
 
 
 @app.get("/api/v2/network/{verb}")
-async def query_network_find(verb: NetworkVerbs, request: Request,
-                             token: str = Depends(get_api_key),
-                             format: str = None,
-                             columns: List[str] = Query(default=["default"]),
-                             namespace: List[str] = Query(None),
-                             hostname: List[str] = Query(None),
-                             start_time: str = "", end_time: str = "",
-                             view: ViewValues = "latest",
-                             address: List[str] = Query(None),
-                             vlan: str = '', vrf: str = '',
-                             query_str: str = None,
-                             ):
+async def query_network(verb: NetworkVerbs, request: Request,
+                        token: str = Depends(get_api_key),
+                        format: str = None,
+                        columns: List[str] = Query(default=["default"]),
+                        namespace: List[str] = Query(None),
+                        hostname: List[str] = Query(None),
+                        start_time: str = "", end_time: str = "",
+                        view: ViewValues = "latest",
+                        address: List[str] = Query(None),
+                        vlan: str = '', vrf: str = '',
+                        query_str: str = None,
+                        ):
     function_name = inspect.currentframe().f_code.co_name
     return read_shared(function_name, verb, request, locals())
 

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -388,6 +388,7 @@ async def query_devconfig(verb: CommonVerbs, request: Request,
                           namespace: List[str] = Query(None),
                           columns: List[str] = Query(default=["default"]),
                           query_str: str = None,
+                          what: str = None,
                           count: str = None, reverse: str = None,
                           ):
     function_name = inspect.currentframe().f_code.co_name
@@ -699,7 +700,8 @@ async def query_table(
         view: ViewValues = "latest", namespace: List[str] = Query(None),
         columns: List[str] = Query(default=["default"]),
         query_str: str = None, table: str = None,
-        count: str = None,
+        what: str = None,
+        count: str = None, reverse: str = None,
 ):
     function_name = inspect.currentframe().f_code.co_name
     return read_shared(function_name, verb, request, locals())

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -304,7 +304,7 @@ async def query_address(verb: CommonVerbs, request: Request,
                         ifname: List[str] = Query(None),
                         prefix: List[str] = Query(None),
                         ipvers: str = None, what: str = None,
-                        vrf: List[str] = None, query_str: str = None,
+                        vrf: List[str] = Query(None), query_str: str = None,
                         count: str = None, reverse: str = None,
                         ):
     function_name = inspect.currentframe().f_code.co_name

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -36,6 +36,7 @@ MISSING_SPEED = -1
 NO_SPEED = 0
 MISSING_SPEED_IF_TYPES = ['ethernet', 'bond', 'bond_slave']
 SUPPORTED_ENGINES = ['pandas', 'rest']
+DATA_FORMATS = ["text", "json", "csv", "markdown"]
 
 
 class PollerTransport(str, Enum):

--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -294,6 +294,10 @@ class SqObject(SqPlugin):
 
         table = kwargs.get('table', self.table)
 
+        if table in ['interface', 'route', 'mac', 'table']:
+            # Handle singular/plural conversion
+            table += 's'
+
         cols = kwargs.get('columns', ['default'])
         if cols not in [['default'], ['*']]:
             df = pd.DataFrame(

--- a/suzieq/sqobjects/devconfig.py
+++ b/suzieq/sqobjects/devconfig.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from suzieq.sqobjects.basicobj import SqObject
 
 
@@ -8,3 +9,7 @@ class DevconfigObj(SqObject):
         super().__init__(table='devconfig', **kwargs)
         self._valid_get_args = ['namespace', 'hostname', 'columns',
                                 'query_str']
+
+    def unique(self, **kwargs) -> pd.DataFrame:
+        return pd.DataFrame(
+            {'error': ['Unique not supported for Device Config']})

--- a/tests/integration/sqcmds/common-samples/help.yml
+++ b/tests/integration/sqcmds/common-samples/help.yml
@@ -262,8 +262,8 @@ tests:
     \ - describe: \e[36mDisplay the schema of the table\e[0m\n - help: \e[36mShow\
     \ help for a command\e[0m\n - show: \e[36mShow device config info\e[0m\n - summarize:\
     \ \e[36mSummarize relevant information about the table\e[0m\n - top: \e[36mReturn\
-    \ the top n values for a field in a table\e[0m\n - unique: \e[36mUnique device\
-    \ config info\e[0m\n"
+    \ the top n values for a field in a table\e[0m\n - unique: \e[36mGet unique values\
+    \ (and counts) associated with requested field\e[0m\n"
 - command: device help
   data-directory: tests/data/eos/parquet-out/
   format: text

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -346,6 +346,16 @@ def get_app_routes(sq_app: FastAPI) -> Dict:
         except Exception:
             assert False, error_msg
 
+    def check_func_name(route: APIRoute, table: str):
+        """ Check the function is called <something>_<table>.
+        If not, the read_shared function won't work correctly
+        """
+        fun_name = route.dependant.call.__name__
+        assert fun_name.split('_')[1] == table, \
+            (f'Wrong function name for {route.path}. It should be similar to '
+             f'query_{table}'
+             )
+
     app_routes = {}
     for route in sq_app.routes:
         path = route.path
@@ -357,6 +367,7 @@ def get_app_routes(sq_app: FastAPI) -> Dict:
         check_token(route)
         path = path.split('/api/v2/')[1]
         table, verbs = path.split('/')
+        check_func_name(route, table)
         if verbs == '{verb}':
             verb_model = route.dependant.path_params[0]
             verbs = extract_verbs_from_model(verb_model)

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -1,18 +1,23 @@
-import os
-import json
 import inspect
+import json
+import os
 import warnings
+from dataclasses import dataclass
+from typing import Dict, List
 
-import pytest
 import pandas as pd
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
-
-from tests.conftest import cli_commands, create_dummy_config_file, tables
-
-from suzieq.restServer.query import (NetworkVerbs, app, get_configured_api_key,
-                                     API_KEY_NAME)
-from suzieq.sqobjects import get_sqobject
+from pydantic.fields import ModelField
 from suzieq.restServer import query
+from suzieq.restServer.query import (API_KEY_NAME, CommonExtraVerbs,
+                                     CommonVerbs, NetworkVerbs, RouteVerbs,
+                                     app, cleanup_verb, get_configured_api_key)
+from suzieq.sqobjects import get_sqobject
+from suzieq.sqobjects.basicobj import SqObject
+from tests.conftest import cli_commands, create_dummy_config_file, tables
 
 ENDPOINT = "http://localhost:8000/api/v2"
 
@@ -319,6 +324,87 @@ VALIDATE_OUTPUT_FILTER = {
 ####
 
 
+@ dataclass
+class RouteSpecs:
+    verbs: List[str]
+    query_params: List[str]
+
+
+def get_app_routes(sq_app: FastAPI) -> Dict:
+    def extract_verbs_from_model(model: ModelField) -> List[str]:
+        verbs_enum = model.type_
+        return [e.value for e in verbs_enum]
+
+    def extract_query_params_from_models(models: List[ModelField]) \
+            -> List[str]:
+        return [m.name for m in models]
+
+    def check_token(route: APIRoute):
+        error_msg = f'Missing token in {route.path}'
+        try:
+            assert route.dependant.dependencies[0].name == 'token', error_msg
+        except Exception:
+            assert False, error_msg
+
+    app_routes = {}
+    for route in sq_app.routes:
+        path = route.path
+        if not path.startswith('/api/v2/'):
+            continue
+        if path == '/api/v2/{command}':
+            # reserved route for wrong params
+            continue
+        check_token(route)
+        path = path.split('/api/v2/')[1]
+        table, verbs = path.split('/')
+        if verbs == '{verb}':
+            verb_model = route.dependant.path_params[0]
+            verbs = extract_verbs_from_model(verb_model)
+        else:
+            # the verb is explicitly written in the route
+            verbs = [verbs]
+        if table not in app_routes:
+            app_routes[table] = []
+        # append 'token' query_param
+        query_params = extract_query_params_from_models(
+            route.dependant.query_params)
+        app_routes[table].append(RouteSpecs(verbs, query_params))
+
+    return app_routes
+
+
+def get_args_to_match(sqobj: SqObject, verbs: List[str]) -> List[str]:
+    args = []
+    if sqobj.table == 'tables':
+        args += ['table']
+    if 'find' in verbs:
+        return sqobj._valid_find_args
+    return args + (sqobj._valid_assert_args if sqobj._valid_assert_args
+                   else sqobj._valid_get_args)
+
+
+def get_supported_verbs(sqobj: SqObject) -> List[str]:
+    if sqobj.table == 'routes':
+        supported_verbs = [e.value for e in RouteVerbs]
+    elif sqobj.table == 'network':
+        supported_verbs = [e.value for e in NetworkVerbs]
+    else:
+        if sqobj._valid_assert_args:
+            # the assertion is supported for this class
+            supported_verbs = [e.value for e in CommonExtraVerbs]
+        else:
+            supported_verbs = [e.value for e in CommonVerbs]
+        if sqobj.table == 'tables':
+            supported_verbs.append('describe')
+
+    return supported_verbs
+
+
+def assert_missing_args(exp: set, got: set, set_name: str, table: str):
+    missing_args = list(exp.difference(got))
+    assert False, f'Missing {set_name} arguments {missing_args} from {table}'
+
+
 def get(endpoint, service, verb, args):
     '''Make the call'''
     api_key = get_configured_api_key()
@@ -390,10 +476,10 @@ def get(endpoint, service, verb, args):
 @ pytest.mark.parametrize("service", [
     pytest.param(cmd, marks=getattr(pytest.mark, cmd))
     for cmd in cli_commands])
-@pytest.mark.parametrize("verb", [
+@ pytest.mark.parametrize("verb", [
     pytest.param(verb, marks=getattr(pytest.mark, verb))
     for verb in VERBS])
-@pytest.mark.parametrize("arg", FILTERS)
+@ pytest.mark.parametrize("arg", FILTERS)
 # pylint: disable=redefined-outer-name, unused-argument
 def test_rest_services(app_initialize, service, verb, arg):
     '''Main workhorse'''
@@ -520,6 +606,7 @@ def test_rest_server():
     # pylint: disable=import-outside-toplevel
     import subprocess
     from time import sleep
+
     import requests
 
     cfgfile = create_dummy_config_file(
@@ -545,3 +632,55 @@ def test_rest_server():
     sleep(5)
 
     os.remove(cfgfile)
+
+
+@ pytest.mark.rest
+def test_routes_sqobj_consistency():
+    """Checks if the app routes params are consistent with the sqobject
+       params"""
+    routes = get_app_routes(app)
+    config_file = create_dummy_config_file()
+    common_args = {'namespace', 'hostname', 'start_time', 'end_time',
+                   'format', 'view', 'columns', 'query_str'}
+    top_args = {'what', 'reverse', 'count'}
+    for table, table_routes in routes.items():
+        table_verbs = []
+        try:
+            sqobj = get_sqobject(table)(config_file=config_file)
+        except ModuleNotFoundError as e:
+            assert False, e
+
+        supported_verbs = get_supported_verbs(sqobj)
+        unsupported_verbs = [v for v in supported_verbs
+                             if not getattr(sqobj,  cleanup_verb(v), None)]
+        if unsupported_verbs:
+            # some of the verbs specified in the REST server aren't supported
+            # by the sqobject
+            assert False, f'{unsupported_verbs} verbs not supported by {table}'
+
+        for route in table_routes:
+            table_verbs += route.verbs
+            check_top = ('top' in route.verbs)
+            # for /api/v2/table/describe we do not have common_args
+            check_common = (table != 'table' or route.verbs != ['describe'])
+            query_params = set(route.query_params)
+
+            if check_common and not common_args.issubset(query_params):
+                assert_missing_args(common_args, query_params, 'mandatory',
+                                    table)
+            query_params = query_params.difference(common_args)
+
+            if check_top and not top_args.issubset(query_params):
+                assert_missing_args(top_args, query_params, 'top', table)
+            query_params = query_params.difference(top_args)
+
+            args_to_match = get_args_to_match(sqobj, route.verbs)
+            args_to_match = {a for a in args_to_match
+                             if a not in common_args.union(top_args)}
+            if args_to_match != query_params:
+                assert False, (f'different query params for {table}: expected '
+                               f'{args_to_match}. Got {query_params}')
+
+        if set(table_verbs) != set(supported_verbs):
+            assert False, (f'different verbs for {table}: expected '
+                           f'{table_verbs}. Got {supported_verbs}')

--- a/tests/unit/engine/rest/test_rest_engine.py
+++ b/tests/unit/engine/rest/test_rest_engine.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Dict
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from requests.exceptions import ConnectionError
+from suzieq.engines.rest.engineobj import SqRestEngine
+
+
+@dataclass
+class SqContextMock:
+    """ SqContext rest parameters mock
+    """
+    rest_api_key: str
+    rest_transport: str
+    rest_server_ip: str
+    rest_server_port: int
+
+
+@dataclass
+class SqObjMock:
+    """ class used to initialize the SqRestEngine.
+
+    It contains the subset SqObject parameters needed by the rest engine to
+    work
+    """
+    ctxt: SqContextMock
+    start_time: str
+    end_time: str
+    hostname: str
+    namespace: str
+    view: str
+    table: str
+
+
+def validate_args(engine: SqRestEngine, params: Dict):
+    """Validate the request is called with the right paramters
+
+    Args:
+        engine (SqRestEngine): the engine to test
+        params (Dict): the parameters that must be set in the request query
+    """
+    def req_error(param: str, exp: str, got: str) -> str:
+        return f'Wrong request {param}: expected {exp} - got {got}'
+
+    try:
+        # we expect the following function to raise a ConnectionError
+        # exception since the server was not started
+        engine._get_response('verb', **params)
+        assert False, f'The request did not raise an exception for {params}'
+    except ConnectionError as err:
+        # get the request sent in the engine._get_response function
+        url = urlparse(err.request.url)
+
+        # check the path matches the internal variable parameters
+        api_path = f'/api/v2/{engine.iobj.table}/verb'
+        url_params = {
+            # <param_name> : [<got>, <expected>]
+            'ip': [url.hostname, engine.ctxt.rest_server_ip],
+            'port': [url.port, engine.ctxt.rest_server_port],
+            'transport': [url.scheme, engine.ctxt.rest_transport],
+            'path': [url.path, api_path]
+        }
+
+        for param, values in url_params.items():
+            assert values[0] == values[1], \
+                req_error(param, values[1], values[0])
+
+        # check query parameters
+        url_query = parse_qs(url.query)
+        for query_param, query_value in url_query.items():
+            assert len(query_value) == 1, \
+                f'Got more than 1 value for {query_param}'
+            query_value = query_value[0]
+            if query_param == 'access_token':
+                # access_token needs a special validation
+                assert query_value == engine.ctxt.rest_api_key, \
+                    req_error(query_param, engine.ctxt.rest_api_key,
+                              query_value)
+            elif query_param in params:
+                # check parameters set in the query
+                assert params[query_param] == query_value, \
+                    req_error(query_param, params[query_param], query_value)
+            else:
+                # check default parameters
+                assert query_value == 'default', \
+                    req_error(query_param, 'default', query_value)
+
+
+@pytest.mark.engines
+@pytest.mark.rest_engine
+def test_request_params():
+    """This test checks if parameters are set correctly in the request
+    """
+    ctxt = SqContextMock('key', 'http', 'rest-ip', 80)
+    sqobj = SqObjMock(ctxt, 'default', 'default', 'default',
+                      'default', 'default', 'default')
+    engine = SqRestEngine(sqobj)
+    # paramters which will override engine internal paramters
+    sqobj_override_params = ['hostname', 'namespace', 'view']
+    # other parameters
+    other_params = ['other_param_0', 'other_param_1']
+
+    testing_params = sqobj_override_params + other_params
+    # try all combinations of params
+    for n_sq_params in range(1, len(testing_params)+1):
+        for sq_params in combinations(testing_params, n_sq_params):
+            req_params = {p: 'override' for p in sq_params}
+            validate_args(engine, req_params)


### PR DESCRIPTION
## Description

This PR adds some tests for the rest server and the remote CLI. It also contains solutions to problems found during tests.
The problems found are:

### devconfig unique

With the CLI, if we try to run `devconfig unique …` we get an error saying that unique method is not allowed with devconfig. Using the REST server instead and more specifically using the GET method on `/api/v2/devconfig/unique`, no error is raised and actually a unique hostname is returned. I resolved it by moving the devconfig unique check from the sqcmd to the sqobject. Doing so, the same error is raised independently on who is asking to run devconfig unique.

### devconfig top

In the api route, the argument `what` of devconfig was missing. I added it

### Path source
for path, the `src` argument has an alias defined in the route ([here](https://github.com/netenglabs/suzieq/blob/develop/suzieq/restServer/query.py#L605)). Defining the alias in this way, when the user specifies the `src` argument, it is assigned to the `source` parameter. 
Later in the code, this alias was switched back to `src` [here](https://github.com/netenglabs/suzieq/blob/develop/suzieq/restServer/query.py#L747) making the alias useless.
I got rid of the alias.

### sqobject describe

The sqobject describe table argument only accepted columns names, while now commands are singular. Fixed this converting to plural if table name should be.

### access to an old sqobject variable in tables top

In the tables pandas engine, the `top` function accesses an old field of sqobject, causing the function to crash ([here](https://github.com/netenglabs/suzieq/blob/develop/suzieq/sqobjects/basicobj.py#L292)). I removed this line

### return all formats

In the original version, only supported markdown and json formats. I added the support for also csv and text. If no format is specified, it is assumed json

### missing what and reverse args from tables args in REST

For the `/api/v2/tables/{verb}` path, the `what` and `reverse` args were missing causing the function to never work with the rest engine ([here](https://github.com/netenglabs/suzieq/blob/develop/suzieq/restServer/query.py#L688)). I added them.

### rest - vrf filter in address
Vrf filter wasn't handling list of values picking only the last one.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New tests

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR targets the `develop` branch.
- [x] My PR source branch is created from the `develop` branch.
- [x] All my commits have `--signoff` applied
