### PR TITLE
sq-poller: fix blacklisted services not actually disabled

### DIFF
--- a/suzieq/poller/worker/services/service_manager.py
+++ b/suzieq/poller/worker/services/service_manager.py
@@ -146,8 +146,9 @@ class ServiceManager:
             )
 
         svcs = list(Path(service_directory).glob('*.yml'))
-        allsvcs = [os.path.basename(x).split('.')[0] for x in svcs
-                   if x not in BLACKLIST_SERVICES]
+        allsvcs = [s_name for s in svcs
+                   if (s_name := os.path.basename(s).split('.')[0])
+                   not in BLACKLIST_SERVICES]
         svclist = None
 
         if service_only:


### PR DESCRIPTION
## Description

Fix blacklisted services which were actually being executed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

['ifCounters', 'topmem', 'topcpu'] services are now not executed
