### PR TITLE
remove tests on python3.7

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
         group: [1, 2, 3, 4]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

SuzieQ is going to drop support for Python 3.7. This PR remove python 3.7 tests from github actions.

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Tests on python 3.7 are no longer executed

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Both tests on python 3.8 and 3.7 were executed.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
