### PR TITLE
Minor fixes 0.18

### DIFF
--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -274,6 +274,7 @@ class SqCommand(SqPlugin):
         else:
             print(df)
 
+    # pylint: disable=too-many-statements
     def _gen_output(self, df: pd.DataFrame, json_orient: str = "records",
                     dont_strip_cols: bool = False, sort: bool = True):
 
@@ -290,6 +291,9 @@ class SqCommand(SqPlugin):
             else:
                 cols = df.columns.tolist()
             is_error = False
+
+        max_rows = self.ctxt.max_rows
+        all_columns = self.ctxt.all_columns
 
         if dont_strip_cols or not all(item in df.columns for item in cols):
             cols = df.columns.tolist()
@@ -317,9 +321,11 @@ class SqCommand(SqPlugin):
                 'timestamp' not in self.columns and not dont_strip_cols and
                     'timestamp' in df.columns and 'timestamp' in cols):
                 cols.remove('timestamp')
-            with pd.option_context('precision', 3,
-                                   'display.max_colwidth', max_colwidth,
-                                   'display.max_rows', 256):
+            with pd.option_context(
+                    'precision', 3,
+                    'display.max_colwidth', max_colwidth,
+                    'display.max_rows', max_rows,
+                    'display.expand_frame_repr', not all_columns):
                 df = self.sqobj.humanize_fields(df)
                 if df.empty:
                     print(df)

--- a/suzieq/cli/sqcmds/context_commands.py
+++ b/suzieq/cli/sqcmds/context_commands.py
@@ -22,6 +22,11 @@ from suzieq.shared.utils import SUPPORTED_ENGINES, print_version
 @argument("pager", description="Enable pagination prompt on longer outputs",
           choices=['on', 'off'])
 @argument('col_width', description='Max Width of each column in table display')
