### PR TITLE
Support ports in jumphost format (Fix #737)

### DIFF
--- a/suzieq/poller/controller/utils/inventory_models.py
+++ b/suzieq/poller/controller/utils/inventory_models.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-name-in-module
 
-import re
 from typing import Dict, List, Optional
+from urllib3.util import parse_url
 from pydantic import BaseModel, Field, validator
 
 from suzieq.shared.utils import PollerTransport
@@ -36,11 +36,13 @@ class DeviceModel(BaseModel):
 
     @validator('jump_host')
     def jump_host_validator(cls, value):
-        jump_host = value[2:] if value.startswith('//') else value
-        pattern = '([a-zA-Z0-9-.]{1,253})@([a-zA-Z0-9-.]{1,253})'
-        assert re.fullmatch(pattern, jump_host), \
-               'format username@jumphost required'
-        return value
+        '''Validate jump host format'''
+        try:
+            uri = parse_url(value)
+            assert uri.scheme is None, \
+                'format username@jumphost[:port] required'
+        except ValueError:
+            assert False, f'Invalid jumphost format: {value}'
 
     class Config:
         """pydantic configuration


### PR DESCRIPTION
Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>

# Set `develop` as target branch of this PR (delete this line before issuing the PR)

## Test inclusion requirements

In case the PR contains an enhancement or a new platform/service support, some tests have to be added for the new functionality:

- any fix or enhancement SHOULD include relevant new tests or test updates, if any tests need updating.
- a new platform support MUST include the relevant input files similar to what we have in tests/integration/sqcmds/-input directories, along with the relevant tests in the tests/integration/sqcmds/-samples dir. That list MUST include the all.yml file fully filled out.
- any new service (or table) addition MUST include comments about what network OS are supported (along with version) with this command along with test samples for those platforms and input files in the *-input dir

For additional information about tests, follow this [link](https://suzieq.readthedocs.io/en/latest/developer/testing/)

## Related Issue

<!--Add the related issue in the form of #issue-number (Example #100)-->
Fixes #737 

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

Accepts port in jumphost specification (URI format with no scheme). 

...

## Contrast to Current Behavior

Adding port to the jumphost specification results in invalid format error.

...

## Discussion: Benefits and Drawbacks

...

## Changes to the Documentation

Adding docs after sending it to review.

...

## Proposed Release Note Entry

jumphost specification now supports port specification as well. Thus the supported URI format is: [<username>@<hostname or ip>[:<port>]

...
## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
