### PR TITLE
Fix check on empty dataset

### DIFF
--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -129,7 +129,7 @@ class SqParquetDB(SqDB):
                     dataset = ds.dataset(elem, format='parquet',
                                          partitioning='hive')
 
-                    if not dataset:
+                    if not dataset.files:
                         continue
 
                     tmp_df = self._process_dataset(dataset, namespace, start,


### PR DESCRIPTION
## Description

Without this fix we read empty datasets that resulted in several warnings. This happened in case only coalesced data was present.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Double Check


- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
