### PR TITLE
Network find speedup

### DIFF
--- a/suzieq/engines/pandas/device.py
+++ b/suzieq/engines/pandas/device.py
@@ -25,6 +25,7 @@ class DeviceObj(SqPandasEngine):
         status = kwargs.pop('status', '')
         os_version = kwargs.pop('version', '')
         os = kwargs.get('os', '')
+        ignore_neverpoll = kwargs.pop('ignore_neverpoll', False)
 
         addnl_fields = []
         fields = self.schema.get_display_fields(columns)
@@ -49,13 +50,15 @@ class DeviceObj(SqPandasEngine):
         if view == 'latest' and 'status' in df.columns:
             df['status'] = np.where(df.active, df['status'], 'dead')
 
-        poller_df = self._get_table_sqobj('sqPoller').get(
-            namespace=kwargs.get('namespace', []),
-            hostname=kwargs.get('hostname', []),
-            service='device',
-            columns='namespace hostname status timestamp'.split())
+        poller_df = None
+        if not ignore_neverpoll:
+            poller_df = self._get_table_sqobj('sqPoller').get(
+                namespace=kwargs.get('namespace', []),
+                hostname=kwargs.get('hostname', []),
+                service='device',
+                columns='namespace hostname status timestamp'.split())
 
-        if not poller_df.empty:
+        if poller_df is not None and not poller_df.empty:
             # Identify the address to namespace/hostname mapping
             addr_dict = {f"{x['namespace']}-{x['address']}": x['hostname']
                          for x in df[['namespace', 'address', 'hostname']]

--- a/suzieq/engines/pandas/device.py
+++ b/suzieq/engines/pandas/device.py
@@ -50,7 +50,7 @@ class DeviceObj(SqPandasEngine):
         if view == 'latest' and 'status' in df.columns:
             df['status'] = np.where(df.active, df['status'], 'dead')
 
-        poller_df = None
+        poller_df = pd.DataFrame()
         if not ignore_neverpoll:
             poller_df = self._get_table_sqobj('sqPoller').get(
                 namespace=kwargs.get('namespace', []),
@@ -58,7 +58,7 @@ class DeviceObj(SqPandasEngine):
                 service='device',
                 columns='namespace hostname status timestamp'.split())
 
-        if poller_df is not None and not poller_df.empty:
+        if not poller_df.empty:
             # Identify the address to namespace/hostname mapping
             addr_dict = {f"{x['namespace']}-{x['address']}": x['hostname']
                          for x in df[['namespace', 'address', 'hostname']]

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -544,7 +544,8 @@ class InterfacesObj(SqPandasEngine):
 
         devdf = self._get_table_sqobj('device') \
             .get(namespace=namespace, hostname=hostname,
-                 columns=['namespace', 'hostname', 'os', 'status', 'vendor'])
+                 columns=['namespace', 'hostname', 'os'],
+                 ignore_neverpoll=True)
 
         pm_df = pd.DataFrame({'namespace': [], 'hostname': [],
                               'ifname': [], 'portmode': []})

--- a/suzieq/sqobjects/device.py
+++ b/suzieq/sqobjects/device.py
@@ -12,7 +12,7 @@ class DeviceObj(SqObject):
         super().__init__(table='device', **kwargs)
         self._valid_get_args = ['namespace', 'hostname', 'columns', 'os',
                                 'vendor', 'model', 'status', 'version',
-                                'query_str']
+                                'query_str', 'ignore_neverpoll']
         self._valid_arg_vals = {
             'status': ['alive', 'dead', 'neverpoll',
                        '!alive', '!dead', '!neverpoll']

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -695,6 +695,8 @@ def test_routes_sqobj_consistency():
             args_to_match = get_args_to_match(sqobj, route.verbs)
             args_to_match = {a for a in args_to_match
                              if a not in common_args.union(top_args)}
+            if table == 'device':
+                args_to_match.remove('ignore_neverpoll')
             if args_to_match != query_params:
                 assert False, (f'different query params for {table}: expected '
                                f'{args_to_match}. Got {query_params}')

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -573,6 +573,9 @@ def test_rest_arg_consistency(service, verb):
 
         valid_args = set(arglist)
 
+        if service == 'device':
+            valid_args.remove('ignore_neverpoll')
+
         # In the tests below, we warn when we don't have the exact
         # {service}_{verb} REST function, which prevents us from picking the
         # correct set of args.


### PR DESCRIPTION
## Description

This PR speeds up the network find by avoiding to always compute the status of devices doing the merge with the device table. This happens for each arpnd entry and for each result entry of a given search. That is because the for each arpnd entry, interface get is called and since it computes by default the portmode, it needs the device table to get the device's os and therefore it internally does the merge with the sqpoller table.

The behavior mentioned above is observable when sqpoller entries starts to grow, therefore it's possible when poller runs in continuous mode.
 
## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check


- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
