### PR TITLE
Restore network commands for backward compatibility

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     fast
     slow
     smoke
+    deprecated
 
     # update data
     cleanup

--- a/suzieq/cli/sqcmds/NetworkCmd.py
+++ b/suzieq/cli/sqcmds/NetworkCmd.py
@@ -1,3 +1,4 @@
+import ast
 import time
 from nubia import command
 from suzieq.cli.nubia_patch import argument
@@ -61,9 +62,127 @@ class NetworkCmd(SqCommand):
 
         return self._gen_output(df)
 
+    @command("show", help="Deprecated. Use 'namespace show' instead")
+    @argument("model", description="Device model(s), space separated")
+    @argument("os", description='Device NOS(es), space separated')
+    @argument('vendor', description='Device vendor(s), space separated')
+    @argument('version', description='Device NOS version(s), space separated')
+    def show(self, os: str = "", vendor: str = "", model: str = "",
+             version: str = "") -> int:
+        """Deprecated. Use 'namespace show' instead
+        """
+        # backward compatibility
+        self._print_depracation_command_warning('namespace', 'show')
+        now = time.time()
+
+        df = self._invoke_sqobj(self.sqobj.get,
+                                namespace=self.namespace, os=os.split(),
+                                vendor=vendor.split(), model=model.split(),
+                                version=version, query_str=self.query_str,
+                                hostname=self.hostname, ignore_warning=True)
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+
+        return self._gen_output(df)
+
+    @command("summarize", help="Deprecated. Use 'namespace summarize' instead")
+    def summarize(self, **kwargs):
+        """Deprecated. Use 'namespace summarize' instead"""
+        # backward compatibility
+        self._print_depracation_command_warning('namespace', 'summarize')
+        now = time.time()
+
+        summarize_df = self._invoke_sqobj(
+            self.sqobj.summarize, namespace=self.namespace,
+            hostname=self.hostname, query_str=self.query_str,
+            ignore_warning=True,
+            **self.lvars,
+            **kwargs
+        )
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        return self._gen_output(summarize_df, json_orient='columns')
+
+    @command("unique", help="Deprecated. Use 'namespace unique' instead")
+    @argument("count", description="include count of times a value is seen",
+              choices=['True'])
+    def unique(self, count='', **kwargs):
+        """Deprecated. Use 'namespace unique' instead"""
+        # backward compatibility
+        self._print_depracation_command_warning('namespace', 'unique')
+        now = time.time()
+
+        df = self._invoke_sqobj(self.sqobj.unique,
+                                hostname=self.hostname,
+                                namespace=self.namespace,
+                                query_str=self.query_str,
+                                count=count,
+                                ignore_warning=True,
+                                **self.lvars,
+                                **kwargs,
+                                )
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        if 'error' in df.columns:
+            return self._gen_output(df)
+
+        if df.empty:
+            return df
+
+        if not count:
+            return self._gen_output(df.sort_values(by=[df.columns[0]]),
+                                    dont_strip_cols=True)
+        else:
+            return self._gen_output(
+                df.sort_values(by=['numRows', df.columns[0]]),
+                dont_strip_cols=True)
+
+    @ command("top", help="Deprecated. Use 'namespace top' instead")
+    @ argument("count", description="number of rows to return")
+    @ argument("what", description="numeric field to get top values for")
+    @ argument("reverse", description="return bottom n values",
+               choices=['True', 'False'])
+    def top(self, count: int = 5, what: str = '', reverse: str = 'False',
+            **kwargs) -> int:
+        """Deprecated. Use 'namespace top' instead
+
+        Args:
+            count (int, optional): Number of entries to return. Defaults to 5
+            what (str, optional): Field name to use for largest/smallest val
+            reverse (bool, optional): Reverse and return n smallest
+
+        Returns:
+            int: 0 or error code
+        """
+        # backward compatibility
+        self._print_depracation_command_warning('namespace', 'top')
+        now = time.time()
+
+        df = self._invoke_sqobj(self.sqobj.top,
+                                hostname=self.hostname,
+                                namespace=self.namespace,
+                                query_str=self.query_str,
+                                what=what, count=count,
+                                reverse=ast.literal_eval(reverse),
+                                ignore_warning=True,
+                                **self.lvars,
+                                **kwargs,
+                                )
+
+        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
+        if 'error' in df.columns:
+            return self._gen_output(df)
+
+        if not df.empty:
+            df = self.sqobj.humanize_fields(df)
+            return self._gen_output(df.sort_values(
+                by=[what], ascending=(reverse == "True")),
+                dont_strip_cols=True, sort=False)
+        else:
+            return self._gen_output(df)
+
     @ command("help", help="show help for a command")
     @ argument("command", description="command to show help for",
-               choices=['find'])
+               choices=['find', 'show', 'summarize', 'top', 'unique'])
     # pylint: disable=redefined-outer-name
     def help(self, command: str = ''):
         return super().help(command)

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -14,10 +14,12 @@ from prompt_toolkit import prompt
 from natsort import natsort_keygen
 from colorama import Fore, Style
 
