### PR TITLE
New namespace cmd

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,7 @@ markers =
     interface
     lpm
     mac
+    namespace
     route
     show
     sqcmds

--- a/suzieq/cli/sqcmds/AddressCmd.py
+++ b/suzieq/cli/sqcmds/AddressCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.address import AddressObj
 
 
@@ -18,7 +18,7 @@ from suzieq.sqobjects.address import AddressObj
           description=("Show all the addresses in this "
                        "subnet prefix (in quotes)"))
 @command("address", help="Act on interface addresses")
-class AddressCmd(SqCommand):
+class AddressCmd(SqTableCommand):
     """IP and MAC addresses associated with interfaces"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/ArpndCmd.py
+++ b/suzieq/cli/sqcmds/ArpndCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.arpnd import ArpndObj
 
 
@@ -14,7 +14,7 @@ from suzieq.sqobjects.arpnd import ArpndObj
 @argument("macaddr",
           description="MAC address(es), in quotes, space separated")
 @argument("oif", description="Outgoing interface(s), space separated")
-class ArpndCmd(SqCommand):
+class ArpndCmd(SqTableCommand):
     """ARP/Neighbor Discovery information"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/BgpCmd.py
+++ b/suzieq/cli/sqcmds/BgpCmd.py
@@ -5,7 +5,7 @@ from nubia import command
 import pandas as pd
 
 from suzieq.cli.nubia_patch import argument
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.bgp import BgpObj
 
 
@@ -17,7 +17,7 @@ from suzieq.sqobjects.bgp import BgpObj
           description=("IP address(es), in quotes, or the interface name(s), "
                        "space separated"))
 @argument("afiSafi", description="AFI SAFI string to filter by")
-class BgpCmd(SqCommand):
+class BgpCmd(SqTableCommand):
     """BGP protocol information"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/DevconfigCmd.py
+++ b/suzieq/cli/sqcmds/DevconfigCmd.py
@@ -1,12 +1,12 @@
 from nubia import command
 import pandas as pd
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.devconfig import DevconfigObj
 
 
 @command("devconfig", help="Act on device data")
-class DevconfigCmd(SqCommand):
+class DevconfigCmd(SqTableCommand):
     """Device configurations"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/DeviceCmd.py
+++ b/suzieq/cli/sqcmds/DeviceCmd.py
@@ -2,7 +2,7 @@ import shlex
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.device import DeviceObj
 
 
@@ -12,7 +12,7 @@ from suzieq.sqobjects.device import DeviceObj
 @argument("version", description="NOS version(s), space separated")
 @argument("vendor", description="Vendor(s), space separated")
 @argument("model", description="Model(s), space separated")
