### PR TITLE
More parser fixes

### DIFF
--- a/suzieq/config/device.yml
+++ b/suzieq/config/device.yml
@@ -25,18 +25,29 @@ apply:
 
   cumulus:
     version: all
-    command: net show system json
-    normalize: '[
-    "os-version: version",
-    "vendor: vendor?|Cumulus",
-    "uptime: _uptime",
-    "os: os?|cumulus",
-    "memory: memory?|0",
-    "platform/info/model_name: _modelName",
-    "platform/model: model",
-    "eeprom/Serial Number/value: serialNumber",
-    "platform/info/cpu/summary: architecture?|x86_64",
-    ]'
+    merge: False
+    command:
+      - command: net show system json
+        normalize: '[
+        "os-version: version",
+        "vendor: vendor?|Cumulus",
+        "uptime: _uptime",
+        "os: os?|cumulus",
+        "memory: memory?|0",
+        "platform/info/model_name: _modelName?|",
+        "platform/model: model?|",
+        "eeprom/Serial Number/value: serialNumber?|",
+        "platform/info/cpu/summary: architecture?|x86_64",
+        "_entryType: _entryType?|json"
+        ]'
+
+      - command: decode-syseeprom; cat /etc/os-release; cat /proc/meminfo
+        textfsm: textfsm_templates/cls_model_rel.tfsm
+        _entryType: model
+
+      - command: cat /proc/uptime; hostname
+        textfsm: textfsm_templates/cls_uptime_hostname.tfsm
+        _entryType: uptime
 
   iosxe:
     version: all

--- a/suzieq/config/ospfIf.yml
+++ b/suzieq/config/ospfIf.yml
@@ -51,9 +51,14 @@ apply:
 
   iosxe:
     version: all
-    command: show ip ospf interface
-    textfsm: textfsm_templates/iosxe_show_ip_ospfif.tfsm
-      
+    merge: False
+    command:
+      - command: show ip ospf
+        textfsm: textfsm_templates/iosxe_show_ip_ospf.tfsm
+        _entryType: process
+      - command: show ip ospf interface
+        textfsm: textfsm_templates/iosxe_show_ip_ospfif.tfsm
+
   ios:
     copy: iosxe
 

--- a/suzieq/config/textfsm_templates/cls_model_rel.tfsm
+++ b/suzieq/config/textfsm_templates/cls_model_rel.tfsm
@@ -1,0 +1,249 @@
+Value memory (\d+)
+Value vendor (\S+)
+Value serialNumber (\S+)
+Value model (.*)
+Value version ([0-9.]+)
+
+Start
+  ^Vendor\s+Name\s+.*\s+\d+\s+${vendor}\s+
+  ^Product\s+Name\s+.*\s+\d+\s+${model}
+  ^Serial\s+Number\s+.*\s+\d+\s+${serialNumber}
+  ^VERSION_ID=${version}
+  ^MemTotal:\s+${memory}\s+kB
+  
+#TlvInfo Header:
+#   Id String:    TlvInfo
+#   Version:      1
+#   Total Length: 69
+#TLV Name             Code Len Value
+#-------------------- ---- --- -----
+#Vendor Name          0x2D  16 Cumulus Networks
+#Product Name         0x21   2 VX
+#Device Version       0x26   1 3
+#Part Number          0x22   5 4.4.0
+#MAC Addresses        0x2A   2 7
+#Base MAC Address     0x24   6 44:38:39:01:02:01
+#Serial Number        0x23  17 44:38:39:01:02:01
+#CRC-32               0xFE   4 0xC38EB5C2
+#(checksum valid)
+#NAME="Cumulus Linux"
+#VERSION_ID=4.4.0
+#VERSION="Cumulus Linux 4.4.0"
+#PRETTY_NAME="Cumulus Linux"
+#ID=cumulus-linux
+#ID_LIKE=debian
+#CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:4.4.0
+#HOME_URL="http://www.cumulusnetworks.com/"
+#SUPPORT_URL="http://support.cumulusnetworks.com/"
+#MemTotal:         685540 kB
+#MemFree:          109752 kB
+#MemAvailable:     226144 kB
+#Buffers:           24860 kB
+#Cached:           170544 kB
+#SwapCached:            0 kB
+#Active:           392652 kB
+#Inactive:          77196 kB
+#Active(anon):     277764 kB
+#Inactive(anon):     9188 kB
+#Active(file):     114888 kB
+#Inactive(file):    68008 kB
+#Unevictable:           0 kB
+#Mlocked:               0 kB
+#SwapTotal:             0 kB
+#SwapFree:              0 kB
+#Dirty:                 4 kB
+#Writeback:             0 kB
+#AnonPages:        274476 kB
+#Mapped:            56596 kB
+#Shmem:             12512 kB
+#Slab:              74636 kB
+#SReclaimable:      55148 kB
+#SUnreclaim:        19488 kB
+#KernelStack:        2444 kB
+#PageTables:         3056 kB
+#NFS_Unstable:          0 kB
+#Bounce:                0 kB
+#WritebackTmp:          0 kB
+#CommitLimit:      342768 kB
+#Committed_AS:     879348 kB
+#VmallocTotal:   34359738367 kB
+#VmallocUsed:           0 kB
+#VmallocChunk:          0 kB
+#Percpu:             1716 kB
+#HardwareCorrupted:     0 kB
+#AnonHugePages:         0 kB
+#ShmemHugePages:        0 kB
+#ShmemPmdMapped:        0 kB
+#HugePages_Total:       0
+#HugePages_Free:        0
+#HugePages_Rsvd:        0
+#HugePages_Surp:        0
+#Hugepagesize:       2048 kB
+#Hugetlb:               0 kB
+#DirectMap4k:       77676 kB
+#DirectMap2M:      708608 kB
+#DirectMap1G:           0 kB
+#66973.84 66142.72
+#vagrant@leaf01:mgmt:~$ 
+#vagrant@leaf01:mgmt:~$ decode-syseeprom && cat /etc/os-release && cat /proc/meminfo && cat /proc/uptime && cat /etc/hostname
+#TlvInfo Header:
+#   Id String:    TlvInfo
+#   Version:      1
+#   Total Length: 69
+#TLV Name             Code Len Value
+#-------------------- ---- --- -----
+#Vendor Name          0x2D  16 Cumulus Networks
+#Product Name         0x21   2 VX
+#Device Version       0x26   1 3
+#Part Number          0x22   5 4.4.0
+#MAC Addresses        0x2A   2 7
+#Base MAC Address     0x24   6 44:38:39:01:02:01
+#Serial Number        0x23  17 44:38:39:01:02:01
+#CRC-32               0xFE   4 0xC38EB5C2
+#(checksum valid)
+#NAME="Cumulus Linux"
+#VERSION_ID=4.4.0
+#VERSION="Cumulus Linux 4.4.0"
+#PRETTY_NAME="Cumulus Linux"
+#ID=cumulus-linux
+#ID_LIKE=debian
+#CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:4.4.0
+#HOME_URL="http://www.cumulusnetworks.com/"
+#SUPPORT_URL="http://support.cumulusnetworks.com/"
+#MemTotal:         685540 kB
+#MemFree:          110388 kB
+#MemAvailable:     226868 kB
+#Buffers:           24944 kB
+#Cached:           170548 kB
+#SwapCached:            0 kB
+#Active:           392292 kB
+#Inactive:          77208 kB
+#Active(anon):     277324 kB
+#Inactive(anon):     9192 kB
+#Active(file):     114968 kB
+#Inactive(file):    68016 kB
+#Unevictable:           0 kB
+#Mlocked:               0 kB
+#SwapTotal:             0 kB
+#SwapFree:              0 kB
+#Dirty:                 0 kB
+#Writeback:             0 kB
+#AnonPages:        274000 kB
+#Mapped:            56612 kB
+#Shmem:             12512 kB
+#Slab:              74528 kB
+#SReclaimable:      55152 kB
+#SUnreclaim:        19376 kB
+#KernelStack:        2412 kB
+#PageTables:         2964 kB
+#NFS_Unstable:          0 kB
+#Bounce:                0 kB
+#WritebackTmp:          0 kB
+#CommitLimit:      342768 kB
+#Committed_AS:     875532 kB
+#VmallocTotal:   34359738367 kB
+#VmallocUsed:           0 kB
+#VmallocChunk:          0 kB
+#Percpu:             1716 kB
+#HardwareCorrupted:     0 kB
+#AnonHugePages:         0 kB
+#ShmemHugePages:        0 kB
+#ShmemPmdMapped:        0 kB
+#HugePages_Total:       0
+#HugePages_Free:        0
+#HugePages_Rsvd:        0
+#HugePages_Surp:        0
+#Hugepagesize:       2048 kB
+#Hugetlb:               0 kB
+#DirectMap4k:       77676 kB
+#DirectMap2M:      708608 kB
+#DirectMap1G:           0 kB
+#68255.48 67410.21
+#leaf01
+#vagrant@leaf01:mgmt:~$ hostna
+#hostname     hostnamectl  
+#vagrant@leaf01:mgmt:~$ hostnamectl 
+#   Static hostname: leaf01
+#         Icon name: computer-vm
+#           Chassis: vm
+#        Machine ID: 1c2b8c45a8b84106a655a360de11f57a
+#           Boot ID: 3274ff6d2031495eaab2374c8d3fba91
+#    Virtualization: kvm
+#  Operating System: Cumulus Linux
+#       CPE OS Name: cpe:/o:cumulusnetworks:cumulus_linux:4.4.0
+#            Kernel: Linux 4.19.0-cl-1-amd64
+#      Architecture: x86-64
+#vagrant@leaf01:mgmt:~$ decode-syseeprom && cat /etc/os-release && cat /proc/meminfo && cat /proc/uptime && cat /etc/hostname
+#TlvInfo Header:
+#   Id String:    TlvInfo
+#   Version:      1
+#   Total Length: 69
+#TLV Name             Code Len Value
+#-------------------- ---- --- -----
+#Vendor Name          0x2D  16 Cumulus Networks
+#Product Name         0x21   2 VX
+#Device Version       0x26   1 3
+#Part Number          0x22   5 4.4.0
+#MAC Addresses        0x2A   2 7
+#Base MAC Address     0x24   6 44:38:39:01:02:01
+#Serial Number        0x23  17 44:38:39:01:02:01
+#CRC-32               0xFE   4 0xC38EB5C2
+#(checksum valid)
+#NAME="Cumulus Linux"
+#VERSION_ID=4.4.0
+#VERSION="Cumulus Linux 4.4.0"
+#PRETTY_NAME="Cumulus Linux"
+#ID=cumulus-linux
+#ID_LIKE=debian
+#CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:4.4.0
+#HOME_URL="http://www.cumulusnetworks.com/"
+#SUPPORT_URL="http://support.cumulusnetworks.com/"
+#MemTotal:         685540 kB
+#MemFree:          108696 kB
+#MemAvailable:     225284 kB
+#Buffers:           24952 kB
+#Cached:           170612 kB
+#SwapCached:            0 kB
+#Active:           393272 kB
+#Inactive:          77156 kB
+#Active(anon):     278184 kB
+#Inactive(anon):     9200 kB
+#Active(file):     115088 kB
+#Inactive(file):    67956 kB
+#Unevictable:           0 kB
+#Mlocked:               0 kB
+#SwapTotal:             0 kB
+#SwapFree:              0 kB
+#Dirty:                48 kB
+#Writeback:             0 kB
+#AnonPages:        274884 kB
+#Mapped:            56660 kB
+#Shmem:             12516 kB
+#Slab:              75188 kB
+#SReclaimable:      55244 kB
+#SUnreclaim:        19944 kB
+#KernelStack:        2428 kB
+#PageTables:         3012 kB
+#NFS_Unstable:          0 kB
+#Bounce:                0 kB
+#WritebackTmp:          0 kB
+#CommitLimit:      342768 kB
+#Committed_AS:     877148 kB
+#VmallocTotal:   34359738367 kB
+#VmallocUsed:           0 kB
+#VmallocChunk:          0 kB
+#Percpu:             1740 kB
+#HardwareCorrupted:     0 kB
+#AnonHugePages:         0 kB
+#ShmemHugePages:        0 kB
+#ShmemPmdMapped:        0 kB
+#HugePages_Total:       0
+#HugePages_Free:        0
+#HugePages_Rsvd:        0
+#HugePages_Surp:        0
+#Hugepagesize:       2048 kB
+#Hugetlb:               0 kB
+#DirectMap4k:       77676 kB
+#DirectMap2M:      708608 kB
+#DirectMap1G:           0 kB
+#