+from termcolor import cprint, colored
 from suzieq.cli.nubia_patch import argument
 from suzieq.shared.sq_plugin import SqPlugin
 from suzieq.shared.exceptions import UserQueryError
-from suzieq.shared.utils import DATA_FORMATS, SUPPORTED_ENGINES
+from suzieq.shared.utils import (DATA_FORMATS, SUPPORTED_ENGINES,
+                                 deprecated_command_warning)
 
 
 def colorize(x, color):
@@ -399,6 +401,26 @@ class SqCommand(SqPlugin):
 
         self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
         return self._gen_output(df)
+
+    def _print_depracation_command_warning(self,
+                                           new_command: str,
+                                           sub_command: str,
+                                           dep_sub_command: str = None):
+        """Print depracation command warning
+
+        Args:
+            new_command (str): command
+            command (str): _description_
+            dep_command (str, optional): _description_. Defaults to None.
+        """
+        if not dep_sub_command:
+            dep_sub_command = sub_command
+        dep_command = self.sqobj.table
+        warning_msg = deprecated_command_warning(dep_command,
+                                                 dep_sub_command,
+                                                 new_command,
+                                                 sub_command)
+        cprint(colored(warning_msg, 'yellow'))
 
 
 class SqTableCommand(SqCommand):

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -537,6 +537,99 @@ async def query_mlag(verb: CommonVerbs, request: Request,
     return read_shared(function_name, verb, request, locals())
 
 
+@app.get("/api/v2/network/show", deprecated=True)
+async def query_network_depr_show(request: Request,
+                                  token: str = Depends(get_api_key),
+                                  format: str = None,
+                                  columns: List[str] = Query(
+                                      default=["default"]),
+                                  namespace: List[str] = Query(None),
+                                  hostname: List[str] = Query(None),
+                                  start_time: str = "", end_time: str = "",
+                                  version: str = "",
+                                  view: ViewValues = "latest",
+                                  model: List[str] = Query(None),
+                                  vendor: List[str] = Query(None),
+                                  os: List[str] = Query(None),
+                                  query_str: str = None, what: str = None,
+                                  count: str = None, reverse: str = None,
+                                  ):
+    function_name = 'query_namespace'
+    verb = 'show'
+    return read_shared(function_name, verb, request, locals())
+
+
+@app.get("/api/v2/network/summarize", deprecated=True)
+async def query_network_depr_summarize(request: Request,
+                                       token: str = Depends(get_api_key),
+                                       format: str = None,
+                                       columns: List[str] = Query(
+                                           default=["default"]),
+                                       namespace: List[str] = Query(None),
+                                       hostname: List[str] = Query(None),
+                                       start_time: str = "",
+                                       end_time: str = "",
+                                       version: str = "",
+                                       view: ViewValues = "latest",
+                                       model: List[str] = Query(None),
+                                       vendor: List[str] = Query(None),
+                                       os: List[str] = Query(None),
+                                       query_str: str = None,
+                                       what: str = None,
+                                       count: str = None,
+                                       reverse: str = None,
+                                       ):
+    function_name = 'query_namespace'
+    verb = 'summarize'
+    return read_shared(function_name, verb, request, locals())
+
+
+@app.get("/api/v2/network/unique", deprecated=True)
+async def query_network_depr_unique(request: Request,
+                                    token: str = Depends(get_api_key),
+                                    format: str = None,
+                                    columns: List[str] = Query(
+                                        default=["default"]),
+                                    namespace: List[str] = Query(None),
+                                    hostname: List[str] = Query(None),
+                                    start_time: str = "",
+                                    end_time: str = "",
+                                    version: str = "",
+                                    view: ViewValues = "latest",
+                                    model: List[str] = Query(None),
+                                    vendor: List[str] = Query(None),
+                                    os: List[str] = Query(None),
+                                    query_str: str = None,
+                                    what: str = None,
+                                    count: str = None, reverse: str = None,
+                                    ):
+    function_name = 'query_namespace'
+    verb = 'unique'
+    return read_shared(function_name, verb, request, locals())
+
+
+@app.get("/api/v2/network/top", deprecated=True)
+async def query_network_depr_top(request: Request,
+                                 token: str = Depends(get_api_key),
+                                 format: str = None,
+                                 columns: List[str] = Query(
+                                     default=["default"]),
+                                 namespace: List[str] = Query(None),
+                                 hostname: List[str] = Query(None),
+                                 start_time: str = "", end_time: str = "",
+                                 version: str = "",
+                                 view: ViewValues = "latest",
+                                 model: List[str] = Query(None),
+                                 vendor: List[str] = Query(None),
+                                 os: List[str] = Query(None),
+                                 query_str: str = None, what: str = None,
+                                 count: str = None, reverse: str = None,
+                                 ):
+    function_name = 'query_namespace'
+    verb = 'top'
+    return read_shared(function_name, verb, request, locals())
+
+
 @app.get("/api/v2/network/{verb}")
 async def query_network(verb: NetworkVerbs, request: Request,
                         token: str = Depends(get_api_key),

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -921,7 +921,7 @@ def print_version():
     print(SUZIEQ_VERSION)
 
 
-def depracated_table_function_warning(dep_table: str, dep_command: str,
+def deprecated_table_function_warning(dep_table: str, dep_command: str,
                                       table: str = None,
                                       command: str = None) -> str:
     """Return the string of the warning for a deprecated function
@@ -960,5 +960,5 @@ def deprecated_command_warning(dep_command: str, dep_sub_command: str,
         str: deprecated command warning message
     """
 
-    return depracated_table_function_warning(dep_command, dep_sub_command,
+    return deprecated_table_function_warning(dep_command, dep_sub_command,
                                              command, sub_command)

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -941,3 +941,24 @@ def depracated_table_function_warning(dep_table: str, dep_command: str,
     if dep_table and dep_command:
         warning_str += f" Use '{table} {command}' instead."
     return warning_str
+
+
+def deprecated_command_warning(dep_command: str, dep_sub_command: str,
+                               command: str = None,
+                               sub_command: str = None) -> str:
+    """It's a wrapper for the deprecated_table_function_warning. It is used to
+    display a message when the user writes a deprecated command.
+
+    Args:
+        dep_command (str): deprecated command
+        dep_sub_command (str): deprecated sub command
+        command (str, optional): command to use instead. Defaults to None.
+        sub_command (str, optional): subcommand to use instead.
+        Defaults to None.
+
+    Returns:
+        str: deprecated command warning message
+    """
+
+    return depracated_table_function_warning(dep_command, dep_sub_command,
+                                             command, sub_command)

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -919,3 +919,25 @@ def convert_asndot_to_asn(asn: str) -> int:
 def print_version():
     '''Print the suzieq version and return'''
     print(SUZIEQ_VERSION)
+
+
+def depracated_table_function_warning(dep_table: str, dep_command: str,
+                                      table: str = None,
+                                      command: str = None) -> str:
+    """Return the string of the warning for a deprecated function
+
+    If both table and command aren't provided, the warning will only
+    return that the function is deprecated.
+    If instead we provide them, the warning will also contain the new command
+    to call
+
+    Args:
+        table (str): correct table to run the command
+        command (str): correct command to call
+        dep_table (str): deprecated table command
+        dep_command (str): deprecated command
+    """
+    warning_str = f"WARNING: '{dep_table} {dep_command}' is deprecated."
+    if dep_table and dep_command:
+        warning_str += f" Use '{table} {command}' instead."
+    return warning_str

--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -1,8 +1,9 @@
-import typing
+from typing import List
 import pandas as pd
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
-from suzieq.shared.utils import load_sq_config, humanize_timestamp
+from suzieq.shared.utils import (load_sq_config, humanize_timestamp,
+                                 depracated_table_function_warning)
 from suzieq.shared.schema import Schema, SchemaForTable
 from suzieq.engines import get_sqengine
 from suzieq.shared.sq_plugin import SqPlugin
@@ -13,10 +14,10 @@ class SqObject(SqPlugin):
     '''The base class for accessing the backend independent of the engine'''
 
     def __init__(self, engine_name: str = '',
-                 hostname: typing.List[str] = None,
+                 hostname: List[str] = None,
                  start_time: str = '', end_time: str = '',
-                 view: str = '', namespace: typing.List[str] = None,
-                 columns: typing.List[str] = None,
+                 view: str = '', namespace: List[str] = None,
+                 columns: List[str] = None,
                  context=None, table: str = '', config_file=None) -> None:
 
         if not context:
@@ -106,7 +107,7 @@ class SqObject(SqPlugin):
             return
 
         # add standard args that are always
-        good_arg_list = good_arg_list + (['namespace'])
+        good_arg_list = good_arg_list + (['namespace', 'ignore_warning'])
 
         for arg in kwargs:
             if arg not in good_arg_list:
@@ -146,7 +147,7 @@ class SqObject(SqPlugin):
         '''Validate the values of the summarize function'''
         self._check_input_for_valid_args(self._valid_get_args, **kwargs)
 
-    def validate_columns(self, columns: typing.List[str]) -> bool:
+    def validate_columns(self, columns: List[str]) -> bool:
         """Validate that the provided columns are valid for the table
 
         Args:
@@ -169,6 +170,7 @@ class SqObject(SqPlugin):
 
     def get(self, **kwargs) -> pd.DataFrame:
         '''Return the data for this table given a set of attributes'''
+        kwargs.pop('ignore_warning', None)
         if not self._table:
             raise NotImplementedError
 
@@ -207,6 +209,7 @@ class SqObject(SqPlugin):
 
     def summarize(self, **kwargs) -> pd.DataFrame:
         '''Summarize the data from specific table'''
+        kwargs.pop('ignore_warning', None)
         if self.columns != ["default"]:
             self.summarize_df = pd.DataFrame(
                 {'error':
@@ -225,6 +228,7 @@ class SqObject(SqPlugin):
 
     def unique(self, **kwargs) -> pd.DataFrame:
         '''Identify unique values and value counts for a column in table'''
+        kwargs.pop('ignore_warning', None)
         if not self._table:
             raise NotImplementedError
 
@@ -247,6 +251,7 @@ class SqObject(SqPlugin):
 
     def aver(self, **kwargs):
         '''Assert one or more checks on table'''
+        kwargs.pop('ignore_warning', None)
         if self._valid_assert_args:
             return self._assert_if_supported(**kwargs)
 
@@ -255,7 +260,7 @@ class SqObject(SqPlugin):
     def top(self, what: str = '', count: int = 5, reverse: bool = False,
             **kwargs) -> pd.DataFrame:
         """Get the list of top/bottom entries of "what" field"""
-
+        kwargs.pop('ignore_warning', None)
         columns = kwargs.get('columns', ['default'])
         # This raises ValueError if it fails
         self.validate_columns(columns)
@@ -291,7 +296,7 @@ class SqObject(SqPlugin):
 
     def describe(self, **kwargs):
         """Describes the fields for a given table"""
-
+        kwargs.pop('ignore_warning', None)
         table = kwargs.get('table', self.table)
 
         if table in ['interface', 'route', 'mac', 'table']:
@@ -406,3 +411,51 @@ class SqObject(SqPlugin):
             df = df[req_cols]
 
         return df
+
+    def _run_deprecated_function(self, table: str, command: str,
+                                 dep_command: str = None,
+                                 ignore_warning: str = False,
+                                 **kwargs):
+        """ This function is in charge of running a deprecated function.
+        First, it initializes a new sqobject using the same parameters used to
+        initialize the sqobject calling this function. Then it checks if the
+        command exists and run it setting the kwargs as arguments.
+
+        Args:
+            table (str): table to run the command
+            command (str): command to run
+            dep_command (str, optional): deprecated command.
+            ignore_warning (str, optional): do not print the warning message.
+
+        Raises:
+            RuntimeError: unknown table or command
+        """
+        try:
+            init_args = {
+                'hostname': self.hostname,
+                'start_time': self.start_time,
+                'end_time': self.end_time,
+                'view': self.view,
+                'namespace': self.namespace,
+                'columns': self.columns,
+                'context': self.ctxt
+            }
+            if not dep_command:
+                dep_command = command
+            dep_table = self.table
+
+            sqobjs = SqObject.get_plugins()
+            if table not in sqobjs:
+                raise RuntimeError(f'unknown table {table}')
+            sqobj = sqobjs[table](**init_args)
+            func = getattr(sqobj, command, None)
+            if func is None or not callable(func):
+                raise RuntimeError(f'unsupported function {command} '
+                                   f'for {table}')
+            if not ignore_warning:
+                print(depracated_table_function_warning(
+                    dep_table, dep_command, table, command
+                ))
+            return func(**kwargs)
+        except RuntimeError as e:
+            return pd.DataFrame({'error': [str(e)]})

--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -3,7 +3,7 @@ import pandas as pd
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 from suzieq.shared.utils import (load_sq_config, humanize_timestamp,
-                                 depracated_table_function_warning)
+                                 deprecated_table_function_warning)
 from suzieq.shared.schema import Schema, SchemaForTable
 from suzieq.engines import get_sqengine
 from suzieq.shared.sq_plugin import SqPlugin
@@ -453,7 +453,7 @@ class SqObject(SqPlugin):
                 raise RuntimeError(f'unsupported function {command} '
                                    f'for {table}')
             if not ignore_warning:
-                print(depracated_table_function_warning(
+                print(deprecated_table_function_warning(
                     dep_table, dep_command, table, command
                 ))
             return func(**kwargs)

--- a/suzieq/sqobjects/network.py
+++ b/suzieq/sqobjects/network.py
@@ -44,6 +44,24 @@ class NetworkObj(SqObject):
 
         return self.engine.find(**kwargs)
 
+    def get(self, **kwargs) -> pd.DataFrame:
+        return self._run_deprecated_function(table='namespace', command='get',
+                                             **kwargs)
+
+    def summarize(self, **kwargs) -> pd.DataFrame:
+        return self._run_deprecated_function(table='namespace',
+                                             command='summarize', **kwargs)
+
+    def top(self, what: str = '', count: int = 5, reverse: bool = False,
+            **kwargs) -> pd.DataFrame:
+        return self._run_deprecated_function(table='namespace', command='top',
+                                             what=what, count=count,
+                                             reverse=reverse, **kwargs)
+
+    def unique(self, **kwargs) -> pd.DataFrame:
+        return self._run_deprecated_function(table='namespace',
+                                             command='unique', **kwargs)
+
     def humanize_fields(self, df: pd.DataFrame, _=None) -> pd.DataFrame:
         '''Humanize the timestamp fields'''
         if df.empty:

--- a/suzieq/sqobjects/routes.py
+++ b/suzieq/sqobjects/routes.py
@@ -37,6 +37,7 @@ class RoutesObj(SqObject):
 
     def lpm(self, **kwargs) -> pd.DataFrame:
         '''Get the lpm for the given address'''
+        kwargs.pop('ignore_warning', None)
         if not kwargs.get("address", None):
             raise AttributeError('ip address is mandatory parameter')
         if isinstance(kwargs['address'], list):

--- a/tests/integration/sqcmds/common-samples/deprecated.yml
+++ b/tests/integration/sqcmds/common-samples/deprecated.yml
@@ -1,0 +1,108 @@
+description: Testing commands keep only for backward compatibility
+tests:
+- command: network help --command=show
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network help command deprecated
+  output: "network show: \e[36mDeprecated. Use 'namespace show' instead\e[0m\n\e[33m\n\
+    Use quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n\
+    \ - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - end_time:\
+    \ \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e\
+    [36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s),\
+    \ space separated\e[0m\n - model: \e[36m\e[1mDevice model(s), space separated\e\
+    [0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - os: \e[36m\e\
+    [1mDevice NOS(es), space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank\
+    \ terminated pandas query format to further filter the output\e[0m\n - start_time:\
+    \ \e[36m\e[1mStart of time window, try natural language spec\e[0m\n - vendor:\
+    \ \e[36m\e[1mDevice vendor(s), space separated\e[0m\n - version: \e[36m\e[1mDevice\
+    \ NOS version(s), space separated\e[0m\n - view: \e[36m\e[1mView all records or\
+    \ just the latest\e[0m\n"
+- command: network help --command=summarize
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network help command deprecated
+  output: "network summarize: \e[36mDeprecated. Use 'namespace summarize' instead\e\
+    [0m\n\e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
+    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
+    \ - end_time: \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n\
+    \ - format: \e[36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e\
+    [36m\e[1mHostname(s), space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s),\
+    \ space separated\e[0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas\
+    \ query format to further filter the output\e[0m\n - start_time: \e[36m\e[1mStart\
+    \ of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView all\
+    \ records or just the latest\e[0m\n"
+- command: network help --command=unique
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network help command deprecated
+  output: "network unique: \e[36mDeprecated. Use 'namespace unique' instead\e[0m\n\
+    \e[33m\nUse quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e\
+    [0m\n - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n\
+    \ - count: \e[36m\e[1minclude count of times a value is seen\e[0m\n - end_time:\
+    \ \e[36m\e[1mEnd of time window, try natural language spec \e[0m\n - format: \e\
+    [36m\e[1mSelect the pformat of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s),\
+    \ space separated\e[0m\n - namespace: \e[36m\e[1mNamespace(s), space separated\e\
+    [0m\n - query_str: \e[36m\e[1mTrailing blank terminated pandas query format to\
+    \ further filter the output\e[0m\n - start_time: \e[36m\e[1mStart of time window,\
+    \ try natural language spec\e[0m\n - view: \e[36m\e[1mView all records or just\
+    \ the latest\e[0m\n"
+- command: network help --command=top
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network help command deprecated
+  output: "network top: \e[36mDeprecated. Use 'namespace top' instead\e[0m\n\e[33m\n\
+    Use quotes when providing more than one value\e[0m\n\e[33m\nArguments:\e[0m\n\
+    \ - columns: \e[36m\e[1mSpace separated list of columns, * for all\e[0m\n - count:\
+    \ \e[36m\e[1mnumber of rows to return\e[0m\n - end_time: \e[36m\e[1mEnd of time\
+    \ window, try natural language spec \e[0m\n - format: \e[36m\e[1mSelect the pformat\
+    \ of the output\e[0m\n - hostname: \e[36m\e[1mHostname(s), space separated\e[0m\n\
+    \ - namespace: \e[36m\e[1mNamespace(s), space separated\e[0m\n - query_str: \e\
+    [36m\e[1mTrailing blank terminated pandas query format to further filter the output\e\
+    [0m\n - reverse: \e[36m\e[1mreturn bottom n values\e[0m\n - start_time: \e[36m\e\
+    [1mStart of time window, try natural language spec\e[0m\n - view: \e[36m\e[1mView\
+    \ all records or just the latest\e[0m\n - what: \e[36m\e[1mnumeric field to get\
+    \ top values for\e[0m\n"
+- command: network show
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network show deprecated
+  output: "WARNING: 'network show' is deprecated. Use 'namespace show' instead.\n\
+    \     namespace  deviceCnt  ...  hasMlag                       lastUpdate\n0 \
+    \    dual-bgp         14  ...     True 2021-12-10 18:37:11.921000+00:00\n1   \
+    \ dual-evpn         14  ...     True 2021-12-10 18:34:58.729000+00:00\n2     \
+    \     eos         14  ...     True 2021-12-10 18:33:51.163000+00:00\n3       \
+    \ junos         12  ...    False 2022-02-05 14:03:21.736000+00:00\n4        mixed\
+    \          8  ...    False 2021-12-10 18:33:53.280000+00:00\n5         nxos  \
+    \       14  ...     True 2021-12-10 18:33:51.216000+00:00\n6    ospf-ibgp    \
+    \     14  ...     True 2022-01-10 16:01:05.167000+00:00\n7  ospf-single      \
+    \   14  ...    False 2021-12-10 18:36:06.022000+00:00\n8        panos        \
+    \ 14  ...     True 2021-12-14 16:21:20.095000+00:00\n9          vmx          5\
+    \  ...    False 2021-12-10 18:33:50.623000+00:00\n\n[10 rows x 9 columns]\n"
+- command: network summarize
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network summarize deprecated
+  output: "WARNING: 'network summarize' is deprecated. Use 'namespace summarize' instead.\n\
+    \                         summary\nnamespacesCnt                 10\nservicePerNsStat\
+    \  [13, 18, 17.5]\nnsWithMlagCnt                  6\nnsWithBgpCnt            \
+    \       8\nnsWithOspfCnt                  7\nnsWithVxlanCnt                 6\n\
+    nsWithErrsvcCnt                0\n"
+- command: network top --what=deviceCnt
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network top deprecated
+  output: "WARNING: 'network top' is deprecated. Use 'namespace top' instead.\n  \
+    \   namespace  deviceCnt  ...  hasMlag                       lastUpdate\n0   \
+    \     panos         14  ...     True 2021-12-14 16:21:20.095000+00:00\n1  ospf-single\
+    \         14  ...    False 2021-12-10 18:36:06.022000+00:00\n2    ospf-ibgp  \
+    \       14  ...     True 2022-01-10 16:01:05.167000+00:00\n3         nxos    \
+    \     14  ...     True 2021-12-10 18:33:51.216000+00:00\n4          eos      \
+    \   14  ...     True 2021-12-10 18:33:51.163000+00:00\n\n[5 rows x 9 columns]\n"
+- command: network unique
+  data-directory: tests/data/parquet/
+  format: text
+  marks: network unique deprecated
+  output: "WARNING: 'network unique' is deprecated. Use 'namespace unique' instead.\n\
+    \     namespace\n0     dual-bgp\n1    dual-evpn\n2          eos\n3        junos\n\
+    4        mixed\n5         nxos\n6    ospf-ibgp\n7  ospf-single\n8        panos\n\
+    9          vmx\n"

--- a/tests/integration/sqcmds/common-samples/help.yml
+++ b/tests/integration/sqcmds/common-samples/help.yml
@@ -969,7 +969,10 @@ tests:
   output: "network: \e[36mAdvanced commands across all the network\e[0m\n\nSupported\
     \ verbs are: \n - describe: \e[36mDisplay the schema of the table\e[0m\n - find:\
     \ \e[36mFind the network attach point of a given IP or MAC address.\e[0m\n - help:\
-    \ \e[36mShow help for a command\e[0m\n"
+    \ \e[36mShow help for a command\e[0m\n - show: \e[36mDeprecated. Use 'namespace\
+    \ show' instead\e[0m\n - summarize: \e[36mDeprecated. Use 'namespace summarize'\
+    \ instead\e[0m\n - top: \e[36mDeprecated. Use 'namespace top' instead\e[0m\n -\
+    \ unique: \e[36mDeprecated. Use 'namespace unique' instead\e[0m\n"
 - command: network help --command=find
   data-directory: tests/data/eos/parquet-out/
   format: text


### PR DESCRIPTION
## Description

This PR restore `network show/summarize/unique/top` commands. They calls underneath the related `namespace show/summarize/unique/top` commands. 
A warning is showed inside the CLI suggesting the new command to use.
![image](https://user-images.githubusercontent.com/66721906/167869057-88df536b-34f4-4848-9a93-bc7fd8b297d4.png)

The REST server routes for the network commands are now marked as deprecated.

Also the sqobjects by default print on stdout a similar warning is displayed on the CLI. It can be ignored passing `ignore_warning=True` as function argument.
 ```python
network_summ_result = get_sqobject('network')(..).summarize(..., ignore_warning=True)
```

## Type of change
- New feature (non-breaking change which adds functionality)

## New Behavior

Now it is possible to call again `network show/summarize/top/unique` commands with the only difference of a warning showed on the CLI explaining that the command is deprecated. The result is the same.

## Contrast to Current Behavior

`network show/summarize/top/unique` commands were removed.

## Discussion: Benefits and Drawbacks

For backward compatibility, we will keep both commands. In the future probably these network commands will be removed.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
