### PR TITLE
interface unique fails with vlan filter

### DIFF
--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -56,8 +56,8 @@ class InterfacesObj(SqPandasEngine):
         if df.empty:
             return df
 
-        if portmode or any(x in fields
-                           for x in ['vlan', 'vlanList', 'portmode']):
+        if vlan or portmode or any(x in fields
+                                   for x in ['vlan', 'vlanList', 'portmode']):
             for x in ['ipAddressList', 'ip6AddressList']:
                 if x in columns or '*' in columns:
                     continue

--- a/tests/integration/sqcmds/cumulus-samples/interface.yml
+++ b/tests/integration/sqcmds/cumulus-samples/interface.yml
@@ -3667,3 +3667,19 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface assert cumulus
   output: '[]'
+- command: interface unique --columns=hostname --vlan='13 24' --namespace=ospf-ibgp
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique cumulus
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf04"}]'
+- command: interface unique --columns=hostname --vlan='24' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique cumulus
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf04"}]'
+- command: interface unique --columns=hostname --vlan='540' --namespace=ospf-ibgp
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique cumulus
+  output: '[]'

--- a/tests/integration/sqcmds/eos-samples/interface.yml
+++ b/tests/integration/sqcmds/eos-samples/interface.yml
@@ -1011,3 +1011,21 @@ tests:
     "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
     "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
     1623025176024}]'
+- command: interface unique --columns=hostname --vlan=10 --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique eos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}]'
+- command: interface unique --columns=hostname --vlan='10 20' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique eos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf04"}]'
+- command: interface unique --columns=hostname --vlan='30' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique eos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf04"}]'
+- command: interface unique --columns=hostname --vlan='540' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique eos
+  output: '[]'

--- a/tests/integration/sqcmds/junos-samples/interface.yml
+++ b/tests/integration/sqcmds/junos-samples/interface.yml
@@ -3271,3 +3271,19 @@ tests:
     {"namespace": "junos", "hostname": "leaf01", "ifname": "jsrv", "state": "up",
     "adminState": "up", "type": "internal", "mtu": 1514, "vlan": 0, "master": "",
     "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025803099}]'
+- command: interface unique --columns=hostname --vlan=10 --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique junos
+  output: '[{"hostname": "leaf01"}]'
+- command: interface unique --columns=hostname --vlan='10 20' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique junos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}]'
+- command: interface unique --columns=hostname --vlan='30' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique junos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}]'
+- command: interface unique --columns=hostname --vlan='540' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique junos
+  output: '[]'

--- a/tests/integration/sqcmds/nxos-samples/interface.yml
+++ b/tests/integration/sqcmds/nxos-samples/interface.yml
@@ -2662,3 +2662,21 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface show nxos
   output: '[]'
+- command: interface unique --columns=hostname --vlan=10 --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique nxos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}]'
+- command: interface unique --columns=hostname --vlan='10 20' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique nxos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf04"}]'
+- command: interface unique --columns=hostname --vlan='30' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique nxos
+  output: '[{"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"},
+    {"hostname": "leaf04"}]'
+- command: interface unique --columns=hostname --vlan='540' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique nxos
+  output: '[]'


### PR DESCRIPTION
If the user specified unique with a VLAN filter, we'd crash because we weren't filling out a specific field. I suspect we may have a few more of these across the tables to check. 