--- a/suzieq/config/textfsm_templates/cls_uptime_hostname.tfsm
+++ b/suzieq/config/textfsm_templates/cls_uptime_hostname.tfsm
@@ -1,0 +1,9 @@
+Value _sysUptime ([0-9.]+)
+Value hostname (\S+)
+
+Start
+  ^${_sysUptime}
+  ^${hostname}
+
+#69002.09 68148.41
+#leaf01

--- a/suzieq/config/textfsm_templates/iosxe_show_bgp_neigh.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_bgp_neigh.tfsm
@@ -35,22 +35,21 @@ Value passive (passive)
 Value extnhEnabled (\w+)
 Value _numConnEstd (\d+)
 Value _numConnDropped (\d+)
-Value Fillup peerIP (.*)
-Value Fillup updateSource ([^,]+)
-Value Fillup lastDownTime (.+?)
+Value peerIP (.*)
+Value updateSource ([^,]+)
+Value lastDownTime (.+?)
 Value softReconfig (\w+)
 Value reason (.+?)
-Value Fillup notificnReason (.+?)
-Value Fillup notificnReasonRx (.+?)
-Value Fillup hopsMax (\d+)
+Value notificnReason (.+?)
+Value notificnReasonRx (.+?)
+Value hopsMax (\d+)
 Value updatesRx (\d+)
 Value updatesTx (\d+)
 Value ifname (\S+)
 Value _adminDown (\S+)
 
 Start
-  ^For\s+address\s+family: -> Continue.Record
-  ^BGP neighbor -> Continue.Record
+  ^For\s+address\s+family:\s+${afi}\s+${safi}\s*$$
   ^For\s+address\s+family:\s+${afi}\s+${safi}\s*$$
   ^BGP neighbor is ${peer},\s+remote\s+AS\s+${peerAsn},.*$$
   ^BGP neighbor is ${peer},\s+vrf\s+${vrf},\s+remote\s+AS\s+${peerAsn},.*$$
@@ -67,10 +66,42 @@ Start
   ^\s+Last\s+reset\s+${lastDownTime},\s+${reason}\s*$$
   ^\s+Last\s+reset\s+${lastDownTime}\s*$$
   ^\s+Interface\s+associated:\s+${ifname}.*$$
-  ^Local\s+host:\s+${updateSource}.*$$
+  ^Local\s+host:\s+${updateSource}.*$$ -> Record
+  ^No\s+Active\s+TCP -> Record
+
 
 
 #For address family: IPv4 Unicast
+#BGP neighbor is 10.127.0.37,  remote AS 65121, external link
+#  BGP version 4, remote router ID 0.0.0.0
+#  BGP state = Active
+#  Neighbor sessions:
+#    0 active, is not multisession capable (disabled)
+#    Stateful switchover support enabled: NO for session 0
+#  Message statistics:
+#    InQ depth is 0
+#    OutQ depth is 0
+#    
+#                         Sent       Rcvd
+#    Opens:                  0          0
+#    Notifications:          0          0
+#    Updates:                0          0
+#    Keepalives:             0          0
+#    Route Refresh:          0          0
+#    Total:                  0          0
+#  Do log neighbor state changes (via global configuration)
+#  Default minimum time between advertisement runs is 30 seconds
+#
+#  Address tracking is enabled, the RIB does have a route to 10.127.0.37
+#  Connections established 2; dropped 2
+#  Last reset 20w2d, due to Active open failed
+#  External BGP neighbor configured for connected checks (single-hop no-disable-connected-check)
+#  Interface associated: GigabitEthernet0/1/0.234 (peering address in same link)
+#  Transport(tcp) path-mtu-discovery is enabled
+#  Graceful-Restart is enabled, restart-time 120 seconds, stalepath-time 360 seconds
+#  SSO is disabled
+#  No active TCP connection
+#
 #BGP neighbor is 10.127.0.1,  remote AS 65000, external link
 #  BGP version 4, remote router ID 10.0.0.12
 #  BGP state = Established, up for 00:08:04