+@argument('max_rows',
+          description='Max rows to display before ellipsis is shown')
+@argument('all_columns',
+          description='Display all columns wrapping around if necessary',
+          choices=['yes', 'no'])
 @argument(
     "engine",
     choices=SUPPORTED_ENGINES,
@@ -57,6 +62,8 @@ def set_ctxt(
         datadir: str = "",
         debug: str = '',
         col_width: int = 50,
+        max_rows: int = None,
+        all_columns: str = None,
         rest_server_ip: str = "",
         rest_server_port: str = "",
         rest_api_key: str = "",
@@ -92,6 +99,15 @@ def set_ctxt(
 
     if col_width:
         ctxt.col_width = int(col_width)
+
+    if max_rows is not None:
+        if max_rows == 0:
+            ctxt.max_rows = None
+        else:
+            ctxt.max_rows = max_rows
+
+    if all_columns is not None:
+        ctxt.all_columns = all_columns == "yes"
 
     if pager == 'on':
         ctxt.pager = True

--- a/suzieq/config/textfsm_templates/iosxe_show_mac.tfsm
+++ b/suzieq/config/textfsm_templates/iosxe_show_mac.tfsm
@@ -3,8 +3,12 @@ Value Required macaddr (\S+)
 Value Required flags (\w+)
 Value oif (\S+)
 Value protocol (\S+)
+Value _learn (\w+)
+Value age (\d+|-)
+Value List _ports (\S+)
 
 Start
+  ^\* -> WithStar
   ^\s+vlan.*protocol.* -> WithProtocol
   ^\s*${vlan}\s+${macaddr}\s+${flags}\s+${oif}.*$$ -> Record
 
@@ -12,43 +16,8 @@ WithProtocol
   ^\s*${vlan}\s+${macaddr}\s+${flags}\s+${protocol}\s+${oif}.*$$ -> Record
   ^Multicast\s+Entries -> Start
 
-#          Mac Address Table
-#-------------------------------------------
-#
-#Vlan    Mac Address       Type        Ports
-#----    -----------       --------    -----
-# All    0100.0ccc.cccc    STATIC      CPU
-# All    0100.0ccc.cccd    STATIC      CPU
-# All    0180.c200.0000    STATIC      CPU
-# All    0180.c200.0001    STATIC      CPU
-# All    0180.c200.0002    STATIC      CPU
-# All    0180.c200.0003    STATIC      CPU
-# All    0180.c200.0004    STATIC      CPU
-# All    0180.c200.0005    STATIC      CPU
-# All    0180.c200.0006    STATIC      CPU
-# All    0180.c200.0007    STATIC      CPU
-# All    0180.c200.0008    STATIC      CPU
-# All    0180.c200.0009    STATIC      CPU
-# All    0180.c200.000a    STATIC      CPU
-# All    0180.c200.000b    STATIC      CPU
-# All    0180.c200.000c    STATIC      CPU
-# All    0180.c200.000d    STATIC      CPU
-# All    0180.c200.000e    STATIC      CPU
-# All    0180.c200.000f    STATIC      CPU
-# All    0180.c200.0010    STATIC      CPU
-# All    0180.c200.0021    STATIC      CPU
-# All    ffff.ffff.ffff    STATIC      CPU
-#   1    780c.f0e1.1dc3    STATIC      Vl1 
-#  51    0000.1111.2222    STATIC      Vl51 
-#  51    780c.f0e1.1dc6    STATIC      Vl51 
-#1021    0000.0c9f.f45c    STATIC      Vl1021 
-#1021    0002.02cc.0002    STATIC      Gi6/0/2 
-#1021    0002.02cc.0003    STATIC      Gi6/0/3 
-#1021    0002.02cc.0004    STATIC      Gi6/0/4 
-#1021    0002.02cc.0005    STATIC      Gi6/0/5 
-#1021    0002.02cc.0006    STATIC      Gi6/0/6 
-#1021    0002.02cc.0007    STATIC      Gi6/0/7 
-#1021    0002.02cc.0008    STATIC      Gi6/0/8 
-#1021    0002.02cc.0009    STATIC      Gi6/0/9 
-#1021    0002.02cc.000a    STATIC      Gi6/0/10
-#
+WithStar
+  ^\* -> Continue.Record
+  ^\*\s+${vlan}\s+${macaddr}\s+${flags}\s+${_learn}\s+${age}\s+${_ports}
+  ^\s+${_ports}
+  

--- a/suzieq/poller/worker/services/macs.py
+++ b/suzieq/poller/worker/services/macs.py
@@ -160,14 +160,26 @@ class MacsService(Service):
         for entry in processed_data:
             entry['macaddr'] = convert_macaddr_format_to_colon(
                 entry.get('macaddr', '0000.0000.0000'))
+            oiflist = []
             oifs = ''
-            for oif in entry.get('oif', '').split(','):
-                # Handle multicast entries
+            oif = entry.get('oif', '').strip()
+            if oif:
+                oiflist = oif.split(',')
+            if not oiflist:
+                # Some versions of IOS/XE have a different output
+                # format and we capture that in a different var
+                oif = entry.get('_ports', '')
+                if oif:
+                    for ele in oif:
+                        oiflist.extend(ele.split(','))
+            for oif in oiflist:
+                # Handles multicast entries
                 oifs += f'{expand_ios_ifname(oif)} '
             if oifs:
                 entry['oif'] = oifs.strip()
             else:
-                entry['oif'] = expand_ios_ifname(entry['oif'])
+                entry['oif'] = ''
+
             entry['remoteVtepIp'] = ''
             if entry.get('vlan', ' ').strip() == "All":
                 entry['vlan'] = 0

--- a/suzieq/poller/worker/services/vlan.py
+++ b/suzieq/poller/worker/services/vlan.py
@@ -6,6 +6,15 @@ from suzieq.poller.worker.services.service import Service
 class VlanService(Service):
     """Vlan service. Different class because Vlan is not right type for EOS"""
 
+    def clean_json_input(self, data):
+        """evpnVni JSON output is busted across many NOS. Fix it"""
+
+        devtype = data.get("devtype", None)
+        if devtype == 'junos-mx':
+            data['data'] = data['data'].replace('}, \n    }\n', '} \n    }\n')
+
+        return data['data']
+
     def _clean_eos_data(self, processed_data, _):
         '''Massage the interface output'''
 

--- a/suzieq/shared/context.py
+++ b/suzieq/shared/context.py
@@ -18,6 +18,8 @@ class SqContext:
     exec_time: str = ''
     engine: str = None
     col_width: int = 50
+    max_rows: int = 256
+    all_columns: bool = False
     debug: bool = False
     sort_fields: List[str] = field(default_factory=list)
     view: str = None

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -452,7 +452,10 @@ def get_timestamp_from_junos_time(in_data, timestamp: int):
 
 
 def convert_macaddr_format_to_colon(macaddr: str) -> str:
-    """Convert NXOS/EOS . macaddr form to standard : format, lowecase
+    """Convert various macaddr forms to standard ':' format, lowecase
+
+    One unexpected side-effect, it'll convert the given string to lowercase
+    even if it doesn't match a macaddr.
 
     :param macaddr: str, the macaddr string to convert
     :returns: the converted macaddr string or all 0s string if arg not str
@@ -471,15 +474,16 @@ def convert_macaddr_format_to_colon(macaddr: str) -> str:
         if re.match(r'[0-9a-f]{4}:[0-9a-f]{4}:[0-9a-f]{4}', macaddr):
             return (':'.join([f'{x[:2]}:{x[2:]}'
                               for x in macaddr.split(':')]))
-        if re.match(r'[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}', macaddr):
-            return (':'.join([f'{x[:2]}:{x[2:]}'
-                              for x in macaddr.split('-')]))
         if ':' not in macaddr and re.match(r'[0-9a-f]{12}', macaddr):
             newmac = ''
             for i in range(0, 12, 2):
                 newmac += f'{macaddr[i:i+2]}:'
             newmac = newmac[:-1]  # remove the trailing ':'
             return newmac
+        if re.match(r'[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}', macaddr):
+            return (':'.join([f'{x[:2]}:{x[2:]}'
+                              for x in macaddr.split('-')]))
+        return macaddr
 
     return '00:00:00:00:00:00'
 

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -460,11 +460,26 @@ def convert_macaddr_format_to_colon(macaddr: str) -> str:
 
     """
     if isinstance(macaddr, str):
-        if re.match(r'[0-9a-zA-Z]{4}.[0-9a-zA-Z]{4}.[0-9a-zA-Z]{4}', macaddr):
+        macaddr = macaddr.lower()
+        if re.match(r'[0-9a-f]{4}\.[0-9a-f]{4}\.[0-9a-f]{4}', macaddr):
             return (':'.join([f'{x[:2]}:{x[2:]}'
-                              for x in macaddr.split('.')])).lower()
-        else:
-            return macaddr.lower()
+                              for x in macaddr.split('.')]))
+        if re.match(r'[0-9a-f]{2}-[0-9a-f]{2}-[0-9a-f]{2}-'
+                    r'[0-9a-f]{2}-[0-9a-f]{2}-[0-9a-f]{2}',
+                    macaddr):
+            return macaddr.replace('-', ':')
+        if re.match(r'[0-9a-f]{4}:[0-9a-f]{4}:[0-9a-f]{4}', macaddr):
+            return (':'.join([f'{x[:2]}:{x[2:]}'
+                              for x in macaddr.split(':')]))
+        if re.match(r'[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}', macaddr):
+            return (':'.join([f'{x[:2]}:{x[2:]}'
+                              for x in macaddr.split('-')]))
+        if ':' not in macaddr and re.match(r'[0-9a-f]{12}', macaddr):
+            newmac = ''
+            for i in range(0, 12, 2):
+                newmac += f'{macaddr[i:i+2]}:'
+            newmac = newmac[:-1]  # remove the trailing ':'
+            return newmac
 
     return '00:00:00:00:00:00'
 

--- a/tests/unit/test_mac_convert.py
+++ b/tests/unit/test_mac_convert.py
@@ -1,0 +1,25 @@
+from suzieq.shared.utils import convert_macaddr_format_to_colon
+
+
+def test_mac_convert():
+    '''Test all formats of MAC formats being converted to std format'''
+    result = '50:9a:4c:36:a1:df'
+    nullmac = '00:00:00:00:00:00'
+
+    assert convert_macaddr_format_to_colon('509A:4C36:A1DF') == result, \
+        'failed to convert 509A:4C36:A1DF'
+
+    assert convert_macaddr_format_to_colon('509A.4C36.A1DF') == result, \
+        'failed to convert 509A.4C36.A1DF'
+
+    assert convert_macaddr_format_to_colon('509A-4C36-A1DF') == result, \
+        'failed to convert 509A.4C36.A1DF'
+
+    assert convert_macaddr_format_to_colon('509A4C36A1DF') == result, \
+        'failed to convert 509A4C36A1DF'
+
+    assert convert_macaddr_format_to_colon('50-9A-4C-36-A1-DF') == result, \
+        'failed to convert 50-9A-4C-36-A1-DF'
+
+    assert convert_macaddr_format_to_colon('50-9Z-4C-36-A1-DF') == nullmac, \
+        'Incorrect conversion of 50-9Z-4C-36-A1-DF'

--- a/tests/unit/test_mac_convert.py
+++ b/tests/unit/test_mac_convert.py
@@ -21,5 +21,15 @@ def test_mac_convert():
     assert convert_macaddr_format_to_colon('50-9A-4C-36-A1-DF') == result, \
         'failed to convert 50-9A-4C-36-A1-DF'
 
-    assert convert_macaddr_format_to_colon('50-9Z-4C-36-A1-DF') == nullmac, \
+    assert convert_macaddr_format_to_colon(
+        '50-9Z-4C-36-A1-DF') == '50-9z-4c-36-a1-df', \
         'Incorrect conversion of 50-9Z-4C-36-A1-DF'
+
+    assert convert_macaddr_format_to_colon(result) == result, \
+        f'Failed to return {result} as is'
+
+    assert convert_macaddr_format_to_colon(1) == nullmac, \
+        f'Incorrect handling when int is passed'
+
+    assert convert_macaddr_format_to_colon([1]) == nullmac, \
+        f'Incorrect handling when list is passed'


### PR DESCRIPTION
This fixes a bunch of minor issues in 0.18:

- Some IOS versions have a different MAC output than the textfsm parser was handling. Fixed this
- Added support for displaying all rows and full column width  