-class DeviceCmd(SqCommand):
+class DeviceCmd(SqTableCommand):
     """Basic device information such as OS, version, model etc."""
 
     def __init__(

--- a/suzieq/cli/sqcmds/EvpnVniCmd.py
+++ b/suzieq/cli/sqcmds/EvpnVniCmd.py
@@ -2,14 +2,14 @@ import time
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.evpnVni import EvpnvniObj
 
 
 @command("evpnVni", help="Act on EVPN VNI data")
 @argument("vni", description="VNI ID(s), space separated")
 @argument("priVtepIp", description="Primary VTEP IP(s), space separated")
-class EvpnVniCmd(SqCommand):
+class EvpnVniCmd(SqTableCommand):
     """EVPN information such as VNI/VLAN mapping, VTEP IPs etc."""
 
     def __init__(

--- a/suzieq/cli/sqcmds/FsCmd.py
+++ b/suzieq/cli/sqcmds/FsCmd.py
@@ -2,7 +2,7 @@ from nubia import command
 import pandas as pd
 
 from suzieq.cli.nubia_patch import argument
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.fs import FsObj
 
 
@@ -10,7 +10,7 @@ from suzieq.sqobjects.fs import FsObj
 @argument("used_percent", description="must be of the form "
           "[<|<=|>=|>|!]value. Eg: '<=20'")
 @argument("mountPoint", description="Mount point(s), space separated")
-class FsCmd(SqCommand):
+class FsCmd(SqTableCommand):
     """Filesystem information such as total disk space, filesystems etc"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/InterfaceCmd.py
+++ b/suzieq/cli/sqcmds/InterfaceCmd.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from suzieq.cli.nubia_patch import argument
 from suzieq.sqobjects import get_sqobject
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 
 
 @command("interface", help="Act on Interface data")
@@ -20,7 +20,7 @@ from suzieq.cli.sqcmds.command import SqCommand
                    "!notConnected"])
 @argument("mtu",
           description="MTU(s), space separated, can use <, >, <=, >=, !")
-class InterfaceCmd(SqCommand):
+class InterfaceCmd(SqTableCommand):
     """Device interface information including MTU, Speed, IP address etc"""
 
     # pylint: disable=redefined-builtin

--- a/suzieq/cli/sqcmds/InventoryCmd.py
+++ b/suzieq/cli/sqcmds/InventoryCmd.py
@@ -2,7 +2,7 @@ import re
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.inventory import InventoryObj
 
 
@@ -15,7 +15,7 @@ from suzieq.sqobjects.inventory import InventoryObj
 @argument("model", description="Filter by model")
 @argument("serial", description="Serial number(s), space separated")
 @argument("vendor", description="Vendor(s), space separated")
-class InventoryCmd(SqCommand):
+class InventoryCmd(SqTableCommand):
     """Device inventory information such as serial number, cable info etc"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/LldpCmd.py
+++ b/suzieq/cli/sqcmds/LldpCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.lldp import LldpObj
 
 
@@ -9,7 +9,7 @@ from suzieq.sqobjects.lldp import LldpObj
 @argument("ifname", description="Interface name(s), space separated")
 @argument("peerHostname", description="Peer hostname(s), space separated")
 @argument("peerMacaddr", description="Peer mac address(es), space separated")
-class LldpCmd(SqCommand):
+class LldpCmd(SqTableCommand):
     """LLDP protocol information"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/MacCmd.py
+++ b/suzieq/cli/sqcmds/MacCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.macs import MacsObj
 
 
@@ -15,7 +15,7 @@ from suzieq.sqobjects.macs import MacsObj
 @argument("local", type=bool,
           description="filter entries with no remoteVtep")
 @argument("moveCount", description="num of times this MAC has moved")
-class MacCmd(SqCommand):
+class MacCmd(SqTableCommand):
     """MAC address table information"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/MlagCmd.py
+++ b/suzieq/cli/sqcmds/MlagCmd.py
@@ -1,11 +1,11 @@
 from nubia import command
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.mlag import MlagObj
 
 
 @command('mlag', help="Act on mlag data")
-class MlagCmd(SqCommand):
+class MlagCmd(SqTableCommand):
     """Multichassis LAG information (includes variants such as NXOX vPC)"""
 
     def __init__(self, engine: str = '', hostname: str = '',

--- a/suzieq/cli/sqcmds/NamespaceCmd.py
+++ b/suzieq/cli/sqcmds/NamespaceCmd.py
@@ -6,9 +6,9 @@ from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.namespace import NamespaceObj
 
 
-@command("namespace", help="Summarize network-wide data")
+@command("namespace", help="Summarize namespace-wide network data")
 class NamespaceCmd(SqTableCommand):
-    """Overall network information such as namespaces present etc."""
+    """Overall network information such as device count, bgp enabled etc."""
 
     def __init__(
             self,
@@ -35,15 +35,15 @@ class NamespaceCmd(SqTableCommand):
             sqobj=NamespaceObj,
         )
 
-    @command("show", help="Show device information")
-    @argument("model", description="model(s), space separated")
-    @argument("os", description='NOS(es), space separated')
-    @argument('vendor', description='Vendor(s), space separated')
-    @argument('version', description='NOS version(s), space separated')
+    @command("show", help="Show namespace information")
+    @argument("model", description="Device model(s), space separated")
+    @argument("os", description='Device NOS(es), space separated')
+    @argument('vendor', description='Device vendor(s), space separated')
+    @argument('version', description='Device NOS version(s), space separated')
     # pylint: disable=arguments-differ
     def show(self, os: str = "", vendor: str = "", model: str = "",
              version: str = "") -> int:
-        """Show network info
+        """Show namespace info
         """
 
         now = time.time()

--- a/suzieq/cli/sqcmds/NamespaceCmd.py
+++ b/suzieq/cli/sqcmds/NamespaceCmd.py
@@ -1,0 +1,59 @@
+import time
+from nubia import command
+from suzieq.cli.nubia_patch import argument
+
+from suzieq.cli.sqcmds.command import SqTableCommand
+from suzieq.sqobjects.namespace import NamespaceObj
+
+
+@command("namespace", help="Summarize network-wide data")
+class NamespaceCmd(SqTableCommand):
+    """Overall network information such as namespaces present etc."""
+
+    def __init__(
+            self,
+            engine: str = "",
+            hostname: str = "",
+            start_time: str = "",
+            end_time: str = "",
+            view: str = "",
+            namespace: str = "",
+            format: str = "",  # pylint: disable=redefined-builtin
+            query_str: str = " ",
+            columns: str = "default",
+    ) -> None:
+        super().__init__(
+            engine=engine,
+            hostname=hostname,
+            start_time=start_time,
+            end_time=end_time,
+            view=view,
+            namespace=namespace,
+            columns=columns,
+            format=format,
+            query_str=query_str,
+            sqobj=NamespaceObj,
+        )
+
+    @command("show", help="Show device information")
+    @argument("model", description="model(s), space separated")
+    @argument("os", description='NOS(es), space separated')
+    @argument('vendor', description='Vendor(s), space separated')
+    @argument('version', description='NOS version(s), space separated')
+    # pylint: disable=arguments-differ
+    def show(self, os: str = "", vendor: str = "", model: str = "",
+             version: str = "") -> int:
+        """Show network info
+        """
+
+        now = time.time()
+
+        df = self._invoke_sqobj(self.sqobj.get,
+                                namespace=self.namespace, os=os.split(),
+                                vendor=vendor.split(), model=model.split(),
+                                version=version, query_str=self.query_str,
+                                hostname=self.hostname)
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+
+        return self._gen_output(df)

--- a/suzieq/cli/sqcmds/NetworkCmd.py
+++ b/suzieq/cli/sqcmds/NetworkCmd.py
@@ -8,7 +8,7 @@ from suzieq.sqobjects.network import NetworkObj
 
 @command("network", help="Act on network-wide data")
 class NetworkCmd(SqCommand):
-    """Overall network information such as namespaces present etc."""
+    """Advanced commands across all the network"""
 
     def __init__(
             self,
@@ -35,29 +35,6 @@ class NetworkCmd(SqCommand):
             sqobj=NetworkObj,
         )
 
-    @command("show", help="Show device information")
-    @argument("model", description="model(s), space separated")
-    @argument("os", description='NOS(es), space separated')
-    @argument('vendor', description='Vendor(s), space separated')
-    @argument('version', description='NOS version(s), space separated')
-    # pylint: disable=arguments-differ
-    def show(self, os: str = "", vendor: str = "", model: str = "",
-             version: str = "") -> int:
-        """Show network info
-        """
-
-        now = time.time()
-
-        df = self._invoke_sqobj(self.sqobj.get,
-                                namespace=self.namespace, os=os.split(),
-                                vendor=vendor.split(), model=model.split(),
-                                version=version, query_str=self.query_str,
-                                hostname=self.hostname)
-
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-
-        return self._gen_output(df)
-
     @command("find", help="find where an IP/MAC address is attached")
     @argument("address", type=str,
               description="IP/MAC addresses, in quotes, space separated")
@@ -83,3 +60,10 @@ class NetworkCmd(SqCommand):
         self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
 
         return self._gen_output(df)
+
+    @ command("help", help="show help for a command")
+    @ argument("command", description="command to show help for",
+               choices=['find'])
+    # pylint: disable=redefined-outer-name
+    def help(self, command: str = ''):
+        return super().help(command)

--- a/suzieq/cli/sqcmds/OspfCmd.py
+++ b/suzieq/cli/sqcmds/OspfCmd.py
@@ -4,7 +4,7 @@ from nubia import command
 import pandas as pd
 
 from suzieq.cli.nubia_patch import argument
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.ospf import OspfObj
 
 
@@ -18,7 +18,7 @@ from suzieq.sqobjects.ospf import OspfObj
 @argument("state", description="Select view based on OSPF state",
           choices=["full", "other", "passive", "!full", "!passive",
                    "!other"])
-class OspfCmd(SqCommand):
+class OspfCmd(SqTableCommand):
     """OSPFv2 protocol information"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/PathCmd.py
+++ b/suzieq/cli/sqcmds/PathCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.path import PathObj
 
 
@@ -9,7 +9,7 @@ from suzieq.sqobjects.path import PathObj
 @argument("src", description="Source IP address, in quotes")
 @argument("dest", description="Destination IP address, in quotes")
 @argument("vrf", description="VRF to trace path in")
-class PathCmd(SqCommand):
+class PathCmd(SqTableCommand):
     """Path trace information including overlay and underlay"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/RouteCmd.py
+++ b/suzieq/cli/sqcmds/RouteCmd.py
@@ -5,7 +5,7 @@ import pandas as pd
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.routes import RoutesObj
 
 
@@ -15,7 +15,7 @@ from suzieq.sqobjects.routes import RoutesObj
 @argument("prefix", description="Prefix(es), in quotes, space separated")
 @argument("prefixlen", description="must be of the form "
           "[<|<=|>=|>|!] length")
-class RouteCmd(SqCommand):
+class RouteCmd(SqTableCommand):
     """Routing table information"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/SqPollerCmd.py
+++ b/suzieq/cli/sqcmds/SqPollerCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.sqPoller import SqPollerObj
 
 
@@ -12,7 +12,7 @@ from suzieq.sqobjects.sqPoller import SqPollerObj
 @argument('poll_period_exceeded',
           description="filter if poll period exceeded",
           choices=['True', 'False'])
-class SqPollerCmd(SqCommand):
+class SqPollerCmd(SqTableCommand):
     """Information about the poller"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/TableCmd.py
+++ b/suzieq/cli/sqcmds/TableCmd.py
@@ -4,12 +4,12 @@ import pandas as pd
 from nubia import command
 
 from suzieq.cli.nubia_patch import argument
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.tables import TablesObj
 
 
 @command('table', help='get data about data captured for various tables')
-class TableCmd(SqCommand):
+class TableCmd(SqTableCommand):
     """Meta information about the various data gathered"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/TopcpuCmd.py
+++ b/suzieq/cli/sqcmds/TopcpuCmd.py
@@ -1,11 +1,11 @@
 from nubia import command
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.topcpu import TopcpuObj
 
 
 @command("topcpu", help="Act on topcpu data")
-class TopcpuCmd(SqCommand):
+class TopcpuCmd(SqTableCommand):
     """Information about Top CPU users"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/TopmemCmd.py
+++ b/suzieq/cli/sqcmds/TopmemCmd.py
@@ -1,11 +1,11 @@
 from nubia import command
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.topmem import TopmemObj
 
 
 @command("topmem", help="Act on topmem data")
-class TopmemCmd(SqCommand):
+class TopmemCmd(SqTableCommand):
     '''The CLI command providing access to the topmem table'''
 
     def __init__(

--- a/suzieq/cli/sqcmds/TopologyCmd.py
+++ b/suzieq/cli/sqcmds/TopologyCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.topology import TopologyObj
 
 
@@ -19,7 +19,7 @@ from suzieq.sqobjects.topology import TopologyObj
 @ argument("peerHostname",
            description="Peer hostname(s), space separated, "
            "space separated")
-class TopologyCmd(SqCommand):
+class TopologyCmd(SqTableCommand):
     """Information about the topology constructed from various protocols"""
 
     def __init__(

--- a/suzieq/cli/sqcmds/VlanCmd.py
+++ b/suzieq/cli/sqcmds/VlanCmd.py
@@ -1,7 +1,7 @@
 from nubia import command
 from suzieq.cli.nubia_patch import argument
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.vlan import VlanObj
 
 
@@ -12,7 +12,7 @@ from suzieq.sqobjects.vlan import VlanObj
           description="VLAN(s), space separated, can use <, >, <=, >=, !")
 @argument('vlanName',
           description="VLAN name(s), space separated")
-class VlanCmd(SqCommand):
+class VlanCmd(SqTableCommand):
     """Information about VLANs including interfaces belonging to a VLAN"""
 
     # pylint: disable=redefined-builtin

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -59,20 +59,20 @@ def colorize(x, color):
     "further filter the output"
 )
 class SqCommand(SqPlugin):
-    """Base Command Class for use with all verbs"""
+    """Base Command Class for SuzieQ commands"""
 
     def __init__(
-            self,
-            engine: str = "",
-            hostname: str = "",
-            start_time: str = "",
-            end_time: str = "",
-            view: str = "",
-            namespace: str = "",
-            format: str = "",  # pylint: disable=redefined-builtin
-            columns: str = "default",
-            query_str: str = " ",
-            sqobj=None,
+        self,
+        engine: str = "",
+        hostname: str = "",
+        start_time: str = "",
+        end_time: str = "",
+        view: str = "",
+        namespace: str = "",
+        format: str = "",  # pylint: disable=redefined-builtin
+        columns: str = "default",
+        query_str: str = " ",
+        sqobj=None,
     ) -> None:
         self.ctxt = context.get_context().ctxt
         self._cfg = self.ctxt.cfg
@@ -146,147 +146,8 @@ class SqCommand(SqPlugin):
         '''Return the schemas'''
         return self._schemas
 
-    @command("summarize", help='produce a summarize of the data')
-    def summarize(self, **kwargs):
-        """Summarize relevant information about the table"""
-        now = time.time()
-
-        summarize_df = self._invoke_sqobj(
-            self.sqobj.summarize, namespace=self.namespace,
-            hostname=self.hostname, query_str=self.query_str,
-            **self.lvars,
-            **kwargs
-        )
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-        return self._gen_output(summarize_df, json_orient='columns')
-
-    @command("show")
-    def show(self):
-        """Show address info
-        """
-        # Get the default display field names
-        now = time.time()
-        if self.columns != ["default"]:
-            self.ctxt.sort_fields = None
-        else:
-            self.ctxt.sort_fields = []
-
-        df = self._invoke_sqobj(self.sqobj.get,
-                                hostname=self.hostname,
-                                columns=self.columns,
-                                query_str=self.query_str,
-                                namespace=self.namespace,
-                                **self.lvars,
-                                )
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-        return self._gen_output(df)
-
-    @command("unique", help="find the list of unique items in a column")
-    @argument("count", description="include count of times a value is seen",
-              choices=['True'])
-    def unique(self, count='', **kwargs):
-        """Get unique values (and counts) associated with requested field"""
-        now = time.time()
-
-        df = self._invoke_sqobj(self.sqobj.unique,
-                                hostname=self.hostname,
-                                namespace=self.namespace,
-                                query_str=self.query_str,
-                                count=count,
-                                **self.lvars,
-                                **kwargs,
-                                )
-
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-        if 'error' in df.columns:
-            return self._gen_output(df)
-
-        if df.empty:
-            return df
-
-        if not count:
-            return self._gen_output(df.sort_values(by=[df.columns[0]]),
-                                    dont_strip_cols=True)
-        else:
-            return self._gen_output(
-                df.sort_values(by=['numRows', df.columns[0]]),
-                dont_strip_cols=True)
-
-    @command("describe", help="describe the table and its fields")
-    def describe(self):
-        """Display the schema of the table
-
-        Returns:
-            [type]: 0 or error
-        """
-        now = time.time()
-
-        for x in list(filter(lambda x: not x.startswith('_') and
-                             x not in ['ctxt', 'sqobj', 'query_str',
-                                       'format', 'columns', 'lvars'],
-                             self.__dict__)):
-            if getattr(self, x):
-                print(Fore.RED + "Error: No arguments allowed for describe")
-                return 1
-
-        if any(x for x in self.lvars.values()):
-            print(Fore.RED + "Error: No arguments allowed for describe")
-            return 1
-
-        df = self._invoke_sqobj(self.sqobj.describe,
-                                hostname=self.hostname,
-                                namespace=self.namespace,
-                                query_str=self.query_str,
-                                )
-
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-        return self._gen_output(df)
-
-    @ command("top", help="find the top n values for a field")
-    @ argument("count", description="number of rows to return")
-    @ argument("what", description="numeric field to get top values for")
-    @ argument("reverse", description="return bottom n values",
-               choices=['True', 'False'])
-    def top(self, count: int = 5, what: str = '', reverse: str = 'False',
-            **kwargs) -> int:
-        """Return the top n values for a field in a table
-
-        Args:
-            count (int, optional): Number of entries to return. Defaults to 5
-            what (str, optional): Field name to use for largest/smallest val
-            reverse (bool, optional): Reverse and return n smallest
-
-        Returns:
-            int: 0 or error code
-        """
-        now = time.time()
-
-        df = self._invoke_sqobj(self.sqobj.top,
-                                hostname=self.hostname,
-                                namespace=self.namespace,
-                                query_str=self.query_str,
-                                what=what, count=count,
-                                reverse=ast.literal_eval(reverse),
-                                **self.lvars,
-                                **kwargs,
-                                )
-
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-        if 'error' in df.columns:
-            return self._gen_output(df)
-
-        if not df.empty:
-            df = self.sqobj.humanize_fields(df)
-            return self._gen_output(df.sort_values(
-                by=[what], ascending=(reverse == "True")),
-                dont_strip_cols=True, sort=False)
-        else:
-            return self._gen_output(df)
-
     @ command("help", help="show help for a command")
-    @ argument("command", description="command to show help for",
-               choices=['show', 'unique', 'summarize', 'assert', 'describe',
-                        'top', "find", "lpm"])
+    @ argument("command", description="command to show help for")
     # pylint: disable=redefined-outer-name
     def help(self, command: str = ''):
         """Show help for a command
@@ -508,3 +369,152 @@ class SqCommand(SqPlugin):
                 df = pd.DataFrame({'error': [f'ERROR: {ex}']})
 
         return df
+
+    @command("describe", help="describe the table and its fields")
+    def describe(self):
+        """Display the schema of the table
+
+        Returns:
+            [type]: 0 or error
+        """
+        now = time.time()
+
+        for x in list(filter(lambda x: not x.startswith('_') and
+                             x not in ['ctxt', 'sqobj', 'query_str',
+                                       'format', 'columns', 'lvars'],
+                             self.__dict__)):
+            if getattr(self, x):
+                print(Fore.RED + "Error: No arguments allowed for describe")
+                return 1
+
+        if any(x for x in self.lvars.values()):
+            print(Fore.RED + "Error: No arguments allowed for describe")
+            return 1
+
+        df = self._invoke_sqobj(self.sqobj.describe,
+                                hostname=self.hostname,
+                                namespace=self.namespace,
+                                query_str=self.query_str,
+                                )
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        return self._gen_output(df)
+
+
+class SqTableCommand(SqCommand):
+    """Base Command Class for table commands"""
+
+    @command("summarize", help='produce a summarize of the data')
+    def summarize(self, **kwargs):
+        """Summarize relevant information about the table"""
+        now = time.time()
+
+        summarize_df = self._invoke_sqobj(
+            self.sqobj.summarize, namespace=self.namespace,
+            hostname=self.hostname, query_str=self.query_str,
+            **self.lvars,
+            **kwargs
+        )
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        return self._gen_output(summarize_df, json_orient='columns')
+
+    @command("show")
+    def show(self):
+        """Show address info
+        """
+        # Get the default display field names
+        now = time.time()
+        if self.columns != ["default"]:
+            self.ctxt.sort_fields = None
+        else:
+            self.ctxt.sort_fields = []
+
+        df = self._invoke_sqobj(self.sqobj.get,
+                                hostname=self.hostname,
+                                columns=self.columns,
+                                query_str=self.query_str,
+                                namespace=self.namespace,
+                                **self.lvars,
+                                )
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        return self._gen_output(df)
+
+    @command("unique", help="find the list of unique items in a column")
+    @argument("count", description="include count of times a value is seen",
+              choices=['True'])
+    def unique(self, count='', **kwargs):
+        """Get unique values (and counts) associated with requested field"""
+        now = time.time()
+
+        df = self._invoke_sqobj(self.sqobj.unique,
+                                hostname=self.hostname,
+                                namespace=self.namespace,
+                                query_str=self.query_str,
+                                count=count,
+                                **self.lvars,
+                                **kwargs,
+                                )
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        if 'error' in df.columns:
+            return self._gen_output(df)
+
+        if df.empty:
+            return df
+
+        if not count:
+            return self._gen_output(df.sort_values(by=[df.columns[0]]),
+                                    dont_strip_cols=True)
+        else:
+            return self._gen_output(
+                df.sort_values(by=['numRows', df.columns[0]]),
+                dont_strip_cols=True)
+
+    @ command("top", help="find the top n values for a field")
+    @ argument("count", description="number of rows to return")
+    @ argument("what", description="numeric field to get top values for")
+    @ argument("reverse", description="return bottom n values",
+               choices=['True', 'False'])
+    def top(self, count: int = 5, what: str = '', reverse: str = 'False',
+            **kwargs) -> int:
+        """Return the top n values for a field in a table
+
+        Args:
+            count (int, optional): Number of entries to return. Defaults to 5
+            what (str, optional): Field name to use for largest/smallest val
+            reverse (bool, optional): Reverse and return n smallest
+
+        Returns:
+            int: 0 or error code
+        """
+        now = time.time()
+
+        df = self._invoke_sqobj(self.sqobj.top,
+                                hostname=self.hostname,
+                                namespace=self.namespace,
+                                query_str=self.query_str,
+                                what=what, count=count,
+                                reverse=ast.literal_eval(reverse),
+                                **self.lvars,
+                                **kwargs,
+                                )
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        if 'error' in df.columns:
+            return self._gen_output(df)
+
+        if not df.empty:
+            df = self.sqobj.humanize_fields(df)
+            return self._gen_output(df.sort_values(
+                by=[what], ascending=(reverse == "True")),
+                dont_strip_cols=True, sort=False)
+        else:
+            return self._gen_output(df)
+
+    @ command("help", help="show help for a command")
+    @ argument("command", description="command to show help for",
+               choices=['show', 'unique', 'summarize', 'assert', 'describe',
+                        'top', "lpm"])
+    # pylint: disable=redefined-outer-name
+    def help(self, command: str = ''):
+        return super().help(command)

--- a/suzieq/config/schema/namespace.avsc
+++ b/suzieq/config/schema/namespace.avsc
@@ -1,0 +1,82 @@
+{
+    "namespace": "suzieq",
+    "name": "namespace",
+    "type": "derivedRecord",
+    "depends": [
+        "device",
+        "bgp",
+        "ospf",
+        "evpnVni",
+        "mlag",
+        "sqPoller"
+    ],
+    "fields": [
+        {
+            "name": "sqvers",
+            "type": "string",
+            "partition": 0,
+            "default": "2.0",
+            "suppress": true,
+            "description": "Schema version, not selectable"
+        },
+        {
+            "name": "deviceCnt",
+            "type": "long",
+            "display": 1,
+            "description": "Number of devices in inventory in this namespace"
+        },
+        {
+            "name": "serviceCnt",
+            "type": "long",
+            "display": 2,
+            "description": "Number of services polled in this namespace"
+        },
+        {
+            "name": "errSvcCnt",
+            "type": "long",
+            "display": 3,
+            "description": "Number of services with errors in this namespace"
+        },
+        {
+            "name": "hasOspf",
+            "type": "boolean",
+            "display": 4,
+            "description": "Is OSPF used in this namespace"
+        },
+        {
+            "name": "hasBgp",
+            "type": "boolean",
+            "display": 5,
+            "description": "Is BGP used in this namespace"
+        },
+        {
+            "name": "hasVxlan",
+            "type": "boolean",
+            "display": 6,
+            "description": "Is VXLAN used in this namespace"
+        },
+        {
+            "name": "hasMlag",
+            "type": "boolean",
+            "display": 7,
+            "description": "Is MLAG used in this namespace"
+        },
+        {
+            "name": "namespace",
+            "type": "string",
+            "key": 0,
+            "display": 0,
+            "description": "Namespace associated with this record"
+        },
+        {
+            "name": "lastUpdate",
+            "type": "timestamp",
+            "display": 8,
+            "description": "Time when any service was last polled"
+        },
+        {
+            "name": "active",
+            "type": "boolean"
+        }
+    ]
+}

--- a/suzieq/config/schema/network.avsc
+++ b/suzieq/config/schema/network.avsc
@@ -3,82 +3,70 @@
     "name": "network",
     "type": "derivedRecord",
     "depends": [
-        "device",
         "interfaces",
-        "routes",
         "macs",
-        "bgp",
-        "ospf",
-        "evpnVni",
-        "vlan"
+        "bgp"
     ],
     "fields": [
         {
-            "name": "sqvers",
+            "name": "bondMembers",
             "type": "string",
-            "partition": 0,
-            "default": "2.0",
-            "suppress": true,
-            "description": "Schema version, not selectable"
-        },
-        {
-            "name": "deviceCnt",
-            "type": "long",
-            "display": 1,
-            "description": "Number of devices in inventory in this namespace"
-        },
-        {
-            "name": "serviceCnt",
-            "type": "long",
-            "display": 2,
-            "description": "Number of services polled in this namespace"
-        },
-        {
-            "name": "errSvcCnt",
-            "type": "long",
-            "display": 3,
-            "description": "Number of services with errors in this namespace"
-        },
-        {
-            "name": "hasOspf",
-            "type": "boolean",
-            "display": 4,
-            "description": "Is OSPF used in this namespace"
-        },
-        {
-            "name": "hasBgp",
-            "type": "boolean",
-            "display": 5,
-            "description": "Is BGP used in this namespace"
-        },
-        {
-            "name": "hasVxlan",
-            "type": "boolean",
-            "display": 6,
-            "description": "Is VXLAN used in this namespace"
-        },
-        {
-            "name": "hasMlag",
-            "type": "boolean",
             "display": 7,
-            "description": "Is MLAG used in this namespace"
+            "description": "Member ports of a bond interface"
+        },
+        {
+            "name": "hostname",
+            "type": "string",
+            "display": 1,
+            "description": "Hostname associated with this record"
+        },
+        {
+            "name": "ifname",
+            "type": "string",
+            "display": 6,
+            "description": "Interface name"
+        },
+        {
+            "name": "ipAddress",
+            "type": "string",
+            "display":3,
+            "description": "Interface IP address"
+        },
+        {
+            "name": "l2miss",
+            "type": "boolean",
+            "display": 9,
+            "description": "MAC address not found for address"
+        },
+        {
+            "name": "macaddr",
+            "type": "string",
+            "display": 5,
+            "description": "Interface mac address"
         },
         {
             "name": "namespace",
             "type": "string",
-            "key": 0,
             "display": 0,
             "description": "Namespace associated with this record"
         },
         {
-            "name": "lastUpdate",
-            "type": "timestamp",
+            "name": "type",
+            "type": "string",
             "display": 8,
-            "description": "Time when any service was last polled"
+            "description": "Type of interface"
         },
         {
-            "name": "active",
-            "type": "boolean"
+            "name": "vlan",
+            "type": "float",
+            "display": 4,
+            "description": "Interface vlan"
+        },
+        {
+            "name": "vrf",
+            "type": "string",
+            "display": 2,
+            "description": "VRF associated with session"
         }
     ]
 }

--- a/suzieq/engines/pandas/namespace.py
+++ b/suzieq/engines/pandas/namespace.py
@@ -126,4 +126,3 @@ class NamespaceObj(SqPandasEngine):
 
         # At this point we have a single row with index 0, so rename
         return self.ns.T.rename(columns={0: 'summary'})
-

--- a/suzieq/engines/pandas/namespace.py
+++ b/suzieq/engines/pandas/namespace.py
@@ -1,0 +1,129 @@
+import pandas as pd
+
+from suzieq.engines.pandas.engineobj import SqPandasEngine
+
+
+class NamespaceObj(SqPandasEngine):
+    '''Backend class to handle ops on virtual table, namespace, with pandas'''
+
+    @staticmethod
+    def table_name():
+        '''Table name'''
+        return 'namespace'
+
+    def get(self, **kwargs):
+        """Get the information requested"""
+
+        kwargs.get('view', self.iobj.view)
+        columns = kwargs.pop('columns', ['default'])
+        kwargs.pop('addnl_fields', [])
+        user_query = kwargs.pop('query_str', '')
+        os = kwargs.pop('os', [])
+        model = kwargs.pop('model', [])
+        vendor = kwargs.pop('vendor', [])
+        os_version = kwargs.pop('version', [])
+        namespace = kwargs.pop('namespace', [])
+
+        drop_cols = []
+        fields = self.schema.get_display_fields(columns)
+
+        if os or model or vendor or os_version:
+            devdf = self._get_table_sqobj('device').get(
+                columns=['namespace', 'hostname', 'os', 'model', 'vendor',
+                         'version'],
+                os=os, model=model, vendor=vendor, version=os_version,
+                namespace=namespace, **kwargs)
+        else:
+            devdf = self._get_table_sqobj('device').get(
+                columns=['namespace', 'hostname'], namespace=namespace,
+                **kwargs)
+
+        if devdf.empty:
+            return pd.DataFrame()
+
+        namespace = devdf.namespace.unique().tolist()
+        dev_nsgrp = devdf.groupby(['namespace'])
+
+        # Get list of namespaces we're polling
+        pollerdf = self._get_table_sqobj('sqPoller') \
+            .get(columns=['namespace', 'hostname', 'service', 'status',
+                          'timestamp'],
+                 namespace=namespace)
+
+        if pollerdf.empty:
+            return pd.DataFrame()
+
+        pollerdf = devdf.merge(pollerdf, on=['namespace', 'hostname'])
+        nsgrp = pollerdf.groupby(by=['namespace'])
+        pollerns = sorted(pollerdf.namespace.unique().tolist())
+        newdf = pd.DataFrame({
+            'namespace': pollerns,
+            'deviceCnt': dev_nsgrp['hostname'].nunique().tolist(),
+            'serviceCnt': nsgrp['service'].nunique().tolist()
+        })
+        errsvc_df = pollerdf.query('status != 0 and status != 200') \
+                            .groupby(by=['namespace'])['service'] \
+                            .nunique().reset_index()
+        newdf = newdf.merge(errsvc_df, on=['namespace'], how='left',
+                            suffixes=['', '_y']) \
+            .rename({'service': 'errSvcCnt'}, axis=1) \
+            .fillna({'errSvcCnt': 0})
+        newdf['errSvcCnt'] = newdf['errSvcCnt'].astype(int)
+
+        # What protocols exist
+        for table, fld in [('ospf', 'hasOspf'), ('bgp', 'hasBgp'),
+                           ('evpnVni', 'hasVxlan'), ('mlag', 'hasMlag')]:
+            df = self._get_table_sqobj(table) \
+                .get(namespace=pollerns, columns=['namespace', 'hostname'])
+            if df.empty:
+                newdf[fld] = False
+                continue
+
+            df = df.merge(devdf, on=['namespace', 'hostname'])
+            if df.empty:
+                newdf[fld] = False
+                continue
+
+            gotns = df.namespace.unique().tolist()
+            newdf[fld] = newdf.apply(
+                lambda x, y: x.namespace in y,
+                axis=1, args=(gotns,))
+
+        if 'sqvers' in fields:
+            newdf['sqvers'] = self.schema.version
+        newdf['active'] = True
+        newdf = self._handle_user_query_str(newdf, user_query)
+
+        # Look for the rest of info only in selected namepaces
+        newdf['lastUpdate'] = nsgrp['timestamp'].max() \
+            .reset_index()['timestamp']
+
+        newdf = self._handle_user_query_str(newdf, user_query)
+        return newdf.drop(columns=drop_cols)[fields]
+
+    def summarize(self, **kwargs):
+        '''Summarize for network
+
+        Summarize for network is a bit different from the rest of the
+        summaries because its not grouped by namespace.
+        '''
+
+        df = self.get(**kwargs)
+
+        if df.empty:
+            return df
+
+        self.ns = pd.DataFrame({
+            'namespacesCnt': [df.namespace.count()],
+            'servicePerNsStat': [[df.serviceCnt.min(), df.serviceCnt.max(),
+                                  df.serviceCnt.median()]],
+            'nsWithMlagCnt': [df.loc[df.hasMlag].shape[0]],
+            'nsWithBgpCnt': [df.loc[df.hasBgp].shape[0]],
+            'nsWithOspfCnt': [df.loc[df.hasOspf].shape[0]],
+            'nsWithVxlanCnt': [df.loc[df.hasVxlan].shape[0]],
+            'nsWithErrsvcCnt': [df.loc[df.errSvcCnt != 0].shape[0]],
+        })
+
+        # At this point we have a single row with index 0, so rename
+        return self.ns.T.rename(columns={0: 'summary'})
+

--- a/suzieq/engines/pandas/network.py
+++ b/suzieq/engines/pandas/network.py
@@ -7,102 +7,12 @@ from suzieq.shared.utils import convert_macaddr_format_to_colon
 
 
 class NetworkObj(SqPandasEngine):
-    '''Backend class to handle ops on virtual table, network, with pandas'''
+    '''Backend class to handle network queries'''
 
     @staticmethod
     def table_name():
         '''Table name'''
         return 'network'
-
-    def get(self, **kwargs):
-        """Get the information requested"""
-
-        kwargs.get('view', self.iobj.view)
-        columns = kwargs.pop('columns', ['default'])
-        kwargs.pop('addnl_fields', [])
-        user_query = kwargs.pop('query_str', '')
-        os = kwargs.pop('os', [])
-        model = kwargs.pop('model', [])
-        vendor = kwargs.pop('vendor', [])
-        os_version = kwargs.pop('version', [])
-        namespace = kwargs.pop('namespace', [])
-
-        drop_cols = []
-        fields = self.schema.get_display_fields(columns)
-
-        if os or model or vendor or os_version:
-            devdf = self._get_table_sqobj('device').get(
-                columns=['namespace', 'hostname', 'os', 'model', 'vendor',
-                         'version'],
-                os=os, model=model, vendor=vendor, version=os_version,
-                namespace=namespace, **kwargs)
-        else:
-            devdf = self._get_table_sqobj('device').get(
-                columns=['namespace', 'hostname'], namespace=namespace,
-                **kwargs)
-
-        if devdf.empty:
-            return pd.DataFrame()
-
-        namespace = devdf.namespace.unique().tolist()
-        dev_nsgrp = devdf.groupby(['namespace'])
-
-        # Get list of namespaces we're polling
-        pollerdf = self._get_table_sqobj('sqPoller') \
-            .get(columns=['namespace', 'hostname', 'service', 'status',
-                          'timestamp'],
-                 namespace=namespace)
-
-        if pollerdf.empty:
-            return pd.DataFrame()
-
-        pollerdf = devdf.merge(pollerdf, on=['namespace', 'hostname'])
-        nsgrp = pollerdf.groupby(by=['namespace'])
-        pollerns = sorted(pollerdf.namespace.unique().tolist())
-        newdf = pd.DataFrame({
-            'namespace': pollerns,
-            'deviceCnt': dev_nsgrp['hostname'].nunique().tolist(),
-            'serviceCnt': nsgrp['service'].nunique().tolist()
-        })
-        errsvc_df = pollerdf.query('status != 0 and status != 200') \
-                            .groupby(by=['namespace'])['service'] \
-                            .nunique().reset_index()
-        newdf = newdf.merge(errsvc_df, on=['namespace'], how='left',
-                            suffixes=['', '_y']) \
-            .rename({'service': 'errSvcCnt'}, axis=1) \
-            .fillna({'errSvcCnt': 0})
-        newdf['errSvcCnt'] = newdf['errSvcCnt'].astype(int)
-
-        # What protocols exist
-        for table, fld in [('ospf', 'hasOspf'), ('bgp', 'hasBgp'),
-                           ('evpnVni', 'hasVxlan'), ('mlag', 'hasMlag')]:
-            df = self._get_table_sqobj(table) \
-                .get(namespace=pollerns, columns=['namespace', 'hostname'])
-            if df.empty:
-                newdf[fld] = False
-                continue
-
-            df = df.merge(devdf, on=['namespace', 'hostname'])
-            if df.empty:
-                newdf[fld] = False
-                continue
-
-            gotns = df.namespace.unique().tolist()
-            newdf[fld] = newdf.apply(
-                lambda x, y: x.namespace in y,
-                axis=1, args=(gotns,))
-
-        if 'sqvers' in fields:
-            newdf['sqvers'] = self.schema.version
-        newdf['active'] = True
-        newdf = self._handle_user_query_str(newdf, user_query)
-
-        # Look for the rest of info only in selected namepaces
-        newdf['lastUpdate'] = nsgrp['timestamp'].max() \
-            .reset_index()['timestamp']
-
-        newdf = self._handle_user_query_str(newdf, user_query)
-        return newdf.drop(columns=drop_cols)[fields]
 
     def find(self, **kwargs):
         '''Find the information requsted:
@@ -129,32 +39,6 @@ class NetworkObj(SqPandasEngine):
             return df.query(query_str)
 
         return df
-
-    def summarize(self, **kwargs):
-        '''Summarize for network
-
-        Summarize for network is a bit different from the rest of the
-        summaries because its not grouped by namespace.
-        '''
-
-        df = self.get(**kwargs)
-
-        if df.empty:
-            return df
-
-        self.ns = pd.DataFrame({
-            'namespacesCnt': [df.namespace.count()],
-            'servicePerNsStat': [[df.serviceCnt.min(), df.serviceCnt.max(),
-                                  df.serviceCnt.median()]],
-            'nsWithMlagCnt': [df.loc[df.hasMlag].shape[0]],
-            'nsWithBgpCnt': [df.loc[df.hasBgp].shape[0]],
-            'nsWithOspfCnt': [df.loc[df.hasOspf].shape[0]],
-            'nsWithVxlanCnt': [df.loc[df.hasVxlan].shape[0]],
-            'nsWithErrsvcCnt': [df.loc[df.errSvcCnt != 0].shape[0]],
-        })
-
-        # At this point we have a single row with index 0, so rename
-        return self.ns.T.rename(columns={0: 'summary'})
 
     def _find_asn(self, asn: List[str], **kwargs) -> pd.DataFrame:
         """Find the hosts with the ASN listed

--- a/suzieq/gui/stlit/xplore.py
+++ b/suzieq/gui/stlit/xplore.py
@@ -65,7 +65,7 @@ class XplorePage(SqGuiPage):
         tables = filter(
             lambda x: x not in ['path', 'tables', 'ospfIf', 'ospfNbr',
                                 'devconfig', 'topmem', 'topcpu', 'ifCounters',
-                                'time'],
+                                'time', 'network'],
             get_tables()
         )
         table_vals = [''] + sorted(tables)
@@ -79,7 +79,7 @@ class XplorePage(SqGuiPage):
             else:
                 tblidx = table_vals.index(state.table)
         else:
-            tblidx = table_vals.index('network')  # Default starting table
+            tblidx = table_vals.index('namespace')  # Default starting table
         view_idx = 1 if state.view == 'all' else 0
 
         devdf = gui_get_df('device', self._config_file,
@@ -335,7 +335,7 @@ class XplorePage(SqGuiPage):
 
     def _fetch_data(self):
         '''Called when the Get button is pressed, refresh data'''
-        table = getattr(self._state, 'table', 'network')
+        table = getattr(self._state, 'table', 'namespace')
         if f'xplore_show_{table}' in st.session_state:
             del st.session_state[f'xplore_show_{table}']
         self._state.get_clicked = True

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -212,6 +212,10 @@ class RouteVerbs(str, Enum):
     top = "top"
 
 
+class NetworkVerbs(str, Enum):
+    find = "find"
+
+
 class DeviceStatus(str, Enum):
     alive = "alive"
     dead = "dead"
@@ -533,8 +537,8 @@ async def query_mlag(verb: CommonVerbs, request: Request,
     return read_shared(function_name, verb, request, locals())
 
 
-@app.get("/api/v2/network/find")
-async def query_network_find(request: Request,
+@app.get("/api/v2/network/{verb}")
+async def query_network_find(verb: NetworkVerbs, request: Request,
                              token: str = Depends(get_api_key),
                              format: str = None,
                              columns: List[str] = Query(default=["default"]),
@@ -547,25 +551,25 @@ async def query_network_find(request: Request,
                              query_str: str = None,
                              ):
     function_name = inspect.currentframe().f_code.co_name
-    return read_shared(function_name, "find", request, locals())
+    return read_shared(function_name, verb, request, locals())
 
 
-@app.get("/api/v2/network/{verb}")
-async def query_network(verb: CommonVerbs, request: Request,
-                        token: str = Depends(get_api_key),
-                        format: str = None,
-                        columns: List[str] = Query(default=["default"]),
-                        namespace: List[str] = Query(None),
-                        hostname: List[str] = Query(None),
-                        start_time: str = "", end_time: str = "",
-                        version: str = "",
-                        view: ViewValues = "latest",
-                        model: List[str] = Query(None),
-                        vendor: List[str] = Query(None),
-                        os: List[str] = Query(None),
-                        query_str: str = None, what: str = None,
-                        count: str = None, reverse: str = None,
-                        ):
+@app.get("/api/v2/namespace/{verb}")
+async def query_namespace(verb: CommonVerbs, request: Request,
+                          token: str = Depends(get_api_key),
+                          format: str = None,
+                          columns: List[str] = Query(default=["default"]),
+                          namespace: List[str] = Query(None),
+                          hostname: List[str] = Query(None),
+                          start_time: str = "", end_time: str = "",
+                          version: str = "",
+                          view: ViewValues = "latest",
+                          model: List[str] = Query(None),
+                          vendor: List[str] = Query(None),
+                          os: List[str] = Query(None),
+                          query_str: str = None, what: str = None,
+                          count: str = None, reverse: str = None,
+                          ):
     function_name = inspect.currentframe().f_code.co_name
     return read_shared(function_name, verb, request, locals())
 

--- a/suzieq/sqobjects/namespace.py
+++ b/suzieq/sqobjects/namespace.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from suzieq.sqobjects.basicobj import SqObject
+from suzieq.shared.utils import humanize_timestamp
+
+
+class NamespaceObj(SqObject):
+    '''The object providing access to the virtual table: namespace'''
+
+    def __init__(self, **kwargs):
+        super().__init__(table='namespace', **kwargs)
+        self._valid_get_args = ['namespace', 'hostname', 'version', 'os',
+                                'model', 'vendor', 'columns', 'query_str']
+        self._unique_def_column = ['namespace']
+
+    def humanize_fields(self, df: pd.DataFrame, _=None) -> pd.DataFrame:
+        '''Humanize the timestamp fields'''
+        if df.empty:
+            return df
+
+        if 'lastUpdate' in df.columns:
+            df['lastUpdate'] = humanize_timestamp(df.lastUpdate,
+                                                  self.cfg.get('analyzer', {})
+                                                  .get('timezone', None))
+
+        return super().humanize_fields(df)

--- a/suzieq/sqobjects/network.py
+++ b/suzieq/sqobjects/network.py
@@ -12,11 +12,8 @@ class NetworkObj(SqObject):
 
     def __init__(self, **kwargs):
         super().__init__(table='network', **kwargs)
-        self._valid_get_args = ['namespace', 'hostname', 'version', 'os',
-                                'model', 'vendor', 'columns', 'query_str']
         self._valid_find_args = ['namespace', 'hostname', 'vrf', 'vlan',
                                  'address', 'query_str']
-        self._unique_def_column = ['namespace']
 
     def find(self, **kwargs) -> pd.DataFrame():
         '''Find network attach point for a given address'''

--- a/tests/integration/sqcmds/common-samples/all.yml
+++ b/tests/integration/sqcmds/common-samples/all.yml
@@ -29931,9 +29931,9 @@ tests:
     10, "timestamp": 1639476254419}, {"namespace": "panos", "hostname": "leaf04",
     "vlanName": "vlan30", "state": "active", "interfaces": ["bond02", "vni30"], "vlan":
     30, "timestamp": 1639476254419}]'
-- command: network show  --format=json
+- command: namespace show  --format=json
   data-directory: tests/data/parquet
-  marks: network show all nxos
+  marks: namespace show all nxos
   output: '[{"namespace": "dual-bgp", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
     0, "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": true, "lastUpdate":
     1639161431921}, {"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17,

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -376,9 +376,9 @@ tests:
     "True if this device uses link-local address to peer"}, {"name": "vtepIP", "type":
     "string", "key": "", "display": "", "description": "Anycast VTEP IP address, if
     appropriate"}]'
-- command: network describe --format=json
+- command: namespace describe --format=json
   data-directory: tests/data/eos/parquet-out/
-  marks: network describe
+  marks: namespace describe
   output: '[{"name": "active", "type": "boolean", "key": "", "display": "", "description":
     ""}, {"name": "deviceCnt", "type": "long", "key": "", "display": 1, "description":
     "Number of devices in inventory in this namespace"}, {"name": "errSvcCnt", "type":
@@ -597,3 +597,19 @@ tests:
     {"type": "array", "items": {"type": "float", "name": "wrQsize"}}, "key": "", "display":
     7, "description": "[min, max, avg] of write queue size, computed over the greater
     between the last 5 mins and the polling period"}]'
+- command: table describe --table=network --format=json
+  data-directory: tests/data/parquet-out/
+  marks: table network describe
+  output: '[{"name": "bondMembers", "type": "string", "key": "", "display": 7, "description":
+    "Member ports of a bond interface"}, {"name": "hostname", "type": "string", "key":
+    "", "display": 1, "description": "Hostname associated with this record"}, {"name":
+    "ifname", "type": "string", "key": "", "display": 6, "description": "Interface
+    name"}, {"name": "ipAddress", "type": "string", "key": "", "display": 3, "description":
+    "Interface IP address"}, {"name": "l2miss", "type": "boolean", "key": "", "display":
+    9, "description": "MAC address not found for address"}, {"name": "macaddr", "type":
+    "string", "key": "", "display": 5, "description": "Interface mac address"}, {"name":
+    "namespace", "type": "string", "key": "", "display": 0, "description": "Namespace
+    associated with this record"}, {"name": "type", "type": "string", "key": "", "display":
+    8, "description": "Type of interface"}, {"name": "vlan", "type": "float", "key":
+    "", "display": 4, "description": "Interface vlan"}, {"name": "vrf", "type": "string",
+    "key": "", "display": 2, "description": "VRF associated with session"}]'

--- a/tests/integration/sqcmds/common-samples/help.yml
+++ b/tests/integration/sqcmds/common-samples/help.yml
@@ -187,9 +187,9 @@ tests:
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: bgp help command
-  output: "bgp show: \e[36mShow address info\e[0m\n\e[33m\nUse quotes when providing more\
-    \ than one value\e[0m\n\e[33m\nArguments:\e[0m\n - afiSafi: \e[36m\e[1mBGP AFI\
-    \ SAFI lens to filter the topology\e[0m\n - columns: \e[36m\e[1mSpace separated\
+  output: "bgp show: \e[36mShow address info\e[0m\n\e[33m\nUse quotes when providing\
+    \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - afiSafi: \e[36m\e[1mBGP\
+    \ AFI SAFI lens to filter the topology\e[0m\n - columns: \e[36m\e[1mSpace separated\
     \ list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time window,\
     \ try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat of\
     \ the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
@@ -875,22 +875,22 @@ tests:
     \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
     \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
     \ records or just the latest\e[0m\n"
-- command: network help
+- command: namespace help
   data-directory: tests/data/eos/parquet-out/
   format: text
-  marks: network help
-  output: "network: \e[36mOverall network information such as namespaces present etc.\e\
-    [0m\n\nSupported verbs are: \n - describe: \e[36mDisplay the schema of the table\e\
-    [0m\n - find: \e[36mFind the network attach point of a given IP or MAC address.\e\
-    [0m\n - help: \e[36mShow help for a command\e[0m\n - show: \e[36mShow network\
-    \ info\e[0m\n - summarize: \e[36mSummarize relevant information about the table\e\
-    [0m\n - top: \e[36mReturn the top n values for a field in a table\e[0m\n - unique:\
-    \ \e[36mGet unique values (and counts) associated with requested field\e[0m\n"
-- command: network help --command=describe
+  marks: namespace help
+  output: "namespace: \e[36mOverall network information such as namespaces present\
+    \ etc.\e[0m\n\nSupported verbs are: \n - describe: \e[36mDisplay the schema of\
+    \ the table\e[0m\n - help: \e[36mShow help for a command\e[0m\n - show: \e[36mShow\
+    \ network info\e[0m\n - summarize: \e[36mSummarize relevant information about\
+    \ the table\e[0m\n - top: \e[36mReturn the top n values for a field in a table\e\
+    [0m\n - unique: \e[36mGet unique values (and counts) associated with requested\
+    \ field\e[0m\n"
+- command: namespace help --command=describe
   data-directory: tests/data/eos/parquet-out/
   format: text
-  marks: network help command
-  output: "network describe: \e[36mDisplay the schema of the table\e[0m\n\e[33m\n\
+  marks: namespace help command
+  output: "namespace describe: \e[36mDisplay the schema of the table\e[0m\n\e[33m\n\
     Use quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n\
     \ - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - end_time:\
     \ \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e\
@@ -900,11 +900,11 @@ tests:
     \ further filter the output\e[0m\n - start_time: \e[36m\e[1mStart of time window,\
     \ try natural language spec\e[0m\n - view: \e[36m\e[1mView all records or just\
     \ the latest\e[0m\n"
-- command: network help --command=show
+- command: namespace help --command=show
   data-directory: tests/data/eos/parquet-out/
   format: text
-  marks: network help command
-  output: "network show: \e[36mShow network info\e[0m\n\e[33m\nUse quotes when providing\
+  marks: namespace help command
+  output: "namespace show: \e[36mShow network info\e[0m\n\e[33m\nUse quotes when providing\
     \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - columns: \e[36m\e[1mSpace\
     \ separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time\
     \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
@@ -916,6 +916,59 @@ tests:
     \ spec\e[0m\n - vendor: \e[36m\e[1mVendor(s), space separated\e[0m\n - version:\
     \ \e[36m\e[1mNOS version(s), space separated\e[0m\n - view: \e[36m\e[1mView all\
     \ records or just the latest\e[0m\n"
+- command: namespace help --command=summarize
+  data-directory: tests/data/eos/parquet-out/
+  format: text
+  marks: namespace help command
+  output: "namespace summarize: \e[36mSummarize relevant information about the table\e\
+    [0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
+    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
+    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
+    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
+    [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
+    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
+    \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
+    \ records or just the latest\e[0m\n"
+- command: namespace help --command=top
+  data-directory: tests/data/eos/parquet-out/
+  format: text
+  marks: namespace help command
+  output: "namespace top: \e[36mReturn the top n values for a field in a table\e[0m\n\
+    \e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
+    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
+    \ - count: \e[36m\e[1mnumber of rows to return\e[0m\n - end_time: \e[36m\e[1mEnd\
+    \ of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
+    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
+    [0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - query_str:\
+    \ \e[36m\e[1mTrailing blank terminated pandas query format to further filter the\
+    \ output\e[0m\n - reverse: \e[36m\e[1mreturn bottom n values\e[0m\n - start_time:\
+    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - view: \e\
+    [36m\e[1mView all records or just the latest\e[0m\n - what: \e[36m\e[1mnumeric\
+    \ field to get top values for\e[0m\n"
+- command: namespace help --command=unique
+  data-directory: tests/data/eos/parquet-out/
+  format: text
+  marks: namespace help command
+  output: "namespace unique: \e[36mGet unique values (and counts) associated with\
+    \ requested field\e[0m\n\e[33m\nUse quotes when providing more than one value\e\
+    [0m\n\e[33m\nArguments:\e[0m\n - columns: \e[36m\e[1mSpace separated list of columns,\
+    \ * for all\e[0m\n - count: \e[36m\e[1minclude count of times a value is seen\e\
+    [0m\n - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e\
+    [0m\n - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname:\
+    \ \e[36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
+    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
+    \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
+    \ records or just the latest\e[0m\n"
+- command: network help
+  data-directory: tests/data/eos/parquet-out/
+  format: text
+  marks: network help command
+  output: "network: \e[36mAdvanced commands across all the network\e[0m\n\nSupported\
+    \ verbs are: \n - describe: \e[36mDisplay the schema of the table\e[0m\n - find:\
+    \ \e[36mFind the network attach point of a given IP or MAC address.\e[0m\n - help:\
+    \ \e[36mShow help for a command\e[0m\n"
 - command: network help --command=find
   data-directory: tests/data/eos/parquet-out/
   format: text
@@ -932,51 +985,6 @@ tests:
     \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
     \ records or just the latest\e[0m\n - vlan: \e[36m\e[1mFind MAC within this VLAN\e\
     [0m\n - vrf: \e[36m\e[1mFind within this VRF, used for IP addr\e[0m\n"
-- command: network help --command=summarize
-  data-directory: tests/data/eos/parquet-out/
-  format: text
-  marks: network help command
-  output: "network summarize: \e[36mSummarize relevant information about the table\e\
-    [0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
-    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
-    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
-    [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
-    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
-    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
-    \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
-    \ records or just the latest\e[0m\n"
-- command: network help --command=top
-  data-directory: tests/data/eos/parquet-out/
-  format: text
-  marks: network help command
-  output: "network top: \e[36mReturn the top n values for a field in a table\e[0m\n\
-    \e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
-    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
-    \ - count: \e[36m\e[1mnumber of rows to return\e[0m\n - end_time: \e[36m\e[1mEnd\
-    \ of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
-    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
-    [0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - query_str:\
-    \ \e[36m\e[1mTrailing blank terminated pandas query format to further filter the\
-    \ output\e[0m\n - reverse: \e[36m\e[1mreturn bottom n values\e[0m\n - start_time:\
-    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - view: \e\
-    [36m\e[1mView all records or just the latest\e[0m\n - what: \e[36m\e[1mnumeric\
-    \ field to get top values for\e[0m\n"
-- command: network help --command=unique
-  data-directory: tests/data/eos/parquet-out/
-  format: text
-  marks: network help command
-  output: "network unique: \e[36mGet unique values (and counts) associated with requested\
-    \ field\e[0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\n\
-    Arguments:\e[0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for\
-    \ all\e[0m\n - count: \e[36m\e[1minclude count of times a value is seen\e[0m\n\
-    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
-    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
-    [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
-    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
-    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
-    \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
-    \ records or just the latest\e[0m\n"
 - command: path help
   data-directory: tests/data/eos/parquet-out/
   format: text

--- a/tests/integration/sqcmds/common-samples/help.yml
+++ b/tests/integration/sqcmds/common-samples/help.yml
@@ -879,13 +879,13 @@ tests:
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: namespace help
-  output: "namespace: \e[36mOverall network information such as namespaces present\
-    \ etc.\e[0m\n\nSupported verbs are: \n - describe: \e[36mDisplay the schema of\
-    \ the table\e[0m\n - help: \e[36mShow help for a command\e[0m\n - show: \e[36mShow\
-    \ network info\e[0m\n - summarize: \e[36mSummarize relevant information about\
-    \ the table\e[0m\n - top: \e[36mReturn the top n values for a field in a table\e\
-    [0m\n - unique: \e[36mGet unique values (and counts) associated with requested\
-    \ field\e[0m\n"
+  output: "namespace: \e[36mOverall network information such as device count, bgp\
+    \ enabled etc.\e[0m\n\nSupported verbs are: \n - describe: \e[36mDisplay the schema\
+    \ of the table\e[0m\n - help: \e[36mShow help for a command\e[0m\n - show: \e\
+    [36mShow namespace info\e[0m\n - summarize: \e[36mSummarize relevant information\
+    \ about the table\e[0m\n - top: \e[36mReturn the top n values for a field in a\
+    \ table\e[0m\n - unique: \e[36mGet unique values (and counts) associated with\
+    \ requested field\e[0m\n"
 - command: namespace help --command=describe
   data-directory: tests/data/eos/parquet-out/
   format: text
@@ -904,18 +904,19 @@ tests:
   data-directory: tests/data/eos/parquet-out/
   format: text
   marks: namespace help command
-  output: "namespace show: \e[36mShow network info\e[0m\n\e[33m\nUse quotes when providing\
-    \ more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - columns: \e[36m\e[1mSpace\
-    \ separated list of columns, * for all\e[0m\n - end_time: \e[36m\e[1mEnd of time\
-    \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
-    \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
-    \ - model: \e[36m\e[1mmodel(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
-    \ space separated\e[0m\n - os: \e[36m\e[1mNOS(es), space separated\e[0m\n - query_str:\
-    \ \e[36m\e[1mTrailing blank terminated pandas query format to further filter the\
-    \ output\e[0m\n - start_time: \e[36m\e[1mStart of time window, try natural language\
-    \ spec\e[0m\n - vendor: \e[36m\e[1mVendor(s), space separated\e[0m\n - version:\
-    \ \e[36m\e[1mNOS version(s), space separated\e[0m\n - view: \e[36m\e[1mView all\
-    \ records or just the latest\e[0m\n"
+  output: "namespace show: \e[36mShow namespace info\e[0m\n\e[33m\nUse quotes when\
+    \ providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n - columns: \e\
+    [36m\e[1mSpace separated list of columns, * for all\e[0m\n - end_time: \e[36m\e\
+    [1mEnd of time window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect\
+    \ the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e\
+    [0m\n - model: \e[36m\e[1mDevice model(s), space separated\e[0m\n - namespace:\
+    \ \e[36m\e[1mNamespace(s), space separated\e[0m\n - os: \e[36m\e[1mDevice NOS(es),\
+    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
+    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
+    \ of time window, try natural language spec\e[0m\n - vendor: \e[36m\e[1mDevice\
+    \ vendor(s), space separated\e[0m\n - version: \e[36m\e[1mDevice NOS version(s),\
+    \ space separated\e[0m\n - view: \e[36m\e[1mView all records or just the latest\e\
+    [0m\n"
 - command: namespace help --command=summarize
   data-directory: tests/data/eos/parquet-out/
   format: text

--- a/tests/integration/sqcmds/cumulus-samples/all.yml
+++ b/tests/integration/sqcmds/cumulus-samples/all.yml
@@ -5363,10 +5363,10 @@ tests:
     true}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vlanName": "vlan4001",
     "state": "active", "interfaces": ["vxlan4001"], "vlan": 4001, "timestamp": 1616681582524,
     "active": true}]'
-- command: network show --columns='*' --format=json --namespace='ospf-single dual-evpn
+- command: namespace show --columns='*' --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet
-  marks: network show all cumulus
+  marks: namespace show all cumulus
   output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
     0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
     1639161298729, "active": true}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt":

--- a/tests/integration/sqcmds/cumulus-samples/namespace.yml
+++ b/tests/integration/sqcmds/cumulus-samples/namespace.yml
@@ -1,0 +1,64 @@
+description: Testing namespace table for Cumulus
+tests:
+- command: namespace show --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+  data-directory: tests/data/parquet
+  marks: namespace show cumulus
+  output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
+    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161298729}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt": 18,
+    "errSvcCnt": 0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag":
+    true, "lastUpdate": 1641830465167}, {"namespace": "ospf-single", "deviceCnt":
+    14, "serviceCnt": 16, "errSvcCnt": 0, "hasOspf": true, "hasBgp": false, "hasVxlan":
+    false, "hasMlag": false, "lastUpdate": 1639161366022}]'
+- command: namespace show --format=json --os=cumulus --namespace='ospf-single dual-evpn
+    ospf-ibgp'
+  data-directory: tests/data/parquet
+  marks: namespace show  cumulus
+  output: '[{"namespace": "dual-evpn", "deviceCnt": 9, "serviceCnt": 17, "errSvcCnt":
+    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161298729}, {"namespace": "ospf-ibgp", "deviceCnt": 9, "serviceCnt": 18, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1641830465166}, {"namespace": "ospf-single", "deviceCnt": 9, "serviceCnt": 16,
+    "errSvcCnt": 0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag":
+    false, "lastUpdate": 1639161366022}]'
+- command: namespace show --columns='namespace' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
+  data-directory: tests/data/parquet
+  marks: namespace show cumulus
+  output: '[{"namespace": "dual-evpn"}, {"namespace": "ospf-ibgp"}, {"namespace":
+    "ospf-single"}]'
+- command: namespace show --columns='hasOspf hasBgp' --format=json --namespace='ospf-single
+    dual-evpn ospf-ibgp'
+  data-directory: tests/data/parquet
+  marks: namespace show cumulus
+  output: '[{"hasOspf": false, "hasBgp": true}, {"hasOspf": true, "hasBgp": true},
+    {"hasOspf": true, "hasBgp": false}]'
+- command: namespace show --columns='*' --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
+  data-directory: tests/data/parquet
+  marks: namespace show cumulus
+  output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
+    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161298729, "active": true}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt":
+    18, "errSvcCnt": 0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag":
+    true, "lastUpdate": 1641830465167, "active": true}, {"namespace": "ospf-single",
+    "deviceCnt": 14, "serviceCnt": 16, "errSvcCnt": 0, "hasOspf": true, "hasBgp":
+    false, "hasVxlan": false, "hasMlag": false, "lastUpdate": 1639161366022, "active":
+    true}]'
+- command: namespace summarize --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+  data-directory: tests/data/parquet
+  marks: namespace summarize cumulus
+  output: '{"summary": {"namespacesCnt": 3, "servicePerNsStat": [16, 18, 17.0], "nsWithMlagCnt":
+    2, "nsWithBgpCnt": 2, "nsWithOspfCnt": 2, "nsWithVxlanCnt": 2, "nsWithErrsvcCnt":
+    0}}'
+- command: namespace unique --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
+  data-directory: tests/data/parquet/
+  marks: namespace unique
+  output: '[{"namespace": "dual-evpn"}, {"namespace": "ospf-ibgp"}, {"namespace":
+    "ospf-single"}]'
+- command: namespace unique --count=True --format=json --namespace='ospf-single dual-evpn
+    ospf-ibgp'
+  data-directory: tests/data/parquet/
+  marks: namespace unique
+  output: '[{"namespace": "dual-evpn", "numRows": 1}, {"namespace": "ospf-ibgp", "numRows":
+    1}, {"namespace": "ospf-single", "numRows": 1}]'

--- a/tests/integration/sqcmds/cumulus-samples/network.yml
+++ b/tests/integration/sqcmds/cumulus-samples/network.yml
@@ -1,50 +1,5 @@
 description: Testing network table for Cumulus
 tests:
-- command: network show --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
-  data-directory: tests/data/parquet
-  marks: network show cumulus
-  output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161298729}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt": 18,
-    "errSvcCnt": 0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag":
-    true, "lastUpdate": 1641830465167}, {"namespace": "ospf-single", "deviceCnt":
-    14, "serviceCnt": 16, "errSvcCnt": 0, "hasOspf": true, "hasBgp": false, "hasVxlan":
-    false, "hasMlag": false, "lastUpdate": 1639161366022}]'
-- command: network show --format=json --os=cumulus --namespace='ospf-single dual-evpn
-    ospf-ibgp'
-  data-directory: tests/data/parquet
-  marks: network show  cumulus
-  output: '[{"namespace": "dual-evpn", "deviceCnt": 9, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161298729}, {"namespace": "ospf-ibgp", "deviceCnt": 9, "serviceCnt": 18, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1641830465166}, {"namespace": "ospf-single", "deviceCnt": 9, "serviceCnt": 16,
-    "errSvcCnt": 0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag":
-    false, "lastUpdate": 1639161366022}]'
-- command: network show --columns='namespace' --format=json --namespace='ospf-single
-    dual-evpn ospf-ibgp'
-  data-directory: tests/data/parquet
-  marks: network show cumulus
-  output: '[{"namespace": "dual-evpn"}, {"namespace": "ospf-ibgp"}, {"namespace":
-    "ospf-single"}]'
-- command: network show --columns='hasOspf hasBgp' --format=json --namespace='ospf-single
-    dual-evpn ospf-ibgp'
-  data-directory: tests/data/parquet
-  marks: network show cumulus
-  output: '[{"hasOspf": false, "hasBgp": true}, {"hasOspf": true, "hasBgp": true},
-    {"hasOspf": true, "hasBgp": false}]'
-- command: network show --columns='*' --format=json --namespace='ospf-single dual-evpn
-    ospf-ibgp'
-  data-directory: tests/data/parquet
-  marks: network show cumulus
-  output: '[{"namespace": "dual-evpn", "deviceCnt": 14, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": false, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161298729, "active": true}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt":
-    18, "errSvcCnt": 0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag":
-    true, "lastUpdate": 1641830465167, "active": true}, {"namespace": "ospf-single",
-    "deviceCnt": 14, "serviceCnt": 16, "errSvcCnt": 0, "hasOspf": true, "hasBgp":
-    false, "hasVxlan": false, "hasMlag": false, "lastUpdate": 1639161366022, "active":
-    true}]'
 - command: network find --address="172.16.1.101" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
@@ -152,12 +107,6 @@ tests:
     {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01",
     "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616681581182}]'
-- command: network summarize --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
-  data-directory: tests/data/parquet
-  marks: network summarize cumulus
-  output: '{"summary": {"namespacesCnt": 3, "servicePerNsStat": [16, 18, 17.0], "nsWithMlagCnt":
-    2, "nsWithBgpCnt": 2, "nsWithOspfCnt": 2, "nsWithVxlanCnt": 2, "nsWithErrsvcCnt":
-    0}}'
 - command: network find --address="10.0.0.11" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
@@ -203,17 +152,6 @@ tests:
   data-directory: tests/data/parquet
   marks: network find cumulus
   output: '[]'
-- command: network unique --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
-  data-directory: tests/data/parquet/
-  marks: network unique
-  output: '[{"namespace": "dual-evpn"}, {"namespace": "ospf-ibgp"}, {"namespace":
-    "ospf-single"}]'
-- command: network unique --count=True --format=json --namespace='ospf-single dual-evpn
-    ospf-ibgp'
-  data-directory: tests/data/parquet/
-  marks: network unique
-  output: '[{"namespace": "dual-evpn", "numRows": 1}, {"namespace": "ospf-ibgp", "numRows":
-    1}, {"namespace": "ospf-single", "numRows": 1}]'
 - command: network find --address='foobar' --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet

--- a/tests/integration/sqcmds/cumulus-samples/top.yml
+++ b/tests/integration/sqcmds/cumulus-samples/top.yml
@@ -374,10 +374,10 @@ tests:
     "ospf-ibgp", "hostname": "exit02", "vni": 104001, "type": "L3", "vlan": 4001,
     "state": "up", "mcastGroup": "0.0.0.0", "remoteVtepCnt": 0, "priVtepIp": "10.0.0.102",
     "secVtepIp": "", "timestamp": 1616681582523}]'
-- command: network top --what=deviceCnt --format=json --namespace='ospf-single dual-evpn
+- command: namespace top --what=deviceCnt --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
-  marks: network top
+  marks: namespace top
   output: '[{"namespace": "ospf-single", "deviceCnt": 14, "serviceCnt": 16, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161366022}, {"namespace": "ospf-ibgp", "deviceCnt": 14, "serviceCnt": 18,
@@ -408,10 +408,10 @@ tests:
   output: '[{"namespace": "dual-evpn", "hostname": "leaf04", "ifname": "bond02", "state":
     "up", "adminState": "up", "type": "bond", "mtu": 1500, "vlan": 0, "master": "bridge",
     "ipAddressList": [], "ip6AddressList": [], "numChanges": 9, "timestamp": 1616644822983}]'
-- command: network top --what=deviceCnt --count=1 --format=json --namespace='ospf-single
+- command: namespace top --what=deviceCnt --count=1 --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
-  marks: network top
+  marks: namespace top
   output: '[{"namespace": "ospf-single", "deviceCnt": 14, "serviceCnt": 16, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161366022}]'

--- a/tests/integration/sqcmds/eos-samples/all.yml
+++ b/tests/integration/sqcmds/eos-samples/all.yml
@@ -6230,9 +6230,9 @@ tests:
     "active", "interfaces": [], "vlan": 1, "timestamp": 1623025174550, "active": true},
     {"namespace": "eos", "hostname": "dcedge01", "vlanName": "vlan1", "state": "active",
     "interfaces": [], "vlan": 1, "timestamp": 1623025176433, "active": true}]'
-- command: network show --columns='*' --format=json --namespace=eos
+- command: namespace show --columns='*' --format=json --namespace=eos
   data-directory: tests/data/parquet
-  marks: network show all eos
+  marks: namespace show all eos
   output: '[{"namespace": "eos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt": 0,
     "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
     1639161231163, "active": true}]'

--- a/tests/integration/sqcmds/eos-samples/namespace.yml
+++ b/tests/integration/sqcmds/eos-samples/namespace.yml
@@ -1,0 +1,42 @@
+description: Testing namespace table for EOS
+tests:
+- command: namespace show --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace show eos
+  output: '[{"namespace": "eos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt": 0,
+    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231163}]'
+- command: namespace show --format=json --namespace=eos --os=eos
+  data-directory: tests/data/parquet
+  marks: namespace show  eos
+  output: '[{"namespace": "eos", "deviceCnt": 8, "serviceCnt": 18, "errSvcCnt": 0,
+    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231158}]'
+- command: namespace show --columns='namespace' --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace show eos
+  output: '[{"namespace": "eos"}]'
+- command: namespace show --columns='hasOspf hasBgp' --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace show eos
+  output: '[{"hasOspf": true, "hasBgp": true}]'
+- command: namespace show --columns='*' --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace show eos
+  output: '[{"namespace": "eos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt": 0,
+    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231163, "active": true}]'
+- command: namespace unique --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace unique eos
+  output: '[{"namespace": "eos"}]'
+- command: namespace unique --count=True --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace unique eos
+  output: '[{"namespace": "eos", "numRows": 1}]'
+- command: namespace summarize --format=json --namespace=eos
+  data-directory: tests/data/parquet
+  marks: namespace summarize eos
+  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [18, 18, 18.0], "nsWithMlagCnt":
+    1, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
+    0}}'

--- a/tests/integration/sqcmds/eos-samples/network.yml
+++ b/tests/integration/sqcmds/eos-samples/network.yml
@@ -1,31 +1,5 @@
 description: Testing network table for EOS
 tests:
-- command: network show --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network show eos
-  output: '[{"namespace": "eos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt": 0,
-    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231163}]'
-- command: network show --format=json --namespace=eos --os=eos
-  data-directory: tests/data/parquet
-  marks: network show  eos
-  output: '[{"namespace": "eos", "deviceCnt": 8, "serviceCnt": 18, "errSvcCnt": 0,
-    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231158}]'
-- command: network show --columns='namespace' --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network show eos
-  output: '[{"namespace": "eos"}]'
-- command: network show --columns='hasOspf hasBgp' --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network show eos
-  output: '[{"hasOspf": true, "hasBgp": true}]'
-- command: network show --columns='*' --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network show eos
-  output: '[{"namespace": "eos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt": 0,
-    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231163, "active": true}]'
 - command: network find --address="172.16.1.101" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
@@ -62,12 +36,6 @@ tests:
     {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
     "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
     "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177688}]'
-- command: network summarize --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network summarize eos
-  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [18, 18, 18.0], "nsWithMlagCnt":
-    1, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
-    0}}'
 - command: network find --address="10.0.0.11" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
@@ -98,14 +66,6 @@ tests:
   output: '[{"namespace": "eos", "hostname": "exit02", "vrf": "default", "ipAddress":
     "10.0.0.32", "vlan": "0", "macaddr": "44:38:39:c3:55:cb", "ifname": "Ethernet1",
     "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025177202}]'
-- command: network unique --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network unique eos
-  output: '[{"namespace": "eos"}]'
-- command: network unique --count=True --format=json --namespace=eos
-  data-directory: tests/data/parquet
-  marks: network unique eos
-  output: '[{"namespace": "eos", "numRows": 1}]'
 - command: network find --address='foobar' --format=json --namespace=eos
   data-directory: tests/data/parquet
   error:

--- a/tests/integration/sqcmds/junos-samples/all.yml
+++ b/tests/integration/sqcmds/junos-samples/all.yml
@@ -6557,9 +6557,9 @@ tests:
     "interfaces": [], "vlan": 1, "timestamp": 1623025797192, "active": true}, {"namespace":
     "junos", "hostname": "exit02", "vlanName": "vlan1", "state": "active", "interfaces":
     [], "vlan": 1, "timestamp": 1623025797193, "active": true}]'
-- command: network show --columns='*' --format=json --namespace=junos
+- command: namespace show --columns='*' --format=json --namespace=junos
   data-directory: tests/data/parquet
-  marks: network show all junos
+  marks: namespace show all junos
   output: '[{"namespace": "junos", "deviceCnt": 12, "serviceCnt": 17, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
     1644069801736, "active": true}]'

--- a/tests/integration/sqcmds/junos-samples/namespace.yml
+++ b/tests/integration/sqcmds/junos-samples/namespace.yml
@@ -1,0 +1,45 @@
+description: Testing namespace table
+tests:
+- command: namespace show --format=json --namespace=junos --model=vmx
+  data-directory: tests/data/parquet
+  marks: namespace show junos
+  output: '[]'
+- command: namespace show --format=json --namespace=junos --os=junos-qfx
+  data-directory: tests/data/parquet
+  marks: namespace show junos
+  output: '[{"namespace": "junos", "deviceCnt": 7, "serviceCnt": 13, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
+    1644069801736}]'
+- command: namespace show --format=json --namespace=junos --vendor=Juniper
+  data-directory: tests/data/parquet
+  output: '[{"namespace": "junos", "deviceCnt": 7, "serviceCnt": 13, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
+    1644069801736}]'
+- command: namespace show --columns='namespace' --format=json --namespace=junos
+  data-directory: tests/data/parquet
+  marks: namespace show junos
+  output: '[{"namespace": "junos"}]'
+- command: namespace show --columns='hasOspf hasBgp' --format=json --namespace=junos
+  data-directory: tests/data/parquet
+  marks: namespace show junos
+  output: '[{"hasOspf": true, "hasBgp": true}]'
+- command: namespace show --columns='*' --format=json --namespace=junos
+  data-directory: tests/data/parquet
+  marks: namespace show junos
+  output: '[{"namespace": "junos", "deviceCnt": 12, "serviceCnt": 17, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
+    1644069801736, "active": true}]'
+- command: namespace summarize --format=json --namespace=junos
+  data-directory: tests/data/parquet
+  marks: namespace summarize junos
+  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [17, 17, 17.0], "nsWithMlagCnt":
+    0, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
+    0}}'
+- command: namespace unique --format=json --namespace=junos
+  data-directory: tests/data/parquet
+  marks: namespace unique junos
+  output: '[{"namespace": "junos"}]'
+- command: namespace unique --count=True --format=json --namespace=junos
+  data-directory: tests/data/parquet
+  marks: namespace unique junos
+  output: '[{"namespace": "junos", "numRows": 1}]'

--- a/tests/integration/sqcmds/junos-samples/network.yml
+++ b/tests/integration/sqcmds/junos-samples/network.yml
@@ -1,52 +1,11 @@
 description: Testing network table
 tests:
-- command: network show --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network show junos
-  output: '[{"namespace": "junos", "deviceCnt": 12, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
-    1644069801736}]'
-- command: network show --format=json --namespace=junos --model=vmx
-  data-directory: tests/data/parquet
-  marks: network show junos
-  output: '[]'
-- command: network show --format=json --namespace=junos --os=junos-qfx
-  data-directory: tests/data/parquet
-  marks: network show junos
-  output: '[{"namespace": "junos", "deviceCnt": 7, "serviceCnt": 13, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
-    1644069801736}]'
-- command: network show --format=json --namespace=junos --vendor=Juniper
-  data-directory: tests/data/parquet
-  output: '[{"namespace": "junos", "deviceCnt": 7, "serviceCnt": 13, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
-    1644069801736}]'
-- command: network show --columns='namespace' --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network show junos
-  output: '[{"namespace": "junos"}]'
-- command: network show --columns='hasOspf hasBgp' --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network show junos
-  output: '[{"hasOspf": true, "hasBgp": true}]'
-- command: network show --columns='*' --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network show junos
-  output: '[{"namespace": "junos", "deviceCnt": 12, "serviceCnt": 17, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": false, "lastUpdate":
-    1644069801736, "active": true}]'
 - command: network find --address="172.16.1.101" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos
   output: '[{"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "28:b7:ad:3c:81:d0", "ifname": "xe-0/0/2",
     "bondMembers": "", "type": "bridged", "l2miss": false, "timestamp": 1623025797193}]'
-- command: network summarize --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network summarize junos
-  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [17, 17, 17.0], "nsWithMlagCnt":
-    0, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
-    0}}'
 - command: network find --address="10.0.0.11" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos
@@ -75,11 +34,3 @@ tests:
   data-directory: tests/data/parquet
   marks: network find junos
   output: '[]'
-- command: network unique --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network unique junos
-  output: '[{"namespace": "junos"}]'
-- command: network unique --count=True --format=json --namespace=junos
-  data-directory: tests/data/parquet
-  marks: network unique junos
-  output: '[{"namespace": "junos", "numRows": 1}]'

--- a/tests/integration/sqcmds/mixed-samples/all.yml
+++ b/tests/integration/sqcmds/mixed-samples/all.yml
@@ -4757,9 +4757,9 @@ tests:
     "Ethernet1/55", "Ethernet1/56", "Ethernet1/57", "Ethernet1/58", "Ethernet1/59",
     "Ethernet1/60", "Ethernet1/61", "Ethernet1/62", "Ethernet1/63", "Ethernet1/64"],
     "vlan": 1, "timestamp": 1627395439618, "active": true}]'
-- command: network show --columns='*' --format=json --namespace=mixed
+- command: namespace show --columns='*' --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network show all mixed
+  marks: namespace show all mixed
   output: '[{"namespace": "mixed", "deviceCnt": 8, "serviceCnt": 18, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161233280, "active": true}]'

--- a/tests/integration/sqcmds/mixed-samples/namespace.yml
+++ b/tests/integration/sqcmds/mixed-samples/namespace.yml
@@ -1,42 +1,42 @@
-description: Testing network table for Mixed
+description: Testing namespace table for Mixed
 tests:
-- command: network show --format=json --namespace=mixed
+- command: namespace show --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network show mixed
+  marks: namespace show mixed
   output: '[{"namespace": "mixed", "deviceCnt": 8, "serviceCnt": 18, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161233280}]'
-- command: network show --format=json --namespace=mixed --os=nxos
+- command: namespace show --format=json --namespace=mixed --os=nxos
   data-directory: tests/data/parquet/
-  marks: network show mixed
+  marks: namespace show mixed
   output: '[{"namespace": "mixed", "deviceCnt": 2, "serviceCnt": 10, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161233279}]'
-- command: network show --format=json --namespace=mixed --os='nxos eos'
+- command: namespace show --format=json --namespace=mixed --os='nxos eos'
   data-directory: tests/data/parquet/
-  marks: network show mixed
+  marks: namespace show mixed
   output: '[{"namespace": "mixed", "deviceCnt": 4, "serviceCnt": 18, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161233280}]'
-- command: network show --columns='namespace' --format=json --namespace=mixed
+- command: namespace show --columns='namespace' --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network show mixed
+  marks: namespace show mixed
   output: '[{"namespace": "mixed"}]'
-- command: network show --columns='hasOspf hasBgp' --os='nxos' --format=json --namespace=mixed
+- command: namespace show --columns='hasOspf hasBgp' --os='nxos' --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network show mixed
+  marks: namespace show mixed
   output: '[{"hasOspf": true, "hasBgp": false}]'
-- command: network show --columns='*' --format=json --namespace=mixed
+- command: namespace show --columns='*' --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network show mixed
+  marks: namespace show mixed
   output: '[{"namespace": "mixed", "deviceCnt": 8, "serviceCnt": 18, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": false, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161233280, "active": true}]'
-- command: network unique --format=json --namespace=mixed
+- command: namespace unique --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network unique mixed
+  marks: namespace unique mixed
   output: '[{"namespace": "mixed"}]'
-- command: network unique --count=True --format=json --namespace=mixed
+- command: namespace unique --count=True --format=json --namespace=mixed
   data-directory: tests/data/parquet/
-  marks: network unique mixed
+  marks: namespace unique mixed
   output: '[{"namespace": "mixed", "numRows": 1}]'

--- a/tests/integration/sqcmds/nxos-samples/all.yml
+++ b/tests/integration/sqcmds/nxos-samples/all.yml
@@ -11426,9 +11426,9 @@ tests:
     true}, {"namespace": "nxos", "hostname": "exit02", "vlanName": "vlan999", "state":
     "active", "interfaces": [""], "vlan": 999, "timestamp": 1619275257683, "active":
     true}]'
-- command: network show --columns='*' --format=json --namespace=nxos
+- command: namespace show --columns='*' --format=json --namespace=nxos
   data-directory: tests/data/parquet
-  marks: network show all nxos
+  marks: namespace show all nxos
   output: '[{"namespace": "nxos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
     0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
     1639161231216, "active": true}]'

--- a/tests/integration/sqcmds/nxos-samples/namespace.yml
+++ b/tests/integration/sqcmds/nxos-samples/namespace.yml
@@ -1,0 +1,64 @@
+description: Testing namespace table
+tests:
+- command: namespace show --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231216}]'
+- command: namespace show --format=json --namespace=nxos --model=vmx
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[]'
+- command: namespace show --format=json --namespace=nxos --os=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos", "deviceCnt": 8, "serviceCnt": 15, "errSvcCnt": 0,
+    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231211}]'
+- command: namespace show --format=json --namespace=nxos --vendor=Juniper
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos", "deviceCnt": 1, "serviceCnt": 13, "errSvcCnt": 0,
+    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161231216}]'
+- command: namespace show --columns='namespace' --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos"}]'
+- command: namespace show --columns='hasOspf hasBgp' --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"hasOspf": true, "hasBgp": true}]'
+- command: namespace show --columns='*' --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231216, "active": true}]'
+- command: namespace show --columns='*' --os=nxos --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos", "deviceCnt": 8, "serviceCnt": 15, "errSvcCnt": 0,
+    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639161231211, "active": true}]'
+- command: namespace show --columns='*' --vendor=Juniper --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace show nxos
+  output: '[{"namespace": "nxos", "deviceCnt": 1, "serviceCnt": 13, "errSvcCnt": 0,
+    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161231216, "active": true}]'
+- command: namespace summarize --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace summarize nxos
+  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [18, 18, 18.0], "nsWithMlagCnt":
+    1, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
+    0}}'
+- command: namespace unique --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace unique nxos
+  output: '[{"namespace": "nxos"}]'
+- command: namespace unique --count=True --format=json --namespace=nxos
+  data-directory: tests/data/parquet
+  marks: namespace unique nxos
+  output: '[{"namespace": "nxos", "numRows": 1}]'

--- a/tests/integration/sqcmds/nxos-samples/network.yml
+++ b/tests/integration/sqcmds/nxos-samples/network.yml
@@ -1,53 +1,5 @@
 description: Testing network table
 tests:
-- command: network show --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231216}]'
-- command: network show --format=json --namespace=nxos --model=vmx
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[]'
-- command: network show --format=json --namespace=nxos --os=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos", "deviceCnt": 8, "serviceCnt": 15, "errSvcCnt": 0,
-    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231211}]'
-- command: network show --format=json --namespace=nxos --vendor=Juniper
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos", "deviceCnt": 1, "serviceCnt": 13, "errSvcCnt": 0,
-    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
-    1639161231216}]'
-- command: network show --columns='namespace' --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos"}]'
-- command: network show --columns='hasOspf hasBgp' --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"hasOspf": true, "hasBgp": true}]'
-- command: network show --columns='*' --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231216, "active": true}]'
-- command: network show --columns='*' --os=nxos --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos", "deviceCnt": 8, "serviceCnt": 15, "errSvcCnt": 0,
-    "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639161231211, "active": true}]'
-- command: network show --columns='*' --vendor=Juniper --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network show nxos
-  output: '[{"namespace": "nxos", "deviceCnt": 1, "serviceCnt": 13, "errSvcCnt": 0,
-    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
-    1639161231216, "active": true}]'
 - command: network find --address="172.16.1.101" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
@@ -58,12 +10,6 @@ tests:
     "ipAddress": "172.16.1.101", "vlan": "10", "macaddr": "32:bb:c5:b5:3a:20", "ifname":
     "port-channel3", "bondMembers": "Ethernet1/3", "type": "bridged", "l2miss": false,
     "timestamp": 1619275264429}]'
-- command: network summarize --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network summarize nxos
-  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [18, 18, 18.0], "nsWithMlagCnt":
-    1, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
-    0}}'
 - command: network find --address="10.0.0.11" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
@@ -94,14 +40,6 @@ tests:
   data-directory: tests/data/parquet
   marks: network find nxos
   output: '[]'
-- command: network unique --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network unique nxos
-  output: '[{"namespace": "nxos"}]'
-- command: network unique --count=True --format=json --namespace=nxos
-  data-directory: tests/data/parquet
-  marks: network unique nxos
-  output: '[{"namespace": "nxos", "numRows": 1}]'
 - command: network find --address='foobar' --format=json --namespace=nxos
   data-directory: tests/data/parquet
   error:

--- a/tests/integration/sqcmds/panos-samples/namespace.yml
+++ b/tests/integration/sqcmds/panos-samples/namespace.yml
@@ -1,0 +1,42 @@
+description: Testing namespace table
+tests:
+- command: namespace show --format=json --namespace=panos
+  data-directory: tests/data/parquet
+  marks: namespace show panos
+  output: '[{"namespace": "panos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639498880095}]'
+- command: namespace show --format=json --namespace=panos --os=panos
+  data-directory: tests/data/parquet
+  marks: namespace show  panos
+  output: '[{"namespace": "panos", "deviceCnt": 1, "serviceCnt": 7, "errSvcCnt": 0,
+    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639498880046}]'
+- command: namespace show --columns='namespace' --format=json --namespace=panos
+  data-directory: tests/data/parquet
+  marks: namespace show panos
+  output: '[{"namespace": "panos"}]'
+- command: namespace show --columns='hasOspf hasBgp' --format=json --namespace=panos
+  data-directory: tests/data/parquet
+  marks: namespace show panos
+  output: '[{"hasOspf": true, "hasBgp": true}]'
+- command: namespace show --columns='*' --format=json --namespace=panos
+  data-directory: tests/data/parquet
+  marks: namespace show panos
+  output: '[{"namespace": "panos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
+    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
+    1639498880095, "active": true}]'
+- command: namespace summarize --format=json --namespace=panos
+  data-directory: tests/data/parquet
+  marks: namespace summarize panos
+  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [18, 18, 18.0], "nsWithMlagCnt":
+    1, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
+    0}}'
+- command: namespace unique --format=json --namespace=panos
+  data-directory: tests/data/parquet/
+  marks: namespace unique
+  output: '[{"namespace": "panos"}]'
+- command: namespace unique --count=True --format=json --namespace=panos
+  data-directory: tests/data/parquet/
+  marks: namespace unique
+  output: '[{"namespace": "panos", "numRows": 1}]'

--- a/tests/integration/sqcmds/panos-samples/network.yml
+++ b/tests/integration/sqcmds/panos-samples/network.yml
@@ -1,31 +1,5 @@
 description: Testing network table for panos
 tests:
-- command: network show --format=json --namespace=panos
-  data-directory: tests/data/parquet
-  marks: network show panos
-  output: '[{"namespace": "panos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639498880095}]'
-- command: network show --format=json --namespace=panos --os=panos
-  data-directory: tests/data/parquet
-  marks: network show  panos
-  output: '[{"namespace": "panos", "deviceCnt": 1, "serviceCnt": 7, "errSvcCnt": 0,
-    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
-    1639498880046}]'
-- command: network show --columns='namespace' --format=json --namespace=panos
-  data-directory: tests/data/parquet
-  marks: network show panos
-  output: '[{"namespace": "panos"}]'
-- command: network show --columns='hasOspf hasBgp' --format=json --namespace=panos
-  data-directory: tests/data/parquet
-  marks: network show panos
-  output: '[{"hasOspf": true, "hasBgp": true}]'
-- command: network show --columns='*' --format=json --namespace=panos
-  data-directory: tests/data/parquet
-  marks: network show panos
-  output: '[{"namespace": "panos", "deviceCnt": 14, "serviceCnt": 18, "errSvcCnt":
-    0, "hasOspf": true, "hasBgp": true, "hasVxlan": true, "hasMlag": true, "lastUpdate":
-    1639498880095, "active": true}]'
 - command: network find --address="172.16.1.101" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
@@ -46,12 +20,6 @@ tests:
   data-directory: tests/data/parquet
   marks: network find panos
   output: '[]'
-- command: network summarize --format=json --namespace=panos
-  data-directory: tests/data/parquet
-  marks: network summarize panos
-  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [18, 18, 18.0], "nsWithMlagCnt":
-    1, "nsWithBgpCnt": 1, "nsWithOspfCnt": 1, "nsWithVxlanCnt": 1, "nsWithErrsvcCnt":
-    0}}'
 - command: network find --address="10.0.0.11" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
@@ -94,11 +62,3 @@ tests:
     "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress": "10.0.0.32", "vlan":
     "999", "macaddr": "44:39:39:ff:41:96", "ifname": "vlan999", "bondMembers": "",
     "type": "bridged", "l2miss": true, "timestamp": 1639476254425}]'
-- command: network unique --format=json --namespace=panos
-  data-directory: tests/data/parquet/
-  marks: network unique
-  output: '[{"namespace": "panos"}]'
-- command: network unique --count=True --format=json --namespace=panos
-  data-directory: tests/data/parquet/
-  marks: network unique
-  output: '[{"namespace": "panos", "numRows": 1}]'

--- a/tests/integration/sqcmds/vmx-samples/all.yml
+++ b/tests/integration/sqcmds/vmx-samples/all.yml
@@ -2396,9 +2396,9 @@ tests:
   data-directory: tests/data/parquet
   marks: mlag show junos all vmx
   output: '[]'
-- command: network show --columns=* --format=json --namespace=vmx
+- command: namespace show --columns=* --format=json --namespace=vmx
   data-directory: tests/data/parquet
-  marks: network show vmx all vmx
+  marks: namespace show vmx all vmx
   output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
     "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161230623, "active": true}]'
@@ -2822,9 +2822,9 @@ tests:
     "CRP-DIS-SW01", "name": "midplane", "model": "", "status": "present", "vendor":
     "Juniper", "type": "midplane", "version": "", "partType": "", "timestamp": 1631009090098,
     "serial": "", "partNum": "", "active": true}]'
-- command: network show --columns='*' --format=json --namespace=vmx
+- command: namespace show --columns='*' --format=json --namespace=vmx
   data-directory: tests/data/parquet
-  marks: network show all junos vmx
+  marks: namespace show all junos vmx
   output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
     "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
     1639161230623, "active": true}]'

--- a/tests/integration/sqcmds/vmx-samples/namespace.yml
+++ b/tests/integration/sqcmds/vmx-samples/namespace.yml
@@ -1,0 +1,34 @@
+description: Testing namespace table
+tests:
+- command: namespace show --format=json --namespace=vmx
+  data-directory: tests/data/parquet
+  marks: namespace show junos vmx
+  output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
+    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161230623}]'
+- command: namespace show --format=json --namespace=vmx --model=vmx
+  data-directory: tests/data/parquet
+  marks: namespace show junos vmx
+  output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
+    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161230623}]'
+- command: namespace show --columns='*' --os=junos --format=json --namespace=vmx
+  data-directory: tests/data/parquet
+  marks: namespace show vmx junos
+  output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
+    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
+    1639161230623, "active": true}]'
+- command: namespace summarize --namespace=vmx --format=json --namespace=vmx
+  data-directory: tests/data/parquet
+  marks: namespace summarize junos vmx
+  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [13, 13, 13.0], "nsWithMlagCnt":
+    0, "nsWithBgpCnt": 1, "nsWithOspfCnt": 0, "nsWithVxlanCnt": 0, "nsWithErrsvcCnt":
+    0}}'
+- command: namespace unique --namespace=vmx --format=json --namespace=vmx
+  data-directory: tests/data/parquet
+  marks: namespace unique junos vmx
+  output: '[{"namespace": "vmx"}]'
+- command: namespace unique --count=True --namespace=vmx --format=json --namespace=vmx
+  data-directory: tests/data/parquet
+  marks: namespace unique junos vmx
+  output: '[{"namespace": "vmx", "numRows": 1}]'

--- a/tests/integration/sqcmds/vmx-samples/network.yml
+++ b/tests/integration/sqcmds/vmx-samples/network.yml
@@ -1,23 +1,5 @@
 description: Testing network table
 tests:
-- command: network show --format=json --namespace=vmx
-  data-directory: tests/data/parquet
-  marks: network show junos vmx
-  output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
-    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
-    1639161230623}]'
-- command: network show --format=json --namespace=vmx --model=vmx
-  data-directory: tests/data/parquet
-  marks: network show junos vmx
-  output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
-    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
-    1639161230623}]'
-- command: network show --columns='*' --os=junos --format=json --namespace=vmx
-  data-directory: tests/data/parquet
-  marks: network show vmx junos
-  output: '[{"namespace": "vmx", "deviceCnt": 5, "serviceCnt": 13, "errSvcCnt": 0,
-    "hasOspf": false, "hasBgp": true, "hasVxlan": false, "hasMlag": false, "lastUpdate":
-    1639161230623, "active": true}]'
 - command: network find --address="172.16.11.11" --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: network find junos vmx
@@ -54,17 +36,3 @@ tests:
   output: '[{"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "ae2", "ipAddress":
     "10.0.10.2", "vlan": "10", "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/4",
     "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1631009089424}]'
-- command: network summarize --namespace=vmx --format=json --namespace=vmx
-  data-directory: tests/data/parquet
-  marks: network summarize junos vmx
-  output: '{"summary": {"namespacesCnt": 1, "servicePerNsStat": [13, 13, 13.0], "nsWithMlagCnt":
-    0, "nsWithBgpCnt": 1, "nsWithOspfCnt": 0, "nsWithVxlanCnt": 0, "nsWithErrsvcCnt":
-    0}}'
-- command: network unique --namespace=vmx --format=json --namespace=vmx
-  data-directory: tests/data/parquet
-  marks: network unique junos vmx
-  output: '[{"namespace": "vmx"}]'
-- command: network unique --count=True --namespace=vmx --format=json --namespace=vmx
-  data-directory: tests/data/parquet
-  marks: network unique junos vmx
-  output: '[{"namespace": "vmx", "numRows": 1}]'

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from tests.conftest import cli_commands, create_dummy_config_file, tables
 
-from suzieq.restServer.query import (app, get_configured_api_key,
+from suzieq.restServer.query import (NetworkVerbs, app, get_configured_api_key,
                                      API_KEY_NAME)
 from suzieq.sqobjects import get_sqobject
 from suzieq.restServer import query
@@ -407,6 +407,9 @@ def test_rest_arg_consistency(service, verb):
     '''check that the arguments used in REST match whats in sqobjects'''
 
     alias_args = {'path': {'source': 'src'}}
+
+    if service == 'network' and verb not in [e.value for e in NetworkVerbs]:
+        return
 
     if verb == "describe" and not service == "tables":
         return

--- a/tests/integration/test_schema_read.py
+++ b/tests/integration/test_schema_read.py
@@ -39,6 +39,8 @@ def test_schema_data_consistency(table, datadir, columns, get_table_data_cols):
                     return
         elif table == "inventory" and 'vmx' not in datadir:
             return
+        elif table == 'network':
+            return
 
     assert not df.empty
 

--- a/tests/integration/test_sqcmds.py
+++ b/tests/integration/test_sqcmds.py
@@ -271,8 +271,8 @@ def test_table_describe(setup_nubia, table):
                            for x in tables
                            if x not in ['path', 'topmem', 'topcpu',
                                         'topmem', 'time', 'ifCounters',
-                                        'ospfIf', 'ospfNbr',
-                                        'network', 'inventory']
+                                        'ospfIf', 'ospfNbr', 'network',
+                                        'namespace', 'inventory']
                            ])
 @ pytest.mark.parametrize('datadir', DATADIR)
 def test_sqcmds_regex_hostname(table, datadir):
@@ -308,7 +308,7 @@ def test_sqcmds_regex_hostname(table, datadir):
                               x,
                               marks=getattr(pytest.mark, x))
                            for x in tables
-                           if x not in ['path', 'inventory']
+                           if x not in ['path', 'inventory', 'network']
                            ])
 @ pytest.mark.parametrize('datadir', ['tests/data/parquet/'])
 def test_sqcmds_regex_namespace(table, datadir):
@@ -329,8 +329,8 @@ def test_sqcmds_regex_namespace(table, datadir):
     else:
         assert set(df.namespace.unique()) == set(['ospf-ibgp', 'ospf-single'])
 
-    if table in ['network']:
-        # network show has no hostname
+    if table in ['namespace']:
+        # namespace show has no hostname
         return
 
     if table not in ['mlag']:

--- a/tests/unit/test_cli_command.py
+++ b/tests/unit/test_cli_command.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 
-from suzieq.cli.sqcmds.command import SqCommand
+from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.path import PathObj
 
 # valid dataframe extracted from test data
@@ -68,7 +68,7 @@ df = pd.DataFrame({
 def test_cli_outputs_with_error(output_format, setup_nubia):
     '''Test output generation with errors'''
 
-    sqcmd = SqCommand(format=output_format, sqobj=PathObj)
+    sqcmd = SqTableCommand(format=output_format, sqobj=PathObj)
     # pylint: disable=protected-access
     assert sqcmd._gen_output(df) == 1
 
@@ -80,6 +80,6 @@ def test_cli_outputs_with_error(output_format, setup_nubia):
 def test_cli_outputs_without_error(output_format, setup_nubia):
     '''Test output generation without errors'''
 
-    sqcmd = SqCommand(format=output_format, sqobj=PathObj)
+    sqcmd = SqTableCommand(format=output_format, sqobj=PathObj)
     # pylint: disable=protected-access
     assert sqcmd._gen_output(df.drop(columns=['error'])) == 0


### PR DESCRIPTION
## Description

This PR contains moves the content of all the commands of `network`, apart from `network find`, into another command called `namespace`.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## New Behavior

To get the content of the `network show/summarize/top/etc.` now it's necessary to type `namespace show/summarize/etc.`
The `network find` command has not been moved.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