--- a/suzieq/config/textfsm_templates/iosxe_show_bgp_summ.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_bgp_summ.tfsm
@@ -1,4 +1,5 @@
 Value Filldown asn (\d+)
+Value Filldown vrf (\S+)
 Value Filldown afi (\w+)
 Value Filldown safi (\w+)
 Value Required peer ([0-9A-Fa-f.:]+)
@@ -7,6 +8,7 @@ Value statePfx (.*)
 Value Filldown routerId ([0-9.]+)
 
 Start
+  ^BGP\s+summary\s+information\s+for\s+VRF\s+${vrf},address\s+family\s+${afi}\s+${safi}
   ^For\s+address\s+family:\s+${afi}\s+${safi}\s*$$
   ^BGP\s+router\s+identifier\s+${routerId},\s+local\s+AS\s+number\s+${asn}
   ^Neighbor\s+V\s+ -> Nbrs
@@ -15,7 +17,7 @@ Nbrs
   ^${peer}\s+\d+\s+${peerAsn}\s+\d+.*\s+${statePfx}\s*$$ -> Record
   ^\s*$$ -> Start
 
-
+#BGP summary information for VRF default, address family VPNv4 Unicast
 #For address family: IPv4 Unicast
 #BGP router identifier 10.0.0.12, local AS number 65000
 #BGP table version is 7, main routing table version 7

--- a/suzieq/config/textfsm_templates/iosxe_show_ip_ospf.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_ip_ospf.tfsm
@@ -1,0 +1,103 @@
+Value Required _processId (\d+)
+Value routerId ([0-9.]+)
+Value vrf (\S+)
+
+Start
+  ^\s+Routing\s+ -> Continue.Record
+  ^\s+Routing\s+Process\s+"ospf\s+${_processId}"\s+with\s+ID\s+${routerId}
+  ^\s+Connected\s+to\s+MPLS\s+VPN\s+Superbackbone,\s+VRF\s+${vrf}
+  
+
+# Routing Process "ospf 1" with ID 10.0.0.1
+# Start time: 02:30:01.979, Time elapsed: 00:10:30.285
+# Supports only single TOS(TOS0) routes
+# Supports opaque LSA
+# Supports Link-local Signaling (LLS)
+# Supports area transit capability
+# Supports NSSA (compatible with RFC 3101)
+# Supports Database Exchange Summary List Optimization (RFC 5243)
+# Event-log enabled, Maximum number of events: 1000, Mode: cyclic
+# Router is not originating router-LSAs with maximum metric
+# Initial SPF schedule delay 50 msecs
+# Minimum hold time between two consecutive SPFs 200 msecs
+# Maximum wait time between two consecutive SPFs 5000 msecs
+# Incremental-SPF disabled
+# Initial LSA throttle delay 50 msecs
+# Minimum hold time for LSA throttle 200 msecs
+# Maximum wait time for LSA throttle 5000 msecs
+# Minimum LSA arrival 100 msecs
+# LSA group pacing timer 240 secs
+# Interface flood pacing timer 33 msecs
+# Retransmission pacing timer 66 msecs
+# EXCHANGE/LOADING adjacency limit: initial 300, process maximum 300
+# Number of external LSA 0. Checksum Sum 0x000000
+# Number of opaque AS LSA 0. Checksum Sum 0x000000
+# Number of DCbitless external and opaque AS LSA 0
+# Number of DoNotAge external and opaque AS LSA 0
+# Number of areas in this router is 1. 1 normal 0 stub 0 nssa
+# Number of areas transit capable is 0
+# External flood list length 0
+# IETF NSF helper support enabled
+# Cisco NSF helper support enabled
+# Reference bandwidth unit is 100 mbps
+#    Area BACKBONE(0.0.0.0)
+#        Number of interfaces in this area is 3 (1 loopback)
+#	Area has no authentication
+#	SPF algorithm last executed 00:09:40.920 ago
+#	SPF algorithm executed 7 times
+#	Area ranges are
+#	Number of LSA 3. Checksum Sum 0x011041
+#	Number of opaque link LSA 0. Checksum Sum 0x000000
+#	Number of DCbitless LSA 0
+#	Number of indication LSA 0
+#	Number of DoNotAge LSA 0
+#	Flood list length 0
+#
+# Routing Process "ospf 100" with ID 10.0.0.1
+#   Domain ID type 0x0005, value 0.0.0.100
+# Start time: 02:30:05.462, Time elapsed: 00:10:26.803
+# Supports only single TOS(TOS0) routes
+# Supports opaque LSA
+# Supports Link-local Signaling (LLS)
+# Supports area transit capability
+# Supports NSSA (compatible with RFC 3101)
+# Supports Database Exchange Summary List Optimization (RFC 5243)
+# Connected to MPLS VPN Superbackbone, VRF blue
+# Event-log disabled
+# It is an area border router
+# Router is not originating router-LSAs with maximum metric
+# Initial SPF schedule delay 50 msecs
+# Minimum hold time between two consecutive SPFs 200 msecs
+# Maximum wait time between two consecutive SPFs 5000 msecs
+# Incremental-SPF disabled
+# Initial LSA throttle delay 50 msecs
+# Minimum hold time for LSA throttle 200 msecs
+# Maximum wait time for LSA throttle 5000 msecs
+# Minimum LSA arrival 100 msecs
+# LSA group pacing timer 240 secs
+# Interface flood pacing timer 33 msecs
+# Retransmission pacing timer 66 msecs
+# EXCHANGE/LOADING adjacency limit: initial 300, process maximum 300
+# Number of external LSA 0. Checksum Sum 0x000000
+# Number of opaque AS LSA 0. Checksum Sum 0x000000
+# Number of DCbitless external and opaque AS LSA 0
+# Number of DoNotAge external and opaque AS LSA 0
+# Number of areas in this router is 1. 1 normal 0 stub 0 nssa
+# Number of areas transit capable is 0
+# External flood list length 0
+# IETF NSF helper support enabled
+# Cisco NSF helper support enabled
+# Reference bandwidth unit is 100 mbps
+#    Area BACKBONE(0.0.0.0)
+#        Number of interfaces in this area is 1
+#	Area has no authentication
+#	SPF algorithm last executed 00:10:16.911 ago
+#	SPF algorithm executed 4 times
+#	Area ranges are
+#	Number of LSA 3. Checksum Sum 0x026FF1
+#	Number of opaque link LSA 0. Checksum Sum 0x000000
+#	Number of DCbitless LSA 0
+#	Number of indication LSA 0
+#	Number of DoNotAge LSA 0
+#	Flood list length 0
+#

--- a/suzieq/config/textfsm_templates/iosxe_show_ip_ospfif.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_ip_ospfif.tfsm
@@ -13,74 +13,122 @@ Value deadTime (\d+)
 Value retxTime (\d+)
 Value nbrCount (\d+)
 Value passive (\w+)
+Value _processId (\d+)
 
 Start
   ^\S+ is.*$$ -> Continue.Record
   ^${ifname} is ${state}.*$$
   ^\s+Internet Address ${ipAddress},.*Area ${area}\s?${areaStub}.*$$
   ^\s+This interface is ${isUnnumbered}, Area ${area}\s?${areaStub}.*$$
-  ^\s+.*,\s+Router ID ${routerId}, Network Type ${networkType}, Cost:\s+${cost}.*$$
+  ^\s+Process\s+ID\s+${_processId},\s+Router ID ${routerId}, Network Type ${networkType}, Cost:\s+${cost}.*$$
   ^\s+Timer intervals configured, Hello ${helloTime}.*, Dead ${deadTime}.*, Retransmit ${retxTime}.*$$
   ^\s+No Hellos \(${passive} interface\).*$$
   ^\s+Neighbor Count.*, Adjacent neighbor count is ${nbrCount}.*$$
   ^\s+.*treated\s+as\s+a\s+${passive}\s+Host.*$$
 
 #Loopback0 is up, line protocol is up 
-#  Internet Address 1.1.1.1/32, Area 0, Attached via Network Statement
-#  Process ID 1, Router ID 1.1.1.1, Network Type LOOPBACK, Cost: 1
+#  Internet Address 10.0.0.1/32, Interface ID 12, Area 0.0.0.0
+#  Attached via Interface Enable
+#  Process ID 1, Router ID 10.0.0.1, Network Type LOOPBACK, Cost: 1
 #  Topology-MTID    Cost    Disabled    Shutdown      Topology Name
 #        0           1         no          no            Base
