### PR TITLE
Upgrade to python 3.9

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
         group: [1, 2, 3, 4]
     steps:
     - uses: actions/checkout@v2

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,7 +25,7 @@ See section [Poller](./poller.md) and [Inventory file](./inventory.md) for furth
 
 ### As a Python Package
 
-Suzieq is also available as a standard Python package that you can install via pip. We strongly recommend the use of [Python virtual environment](https://docs.python.org/3.8/tutorial/venv.html). **Suzieq only works with Python versions 3.7.1 and above, and on Linux and MacOS**. The releases are always tested with Python versions 3.7 and 3.8.
+Suzieq is also available as a standard Python package that you can install via pip. We strongly recommend the use of [Python virtual environment](https://docs.python.org/3.8/tutorial/venv.html). **Suzieq only works with Python versions 3.8.1 and above, and on Linux and MacOS**. The releases are always tested with Python versions 3.8 and 3.9.
 
 To install suzieq via pip run:
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -2385,8 +2385,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">3.8.1, < 3.9"
-content-hash = "3156868505c90af93fb2da451d27ebae36f0ff4679cace280eab6531867079cb"
+python-versions = ">3.8.1, < 3.10"
+content-hash = "8929b1c773bf451a8bfeda108b27f2860b5fc23d227d4659ffabe7b82dce75ea"
 
 [metadata.files]
 aiofiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">3.8.1, < 3.9"
+python = ">3.8.1, < 3.10"
 aiohttp = "==3.7.4"
 asyncssh = "^2.9"
 textfsm = "*"


### PR DESCRIPTION
## Description

This PR adds python 3.9 as a supported version for SuzieQ.

## Type of change

- New feature (non-breaking change which adds functionality)

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Now it's possible to run SuzieQ on python 3.9

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

It was not possible

## Comment

The only failing test also fails in develop branch. When fixed there, it is fixed here automatically

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
