### PR TITLE
Fix node discovery after first attempt

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -619,7 +619,10 @@ class Node:
                 self.logger.info(
                     f"Connected to {self.address}:{self.port} at "
                     f"{time.time()}")
-                if init_dev_data:
+
+                # Check if we already have the devtype, as otherwise we are
+                # not able get device data
+                if init_dev_data and self.devtype:
                     await self._fetch_init_dev_data()
             except Exception as e:  # pylint: disable=broad-except
                 if isinstance(e, asyncssh.HostKeyNotVerifiable):


### PR DESCRIPTION
## Description

When the poller is not able to do the discovery of a node (i.e. it is not able to connect to it), it will reschedule a new discovery attempt. However once the poller retries the discovery, it is not able to connect to the node even when it is reachable again. Additionally, after the first scheduled attempt, for each command issued on the node a new discovery attempt is performed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

The poller is able to connect to the node at the following discovery attempt if the node is reachable again or, otherwise, a new attempt is scheduled according to a backoff time.