+#  Enabled by interface config, including secondary ip addresses
 #  Loopback interface is treated as a stub Host
-#GigabitEthernet0/1 is up, line protocol is up 
-#  Internet Address 10.2.1.2/30, Area 0, Attached via Network Statement
-#  Process ID 1, Router ID 1.1.1.1, Network Type BROADCAST, Cost: 1
+#GigabitEthernet4 is up, line protocol is up 
+#  Internet Address 172.16.0.1/24, Interface ID 10, Area 0.0.0.0
+#  Attached via Interface Enable
+#  Process ID 1, Router ID 10.0.0.1, Network Type BROADCAST, Cost: 1
 #  Topology-MTID    Cost    Disabled    Shutdown      Topology Name
 #        0           1         no          no            Base
+#  Enabled by interface config, including secondary ip addresses
 #  Transmit Delay is 1 sec, State DR, Priority 1
-#  Designated Router (ID) 1.1.1.1, Interface address 10.2.1.2
-#  Backup Designated router (ID) 22.22.22.22, Interface address 10.2.1.1
+#  Designated Router (ID) 10.0.0.1, Interface address 172.16.0.1
+#  No backup designated router on this network
 #  Timer intervals configured, Hello 10, Dead 40, Wait 40, Retransmit 5
 #    oob-resync timeout 40
-#    Hello due in 00:00:06
+#    No Hellos (Passive interface) 
 #  Supports Link-local Signaling (LLS)
 #  Cisco NSF helper support enabled
 #  IETF NSF helper support enabled
+#  Can be protected by per-prefix Loop-Free FastReroute
+#  Can be used for per-prefix Loop-Free FastReroute repair paths
+#  Not Protected by per-prefix TI-LFA
 #  Index 1/3/3, flood queue length 0
 #  Next 0x0(0)/0x0(0)/0x0(0)
-#  Last flood scan length is 1, maximum is 7
-#  Last flood scan time is 0 msec, maximum is 7 msec
-#  Neighbor Count is 1, Adjacent neighbor count is 1 
-#    Adjacent with neighbor 22.22.22.22  (Backup Designated Router)
+#  Last flood scan length is 0, maximum is 0
+#  Last flood scan time is 0 msec, maximum is 0 msec
+#  Neighbor Count is 0, Adjacent neighbor count is 0 
 #  Suppress hello for 0 neighbor(s)
-#GigabitEthernet0/0 is up, line protocol is up 
-#  Internet Address 10.1.1.2/30, Area 0, Attached via Network Statement
-#  Process ID 1, Router ID 1.1.1.1, Network Type BROADCAST, Cost: 1
+#GigabitEthernet3 is up, line protocol is up 
+#  Internet Address 10.1.0.10/30, Interface ID 9, Area 0.0.0.0
+#  Attached via Interface Enable
+#  Process ID 1, Router ID 10.0.0.1, Network Type POINT_TO_POINT, Cost: 1
 #  Topology-MTID    Cost    Disabled    Shutdown      Topology Name
 #        0           1         no          no            Base
-#  Transmit Delay is 1 sec, State DR, Priority 1
-#  Designated Router (ID) 1.1.1.1, Interface address 10.1.1.2
-#  Backup Designated router (ID) 11.11.11.11, Interface address 10.1.1.1
+#  Enabled by interface config, including secondary ip addresses
+#  Transmit Delay is 1 sec, State POINT_TO_POINT
 #  Timer intervals configured, Hello 10, Dead 40, Wait 40, Retransmit 5
 #    oob-resync timeout 40
 #    Hello due in 00:00:08
 #  Supports Link-local Signaling (LLS)
 #  Cisco NSF helper support enabled
 #  IETF NSF helper support enabled
+#  Can be protected by per-prefix Loop-Free FastReroute
+#  Can be used for per-prefix Loop-Free FastReroute repair paths
+#  Not Protected by per-prefix TI-LFA
 #  Index 1/2/2, flood queue length 0
 #  Next 0x0(0)/0x0(0)/0x0(0)
-#  Last flood scan length is 0, maximum is 7
-#  Last flood scan time is 0 msec, maximum is 8 msec
+#  Last flood scan length is 1, maximum is 1
+#  Last flood scan time is 0 msec, maximum is 0 msec
 #  Neighbor Count is 1, Adjacent neighbor count is 1 
-#    Adjacent with neighbor 11.11.11.11  (Backup Designated Router)
+#    Adjacent with neighbor 10.0.0.4
 #  Suppress hello for 0 neighbor(s)
-#GigabitEthernet0/0 is administratively down, line protocol is down 
-#  Internet Address 10.1.1.2/30, Area 0, Attached via Network Statement
-#  Process ID 1, Router ID 1.1.1.1, Network Type BROADCAST, Cost: 1
+#GigabitEthernet2 is up, line protocol is up 
+#  Internet Address 10.1.0.2/30, Interface ID 8, Area 0.0.0.0
+#  Attached via Interface Enable
+#  Process ID 100, Router ID 10.0.0.1, Network Type POINT_TO_POINT, Cost: 1
 #  Topology-MTID    Cost    Disabled    Shutdown      Topology Name
 #        0           1         no          no            Base
-#  Transmit Delay is 1 sec, State DOWN, Priority 1
-#  No designated router on this network
-#  No backup designated router on this network
+#  Enabled by interface config, including secondary ip addresses
+#  Transmit Delay is 1 sec, State POINT_TO_POINT
 #  Timer intervals configured, Hello 10, Dead 40, Wait 40, Retransmit 5
 #    oob-resync timeout 40
+#    Hello due in 00:00:08
+#  Supports Link-local Signaling (LLS)
+#  Cisco NSF helper support enabled
+#  IETF NSF helper support enabled
+#  Can be protected by per-prefix Loop-Free FastReroute
+#  Can be used for per-prefix Loop-Free FastReroute repair paths
+#  Not Protected by per-prefix TI-LFA
+#  Index 1/2/2, flood queue length 0
+#  Next 0x0(0)/0x0(0)/0x0(0)
+#  Last flood scan length is 1, maximum is 1
+#  Last flood scan time is 0 msec, maximum is 0 msec
+#  Neighbor Count is 1, Adjacent neighbor count is 1 
+#    Adjacent with neighbor 10.0.0.4
+#  Suppress hello for 0 neighbor(s)
+#GigabitEthernet2 is up, line protocol is up 
+#  Internet Address 10.1.0.2/30, Interface ID 8, Area 0.0.0.0
+#  Attached via Interface Enable
+#  Process ID 100, Router ID 10.0.0.1, Network Type POINT_TO_POINT, Cost: 1
+#  Topology-MTID    Cost    Disabled    Shutdown      Topology Name
+#        0           1         no          no            Base
+#  Enabled by interface config, including secondary ip addresses
+#  Transmit Delay is 1 sec, State POINT_TO_POINT
+#  Timer intervals configured, Hello 10, Dead 40, Wait 40, Retransmit 5
+#    oob-resync timeout 40
+#    Hello due in 00:00:08
+#  Supports Link-local Signaling (LLS)
+#  Cisco NSF helper support enabled
+#  IETF NSF helper support enabled
+#  Can be protected by per-prefix Loop-Free FastReroute
+#  Can be used for per-prefix Loop-Free FastReroute repair paths
+#  Not Protected by per-prefix TI-LFA
+#  Index 1/1/1, flood queue length 0
+#  Next 0x0(0)/0x0(0)/0x0(0)
+#  Last flood scan length is 1, maximum is 1
+#  Last flood scan time is 0 msec, maximum is 0 msec
+#  Neighbor Count is 1, Adjacent neighbor count is 1 
+#    Adjacent with neighbor 10.0.0.3
+#  Suppress hello for 0 neighbor(s)
 #

--- a/suzieq/config/textfsm_templates/iosxe_show_vlan.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_vlan.tfsm
@@ -1,36 +1,13 @@
 Value Required vlan (\d+)
 Value Required vlanName (.*)
 Value Required state (active|act/unsup)
-Value interfaces (.*)
+Value List interfaces (.*)
 
 Start
-  ^${vlan}\s+${vlanName}\s+${state}\s+${interfaces}\s*$$ -> Record
+  ^VLAN -> Record
+  ^\d+ -> Continue.Record
+  ^${vlan}\s+${vlanName}\s+${state}\s+${interfaces}\s*$$
+  ^\s+${interfaces}
   ^.*SAID -> End
 
 End
-
-
-#VLAN Name                             Status    Ports
-#---- -------------------------------- --------- -------------------------------
-#1    default                          active    
-#10   localServer                      active    Gi0/3, Gi1/0
-#1002 fddi default                     act/unsup 
-#1003 token-ring-default               act/unsup 
-#1004 fddinet-default                  act/unsup 
-#1005 trnet-default                    act/unsup 
-#
-#VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
-#---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
-#1    enet  100001     1500  -      -      -        -    -        0      0   
-#10   enet  100010     1500  -      -      -        -    -        0      0   
-#1002 fddi  101002     1500  -      -      -        -    -        0      0   
-#1003 tr    101003     1500  -      -      -        -    -        0      0   
-#1004 fdnet 101004     1500  -      -      -        ieee -        0      0   
-#1005 trnet 101005     1500  -      -      -        ibm  -        0      0   
-#
-#Remote SPAN VLANs
-#------------------------------------------------------------------------------
-#
-#
-#Primary Secondary Type              Ports
-#------- --------- ----------------- ------------------------------------------

--- a/suzieq/config/textfsm_templates/iosxe_show_vrf.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_vrf.tfsm
@@ -4,6 +4,8 @@ Value routeDistinguisher ([0-9.:]+)
 Start
  ^VRF\s+${ifname}\s+\(VRF Id = \d+\);\s+default\s+RD\s+${routeDistinguisher};.*$$ -> Record
  ^VRF\s+${ifname}\s+\(VRF Id = \d+\);\s+default\s+RD\s+<not set>;.*$$ -> Record
+ ^VRF\s+${ifname};default\s+RD\s+${routeDistinguisher};.*$$ -> Record
+ ^VRF\s+${ifname};\s+default\s+RD\s+<not set>;.*$$ -> Record 
  
 #VRF BLUE (VRF Id = 2); default RD 65000:20; default VPNID <not set>
 #  New CLI format, supports multiple address-families

--- a/suzieq/config/textfsm_templates/nxos_show_int_brief.tfsm
+++ b/suzieq/config/textfsm_templates/nxos_show_int_brief.tfsm
@@ -1,10 +1,9 @@
 Value Required ifname (\S+)
-Value vrf (\S+)
 Value state (up|down)
-Value IP (\d+\.\d+\.\d+\.\d+)
+Value IP ((\d+\.\d+\.\d+\.\d+)|--)
 Value speed (\S+)
 Value mtu (\d+)
-Value vlan (\d+|--)
+Value vlan (\d+|--|monitor)
 Value type (\S+)
 Value _portmode (routed|access|trunk|pvlan|fabric)
 Value reason (\S+((\s\w+)+)?)
@@ -22,27 +21,31 @@ Start
   ^Port\s+Status -> Tunnel
 
 Mgmt
-  ^${ifname}\s+${vrf}\s+${state}\s+${IP}\s+${speed}\s+${mtu} -> Record
   ^Ethernet\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Port -> Start
+  ^${ifname}\s+\S+\s+${state}\s+${IP}\s+${speed}\s+${mtu} -> Record
 
 Ethernet
-  ^${ifname}\s+${vlan}\s+${type}\s+${_portmode}\s+${state}\s+${reason}\s+${speed}\S*\s+${_portchannel} -> Record
   ^Interface\s+Status\s+Description -> Loopback
   ^Interface\s+Secondary\s+VLAN -> Vlan
   ^Interface\s+Status\s+Peer\s+IP -> PW
+  ^${ifname}\s+${vlan}\s+${type}\s+${_portmode}\s+${state}\s+${reason}\s+${speed}\S*\s+${_portchannel} -> Record
 
 Loopback
-  ^${ifname}\s+${state}\s+${description} -> Record
   ^Interface\s+Secondary\s+VLAN\(Type\)\s+Status\s+Reason -> Vlan
+  ^Ethernet\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Port -> Ethernet
+  ^${ifname}\s+${state}\s+${description} -> Record
 
 Vlan
   ^Interface\s+Status\s+Peer -> PW
   ^Port\s+Status\s+Reason -> Tunnel
+  ^Ethernet\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Port -> Ethernet
   ^${ifname}\s+${type}\s+${state}\s+${reason} -> Record
 
 Tunnel
   ^Interface\s+Status -> PW
+  ^Ethernet\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Port -> Ethernet
   ^${ifname}\s+${state}\s+{reason}\s+${mtu} -> Record
 
 PW
+  ^Ethernet\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Port -> Ethernet
   ^${ifname}\s+${state}\s+${peerIP}\s+${vcid} -> Record

--- a/suzieq/config/textfsm_templates/nxos_show_ip_int.tfsm
+++ b/suzieq/config/textfsm_templates/nxos_show_ip_int.tfsm
@@ -10,11 +10,10 @@ Value _unnum_intf (\S+)
 Value _child_intf (Unnumbered\s+interfaces\s+of)
 
 Start
-  ^\S+,.*,$$ -> Continue.Record
-  ^\s*$$ -> Continue.Record
+  ^\S+.*[Ss]tatus -> Continue.Record
   ^IP\s+Interface\s+Status\s+for\s+VRF\s+"${vrf}"
   ^${ifname},\s+Interface\s+status:\s+protocol-${state}/link-${_operState}/admin-${adminState}
   ^${_child_intf}\s+
-  ^\s+IP\s+address:\s+${ipAddressList},\s+IP\s+subnet:\s+[0-9.]+/${_maskLen}\s+
+  ^\s+IP\s+address:\s+${ipAddressList},\s+IP\s+subnet:\s+[0-9.]+/${_maskLen}
   ^\s+IP\s+unnumbered\s+interface\s+\(${_unnum_intf}\)
   ^\s+IP\s+MTU:\s+${mtu}\s+bytes

--- a/suzieq/config/textfsm_templates/nxos_show_ip_route.tfsm
+++ b/suzieq/config/textfsm_templates/nxos_show_ip_route.tfsm
@@ -7,16 +7,17 @@ Value List metric (\d+)
 Value List nexthopIps (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
 Value List oifs ([\w\./-]+)
 Value statusChangeTimestamp ([\w:\.]+)
-Value _nexthopVrf (\S+)
+Value List _nexthopVrf (\S+)
 Value routeTag (\d+( \(\w+\))?)
 Value _segmentId (\d+)
 Value _tunnelId (0x[a-f\d]+)
 Value _encap (\w+)
 
 Start
+  ^IP\s+Route\s+Table -> Continue.Record
+  ^\d+ -> Continue.Record
   ^IP\s+Route\s+Table\s+for\s+VRF\s+"${vrf}"\s*$$
   # Match the Network/Prefix Line
-  ^\d+ -> Continue.Record
   ^\s*${prefix}, ubest/mbest:
   #
   # Match VXLAN Route Entry

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -591,8 +591,8 @@ class InterfacesObj(SqPandasEngine):
 
         df.loc[df.ifname == "bridge", 'portmode'] = ''
         if 'vlan_y' in df.columns:
-            df['vlan'] = np.where(df.vlan != 0, df.vlan,
-                                  df.vlan_y)
+            df['vlan'] = np.where(df.vlan_y != 0, df.vlan_y,
+                                  df.vlan)
         df['vlan'] = df.vlan.astype(int)
 
         df['portmode'] = np.where(df.adminState != 'up', '',

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -65,7 +65,7 @@ class InterfacesObj(SqPandasEngine):
             df = self._add_portmode(df, **kwargs)
 
         if vlan or "vlanList" in fields:
-            df = self._add_vlanlist(df)
+            df = self._add_vlanlist(df, **kwargs)
 
         if state or portmode:
             query_str = build_query_str([], self.schema, state=state,
@@ -632,6 +632,7 @@ class InterfacesObj(SqPandasEngine):
                             .reset_index() \
                             .rename(columns={'interfaces': 'ifname',
                                              'vlan': 'vlanList'})
+        vlan_if_df = vlan_if_df.dropna(subset=['namespace', 'hostname'])
 
         vlan_if_df['vlanList'] = vlan_if_df.vlanList.apply(sorted)
 

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -509,8 +509,8 @@ class OspfObj(SqPandasEngine):
                                                   .str.split('/').str[0]
                 nopeer_df = nopeer_df.merge(
                     addr_df,
-                    left_on=['namespace', 'vrf', 'peerIP'],
-                    right_on=['namespace', 'vrf', 'ipAddressList'],
+                    left_on=['namespace', 'peerIP'],
+                    right_on=['namespace', 'ipAddressList'],
                     suffixes=['', '_y'], how='left') \
                     .rename(columns={'hostname_y': 'peerHostname',
                                      'ifname_y': 'peerIfname'}) \

--- a/suzieq/engines/pandas/topology.py
+++ b/suzieq/engines/pandas/topology.py
@@ -84,6 +84,8 @@ class TopologyObj(SqPandasEngine):
         afi_safi = kwargs.pop('afiSafi', '')
 
         self._init_dfs(self._namespaces)
+        if self._if_df.empty:
+            return pd.DataFrame({'error': ['No interfaces data found']})
         self.lsdb = pd.DataFrame()
         self._a_df = pd.DataFrame()
         self._ip_table = pd.DataFrame()
@@ -239,7 +241,7 @@ class TopologyObj(SqPandasEngine):
         return df
 
     def _augment_lldp_show(self, df):
-        if not df.empty:
+        if not df.empty and not self._if_df.empty:
             df = df[df.peerHostname != '']
             df = df.merge(
                 self._if_df[['namespace', 'hostname', 'ifname', 'vrf']],

--- a/suzieq/poller/worker/services/mlag.py
+++ b/suzieq/poller/worker/services/mlag.py
@@ -81,7 +81,7 @@ class MlagService(Service):
                 lambda x: x == '1',
                 entry.get('_forwardViaPeerLinkList', []) or []))
             mlagErrorPorts = list(filter(
-                lambda x: x not in ['consistent', 'success'],
+                lambda x: x not in ['consistent', 'success', 'not-applicable'],
                 entry.get('_portConfigSanityList', []) or []))
             mlagDualPorts = entry.get('_portList', []) or []
             mlagDualPorts = list(filter(
@@ -94,11 +94,14 @@ class MlagService(Service):
                 entry['peerLinkStatus'] = 'down'
             entry['peerLink'] = expand_nxos_ifname(entry['peerLink'])
             entry['peerAddress'] = entry.get('peerAddress', [])
-            entry['mlagDualPortsList'] = mlagDualPorts
+            entry['mlagDualPortsList'] = [
+                expand_nxos_ifname(x) for x in mlagDualPorts]
             entry['mlagDualPortsCnt'] = len(mlagDualPorts)
-            entry['mlagSinglePortsList'] = mlagSinglePorts
+            entry['mlagSinglePortsList'] = [
+                expand_nxos_ifname(x) for x in mlagSinglePorts]
             entry['mlagSinglePortsCnt'] = len(mlagSinglePorts)
-            entry['mlagErrorPortsList'] = mlagErrorPorts
+            entry['mlagErrorPortsList'] = [
+                expand_nxos_ifname(x) for x in mlagErrorPorts]
             entry['mlagErrorPortsCnt'] = len(mlagErrorPorts)
             entry['state'] = 'active' \
                 if entry['state'].strip() in ['peer-ok',

--- a/suzieq/poller/worker/services/vlan.py
+++ b/suzieq/poller/worker/services/vlan.py
@@ -123,8 +123,11 @@ class VlanService(Service):
                 entry['vlanName'] = entry['vlanName'].strip()
                 if entry['interfaces']:
                     newiflist = []
-                    for ifname in entry['interfaces'].split(','):
-                        newiflist.append(expand_ios_ifname(ifname.strip()))
+                    for ifname in entry['interfaces']:
+                        newiflist.extend([expand_ios_ifname(x.strip())
+                                          for x in ifname.split(',')])
+                    if newiflist == ['']:
+                        newiflist = []
                     entry['interfaces'] = newiflist
                 else:
                     entry['interfaces'] = []

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -765,6 +765,8 @@ def expand_nxos_ifname(ifname: str) -> str:
         return ifname.replace('Eth', 'Ethernet')
     elif ifname.startswith('Po') and 'port' not in ifname:
         return ifname.replace('Po', 'port-channel')
+    elif ifname.startswith('Lo') and 'loop' not in ifname:
+        return ifname.replace('Lo', 'loopback')
     return ifname
 
 
@@ -830,8 +832,11 @@ def expand_ios_ifname(ifname: str) -> str:
     :rtype: str
     """
 
-    ifmap = {'BE': 'Bundle-Ether',
+    ifmap = {'Ap': 'AppGigabitEthernet',
+             'BE': 'Bundle-Ether',
              'BV': 'BVI',
+             'Fas': 'FastEthernet',
+             'Fa': 'FastEthernet',
              'Fi': 'FiftyGigE',
              'Fo': 'FortyGigE',
              'FH': 'FourHundredGigE',
@@ -847,6 +852,8 @@ def expand_ios_ifname(ifname: str) -> str:
              'Ten': 'TenGigabitEthernet',
              'TF': 'TwentyFiveGigE',
              'TH': 'TwoHundredGigE',
+             'Two': 'TwoGigabitEthernet',
+             'Tw': 'TwoGigabitEthernet',
              'tsec': 'tunnel-ipsec',
              'tmte': 'tunnel-mte',
              'tt': 'tunnel-te',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,13 @@ def create_context_config(datadir: str =
 
 @pytest.fixture()
 def get_table_data(table: str, datadir: str):
+    '''Fixture to get all fields in table.
+
+    This includes sqvers and any suppress field for DB check'''
+    return _get_table_data(table, datadir)
+
+
+def _get_table_data(table: str, datadir: str):
     '''Get all fields including sqvers and any suppress field for DB check'''
     if table in ['path', 'ospfIf', 'ospfNbr']:
         return pd.DataFrame()
@@ -81,7 +88,10 @@ def get_table_data(table: str, datadir: str):
     sqobj = get_sqobject(table)(config_file=cfgfile)
     cols = sqobj.schema.get_display_fields(['*'])
 
-    df = sqobj.get(columns=cols)
+    if table == "interface":
+        df = sqobj.get(columns=cols, type=["all"])
+    else:
+        df = sqobj.get(columns=cols)
 
     if not df.empty and (table not in ['device', 'tables', 'network']):
         device_df = get_sqobject('device')(config_file=cfgfile) \

--- a/tests/integration/test_parsing_arpnd.py
+++ b/tests/integration/test_parsing_arpnd.py
@@ -4,7 +4,7 @@ import re
 import pytest
 
 import pandas as pd
-from tests.conftest import validate_host_shape, DATADIR
+from tests.conftest import validate_host_shape, DATADIR, _get_table_data
 
 
 def validate_arpnd_tbl(df: pd.DataFrame):
@@ -20,6 +20,41 @@ def validate_arpnd_tbl(df: pd.DataFrame):
                            x) is not None).all()
     assert not (pass_df.oif.isin(["", "None"])).all()  # noqa
     assert (pass_df.remote.isin([True, False])).all()
+
+
+def validate_interfaces(df: pd.DataFrame, datadir: str):
+    '''Validate that each VRF/interface list is in interfaces table.
+
+    This is to catch problems in parsing interfaces such that the different
+    tables contain a different interface name than the interface table itself.
+    For example, in parsing older NXOS, we got iftable with Eth1/1 and the
+    route table with Ethernet1/1. The logic of ensuring this also ensures that
+    the VRFs in the route table are all known to the interface table.
+    '''
+
+    # Create a new df of namespace/hostname/vrf to oif mapping
+    only_oifs = df.groupby(by=['namespace', 'hostname'])['oif'] \
+                  .unique() \
+                  .reset_index() \
+                  .explode('oif') \
+                  .rename(columns={'oif': 'ifname'}) \
+                  .reset_index(drop=True)
+
+    # Fetch the address table
+    if_df = _get_table_data('interface', datadir)
+    assert not if_df.empty, 'unexpected empty interfaces table'
+
+    if_oifs = if_df.groupby(by=['namespace', 'hostname'])['ifname'] \
+                   .unique() \
+                   .reset_index() \
+                   .explode('ifname') \
+                   .reset_index(drop=True)
+
+    m_df = only_oifs.merge(if_oifs, how='left', indicator=True)
+    # Verify we have no rows where the route table OIF has no corresponding
+    # interface table info
+    assert m_df.query('_merge != "both"').empty, \
+        'Unknown interfaces in arpnd table'
 
 
 @ pytest.mark.parsing
@@ -43,3 +78,4 @@ def test_arpnd_parsing(table, datadir, get_table_data):
     assert not df.empty
     validate_host_shape(df, ns_dict)
     validate_arpnd_tbl(df)
+    validate_interfaces(df, datadir)

--- a/tests/integration/test_parsing_bgp.py
+++ b/tests/integration/test_parsing_bgp.py
@@ -4,7 +4,8 @@ import pytest
 import pandas as pd
 import numpy as np
 
-from tests.conftest import DATADIR, validate_host_shape
+from tests.conftest import DATADIR, validate_host_shape, _get_table_data
+from tests.integration.utils import validate_vrfs
 
 
 def _validate_estd_bgp_data(df: pd.DataFrame):
@@ -73,6 +74,40 @@ def validate_bgp_data(df: pd.DataFrame):
     _validate_estd_bgp_data(estd_df)
 
 
+def validate_interfaces(df: pd.DataFrame, datadir: str):
+    '''Validate that each VRF/interface list is in interfaces table.
+
+    This is to catch problems in parsing interfaces such that the different
+    tables contain a different interface name than the interface table itself.
+    For example, in parsing older NXOS, we got iftable with Eth1/1 and the
+    route table with Ethernet1/1. The logic of ensuring this also ensures that
+    the VRFs in the route table are all known to the interface table.
+    '''
+
+    # Create a new df of namespace/hostname/vrf to oif mapping
+    only_oifs = df.groupby(by=['namespace', 'hostname'])['ifname'] \
+                  .unique() \
+                  .reset_index() \
+                  .explode('ifname') \
+                  .reset_index(drop=True)
+
+    # Fetch the address table
+    if_df = _get_table_data('address', datadir)
+    assert not if_df.empty, 'Unexpected empty address table'
+
+    addr_oifs = if_df.groupby(by=['namespace', 'hostname'])['ifname'] \
+                     .unique() \
+                     .reset_index() \
+                     .explode('ifname') \
+                     .reset_index(drop=True)
+
+    m_df = only_oifs.merge(addr_oifs, how='left')
+    # Verify we have no rows where the route table OIF has no corresponding
+    # interface table info
+    assert m_df.query('ifname.isna()').empty, \
+        'Unknown interfaces in BGP table'
+
+
 @ pytest.mark.parsing
 @ pytest.mark.bgp
 @pytest.mark.parametrize('table', ['bgp'])
@@ -95,3 +130,5 @@ def test_bgp_parsing(table, datadir, get_table_data):
     assert not df.empty
     validate_host_shape(df, ns_dict)
     validate_bgp_data(df)
+    validate_interfaces(df.query('ifname != ""').reset_index(), datadir)
+    validate_vrfs(df, 'bgp', datadir)

--- a/tests/integration/test_parsing_lldp.py
+++ b/tests/integration/test_parsing_lldp.py
@@ -2,7 +2,7 @@ import pytest
 
 
 import pandas as pd
-from tests.conftest import DATADIR, validate_host_shape
+from tests.conftest import DATADIR, validate_host_shape, _get_table_data
 
 
 def validate_lldp_tbl(df: pd.DataFrame):
@@ -14,6 +14,60 @@ def validate_lldp_tbl(df: pd.DataFrame):
     assert (df.query('subtype == "locally assigned"').peerIfindex != "").all()
     assert (df.subtype.isin(['interface name', 'mac address',
                              'locally assigned'])).all()
+
+
+def validate_interfaces(df: pd.DataFrame, datadir: str):
+    '''Validate that each VRF/interface list is in interfaces table.
+
+    This is to catch problems in parsing interfaces such that the different
+    tables contain a different interface name than the interface table itself.
+    For example, in parsing older NXOS, we got iftable with Eth1/1 and the
+    route table with Ethernet1/1. The logic of ensuring this also ensures that
+    the VRFs in the route table are all known to the interface table.
+    '''
+
+    # Fetch the address table
+    if_df = _get_table_data('interface', datadir)
+    assert not if_df.empty, 'unexpected empty interfaces table'
+
+    # Create a new df of namespace/hostname/vrf to oif mapping
+    only_oifs = df.groupby(by=['namespace', 'hostname'])['ifname'] \
+                  .unique() \
+                  .reset_index() \
+                  .explode('ifname') \
+                  .reset_index(drop=True)
+
+    if_oifs = if_df.groupby(by=['namespace', 'hostname'])['ifname'] \
+                   .unique() \
+                   .reset_index() \
+                   .explode('ifname') \
+                   .reset_index(drop=True)
+
+    m_df = only_oifs.merge(if_oifs, how='left', indicator=True)
+    # Verify we have no rows where the route table OIF has no corresponding
+    # interface table info
+    assert m_df.query('_merge != "both"').empty, \
+        'Unknown interfaces in lldp table column ifname'
+
+    # Now test the peerIfname
+    only_oifs = df.groupby(by=['namespace', 'peerHostname'])['peerIfname'] \
+                  .unique() \
+                  .reset_index() \
+                  .explode('peerIfname') \
+                  .rename(columns={'peerIfname': 'ifname',
+                                   'peerHostname': 'hostname'}) \
+                  .reset_index(drop=True)
+
+    m_df = only_oifs.merge(if_oifs, how='left', indicator=True)
+    # Verify we have no rows where the route table OIF has no corresponding
+    # interface table info
+    if not m_df.query('_merge != "both"').empty:
+        # this could be because the peer host is not polled, so check that
+        for row in m_df.query('_merge != "both"').itertuples():
+            if not if_df.query(f'namespace == "{row.namespace}" and '
+                               f'hostname == "{row.hostname}"').empty:
+                assert False, \
+                    'Unknown interfaces in lldp table column peerIfname'
 
 
 @ pytest.mark.parsing
@@ -37,3 +91,4 @@ def test_lldp_parsing(table, datadir, get_table_data):
     assert not df.empty
     validate_host_shape(df, ns_dict)
     validate_lldp_tbl(df)
+    validate_interfaces(df, datadir)

--- a/tests/integration/test_parsing_mlag.py
+++ b/tests/integration/test_parsing_mlag.py
@@ -5,7 +5,7 @@ from ipaddress import ip_address
 import pytest
 
 import pandas as pd
-from tests.conftest import DATADIR, validate_host_shape
+from tests.conftest import DATADIR, validate_host_shape, _get_table_data
 
 
 def validate_mlag_tbl(df: pd.DataFrame):
@@ -38,6 +38,51 @@ def validate_mlag_tbl(df: pd.DataFrame):
     assert (noncl_df.peerLinkStatus.isin(['up', 'down'])).all()
 
 
+def validate_interfaces(df: pd.DataFrame, datadir: str):
+    '''Validate that all interfaces in various lists are in interfaces table.
+
+    This is to catch problems in parsing interfaces such that the different
+    tables contain a different interface name than face table itself.
+    In case of MLAG, old and new NXOS seem to provide interface names that
+    are the shortened versions.
+    '''
+
+    # Create a new df of namespace/hostname/vrf to oif mapping
+    # exclude interfaces such as cpu/sup-eth1 etc. which have vlan of 0
+    # Fetch the address table
+    if_df = _get_table_data('interface', datadir)
+    assert not if_df.empty, 'unexpected empty interfaces table'
+
+    for field in ['mlagDualPortsList', 'mlagErrorPortsList',
+                  'mlagSinglePortsList']:
+
+        if (df[field].str.len() == 0).all():
+            continue
+
+        only_oifs = df.query(f'{field}.str.len() != 0') \
+                      .explode(field) \
+                      .groupby(by=['namespace', 'hostname'])[field] \
+                      .unique() \
+                      .reset_index() \
+                      .explode(field) \
+                      .rename(columns={field: 'ifname'}) \
+                      .reset_index(drop=True)
+
+        if_oifs = if_df[['namespace', 'hostname', 'ifname']] \
+            .groupby(by=['namespace', 'hostname'])['ifname'] \
+            .unique() \
+            .reset_index() \
+            .explode('ifname') \
+            .reset_index(drop=True)
+
+        merge_df = only_oifs.merge(if_oifs, how='left', indicator=True)
+        # Verify we have no rows where the route table OIF has no corresponding
+        # interface table info
+        assert merge_df \
+            .query('_merge != "both" and namespace != "nxos"').empty, \
+            f'Unknown interfaces in mlag table column:{field}'
+
+
 @ pytest.mark.parsing
 @ pytest.mark.mlag
 @ pytest.mark.parametrize('table', ['mlag'])
@@ -58,3 +103,4 @@ def test_mlag_parsing(table, datadir, get_table_data):
     assert not df.empty
     validate_host_shape(df, ns_dict)
     validate_mlag_tbl(df)
+    validate_interfaces(df, datadir)

--- a/tests/integration/test_parsing_routes.py
+++ b/tests/integration/test_parsing_routes.py
@@ -3,7 +3,8 @@ from ipaddress import ip_network, ip_address
 import pytest
 
 import pandas as pd
-from tests.conftest import DATADIR, validate_host_shape
+from tests.conftest import DATADIR, validate_host_shape, _get_table_data
+from tests.integration.utils import validate_vrfs
 
 
 def validate_routes(df: pd.DataFrame):
@@ -45,6 +46,47 @@ def validate_routes(df: pd.DataFrame):
     assert (upt_df.statusChangeTimestamp != 0).all()
 
 
+def validate_interfaces(df: pd.DataFrame, datadir: str):
+    '''Validate that each VRF/interface list is in interfaces table.
+
+    This is to catch problems in parsing interfaces such that the different
+    tables contain a different interface name than the interface table itself.
+    For example, in parsing older NXOS, we got iftable with Eth1/1 and the
+    route table with Ethernet1/1. The logic of ensuring this also ensures that
+    the VRFs in the route table are all known to the interface table.
+    '''
+
+    # Create a new df of namespace/hostname/vrf to oif mapping
+    only_oifs = df[['namespace', 'hostname', 'vrf', 'oifs']] \
+        .query('vrf != ":vxlan"') \
+        .explode('oifs') \
+        .dropna() \
+        .groupby(by=['namespace', 'hostname', 'vrf'])['oifs'] \
+        .unique() \
+        .reset_index() \
+        .explode('oifs') \
+        .query('~oifs.str.contains("_nexthopVrf:")') \
+        .rename(columns={'oif': 'ifname'}) \
+        .reset_index(drop=True)
+
+    # Fetch the address table
+    addr_df = _get_table_data('address', DATADIR[0])
+    assert not addr_df.empty, 'unexpected empty address table'
+
+    addr_oifs = addr_df[['namespace', 'hostname', 'vrf', 'ifname']] \
+        .groupby(by=['namespace', 'hostname', 'vrf'])['ifname'] \
+        .unique() \
+        .reset_index() \
+        .explode('ifname') \
+        .reset_index(drop=True)
+
+    m_df = only_oifs.merge(addr_oifs, how='left', indicator=True)
+    # Verify we have no rows where the route table OIF has no corresponding
+    # interface table info
+    assert m_df.query('_merge != "both" and namespace != "vmx"').empty, \
+        'Unknown interfaces in routes table'
+
+
 @ pytest.mark.parsing
 @ pytest.mark.route
 @ pytest.mark.parametrize('table', ['routes'])
@@ -66,3 +108,5 @@ def test_routes_parsing(table, datadir, get_table_data):
     assert not df.empty
     validate_host_shape(df, ns_dict)
     validate_routes(df)
+    validate_interfaces(df, datadir)
+    validate_vrfs(df, 'routes', datadir)

--- a/tests/integration/test_parsing_vlan.py
+++ b/tests/integration/test_parsing_vlan.py
@@ -3,7 +3,7 @@ import warnings
 import pytest
 import pandas as pd
 
-from tests.conftest import DATADIR, validate_host_shape
+from tests.conftest import DATADIR, validate_host_shape, _get_table_data
 
 
 def validate_vlan_tbl(df: pd.DataFrame):
@@ -14,6 +14,54 @@ def validate_vlan_tbl(df: pd.DataFrame):
         warnings.warn('Some VLANs not assigned to any interface')
     assert (df.state.isin(['active', 'unsupported'])).all()
     assert (df.vlanName != '').all()
+
+
+def validate_interfaces(df: pd.DataFrame, datadir: str):
+    '''Validate that each interface list is in interfaces table.
+
+    This is to catch problems in parsing interfaces such that the different
+    tables contain a different interface name than the interface table itself.
+    For example, in parsing older NXOS, we got iftable with Eth1/1 and the
+    route table with Ethernet1/1. This also validates the vlan/vlanList field
+    parsing
+    '''
+
+    # Create a new df of namespace/hostname/vrf to oif mapping
+    only_oifs = df[['namespace', 'hostname', 'vlan', 'interfaces']] \
+        .explode('interfaces') \
+        .dropna() \
+        .query('interfaces != ""') \
+        .reset_index(drop=True) \
+        .groupby(by=['namespace', 'hostname', 'vlan'])['interfaces'] \
+        .unique() \
+        .reset_index() \
+        .explode('interfaces') \
+        .rename(columns={'interfaces': 'ifname'}) \
+        .query('ifname != "Cpu" and ~ifname.str.startswith("vtep.")') \
+        .reset_index(drop=True)
+
+    # Fetch the address table
+    if_df = _get_table_data('interface', datadir)
+    assert not if_df.empty, 'unexpected empty interfaces table'
+
+    if_df.apply(lambda x: x['vlanList'].extend([x['vlan']])
+                if x['vlan'] else x['vlanList'], axis=1)
+
+    if_oifs = if_df[['namespace', 'hostname', 'ifname', 'vlanList']] \
+        .explode('vlanList') \
+        .reset_index() \
+        .rename(columns={'vlanList': 'vlan'}) \
+        .groupby(by=['namespace', 'hostname', 'vlan'])['ifname'] \
+        .unique() \
+        .reset_index() \
+        .explode('ifname') \
+        .reset_index(drop=True)
+
+    m_df = only_oifs.merge(if_oifs, how='left', indicator=True)
+    # Verify we have no rows where the route table OIF has no corresponding
+    # interface table info
+    assert m_df.query('_merge != "both"').empty, \
+        'Unknown interfaces in VLAN table'
 
 
 @ pytest.mark.parsing
@@ -38,3 +86,4 @@ def test_vlan_parsing(table, datadir, get_table_data):
 
     validate_host_shape(df, ns_dict)
     validate_vlan_tbl(df)
+    validate_interfaces(df, datadir)

--- a/tests/integration/test_sqcmds.py
+++ b/tests/integration/test_sqcmds.py
@@ -181,7 +181,11 @@ def test_bad_start_time_filter(setup_nubia, get_cmd_object_dict, cmd):
     for cmd in cli_commands])
 def test_bad_show_namespace_filter(setup_nubia, get_cmd_object_dict, cmd):
     options = {'namespace': 'unknown'}
-    _ = _test_bad_show_filter(get_cmd_object_dict[cmd], options)
+    if cmd == "topology":
+        assert_error = True
+    else:
+        assert_error = False
+    _ = _test_bad_show_filter(get_cmd_object_dict[cmd], options, assert_error)
 
 
 def _test_bad_show_filter(cmd, options, assert_error=False):

--- a/tests/unit/poller/worker/test_inventory.py
+++ b/tests/unit/poller/worker/test_inventory.py
@@ -66,7 +66,7 @@ async def ready_inventory():
     inv = _init_inventory()
     with patch.multiple(Node, _init_ssh=get_async_task_mock(),
                         _fetch_init_dev_data=get_async_task_mock()):
-        await inv.build_inventory(None)
+        await inv.build_inventory()
     return inv
 
 
@@ -101,7 +101,7 @@ async def test_inventory_build():
 
     with patch.multiple(Node, _init_ssh=get_async_task_mock(),
                         _fetch_init_dev_data=get_async_task_mock()):
-        nodes = await inv.build_inventory(None)
+        nodes = await inv.build_inventory()
 
     # Check if nodes are registered in the inventory
     assert set(nodes) == set(inv.nodes)


### PR DESCRIPTION
Additional fixes for parsing errors in older NXOS and IOSXE output parsing.

## Test inclusion requirements

Additional tests for validating that what we parsed is consistent has been added to various tables. Specifically, these tests ensure that if a table uses an interface name or a VRF name, the interfaces table contains the necessary info.

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
