### PR TITLE
Port enterprise 1.1.1 fixes

### DIFF
--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -277,7 +277,8 @@ class SqCommand(SqPlugin):
     def _gen_output(self, df: pd.DataFrame, json_orient: str = "records",
                     dont_strip_cols: bool = False, sort: bool = True):
 
-        if 'error' in df.columns:
+        if ('error' in df.columns or
+                ('hopError' in df.columns and (df.hopError != '').all())):
             retcode = 1
             max_colwidth = None
             cols = df.columns.tolist()

--- a/suzieq/config/schema/path.avsc
+++ b/suzieq/config/schema/path.avsc
@@ -122,6 +122,12 @@
             "description": "IP address of routing nexthop"
         },
         {
+            "name": "hopError",
+            "type": "string",
+            "display": 15,
+            "description": "Hop-specific error such as MTU mismatch"
+        },
+        {
             "name": "timestamp",
             "type": "timestamp",
             "display": 17

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -318,14 +318,14 @@ class OspfObj(SqPandasEngine):
             left_on=["namespace", "hostname", "ifname"],
             right_on=["namespace", "peerHostname", "peerIfname"]) \
             .rename(columns={'assertReason_x': 'assertReason'}) \
-            .dropna(subset=['ipAddress_x', 'index_x', 'ipAddress_y']) \
+            .dropna(subset=['ipAddress_x', 'ipAddress_y']) \
             .fillna({'isUnnumbered_y': False})
 
         if peer_df.empty:
             # We're unable to find a peer but the sessions have failed
             failed_df['assertReason'] = failed_df.apply(
-                lambda x: 'Loopback not configured passive'
-                if x['networkType'] == 'loopback' else 'No Peer Found',
+                lambda x: ['Loopback not configured passive']
+                if x['networkType'] == 'loopback' else ['No Peer Found'],
                 axis=1)
 
             return self._create_aver_result([ok_df, ifdown_df, failed_df],
@@ -550,6 +550,4 @@ class OspfObj(SqPandasEngine):
 
         return ospf_df[['namespace', 'hostname', 'vrf', 'ifname', 'adjState',
                         'assertReason', 'result']] \
-            .explode('assertReason') \
-            .fillna('') \
             .reset_index(drop=True)

--- a/suzieq/engines/pandas/path.py
+++ b/suzieq/engines/pandas/path.py
@@ -870,8 +870,10 @@ class PathObj(SqPandasEngine):
                         if dst_mtu > MAX_MTU:
                             dst_mtu = copy_dest.get('mtu', 0)
                         if dst_mtu != src_mtu:
-                            if 'Dst MTU != Src MTU' not in copy_dest['hopError']:
-                                copy_dest['hopError'].append('Dst MTU != Src MTU')
+                            if ('Dst MTU != Src MTU' not in
+                                    copy_dest['hopError']):
+                                copy_dest['hopError']\
+                                    .append('Dst MTU != Src MTU')
                         # This is weird because we have no room to store the
                         # prev hop's outgoing IIF MTU on the last hop
                         copy_dest['outMtu'] = \
@@ -897,8 +899,10 @@ class PathObj(SqPandasEngine):
                         if dst_mtu > MAX_MTU:
                             dst_mtu = copy_dest.get('mtu', 0)
                         if dst_mtu != src_mtu:
-                            if 'Dst MTU != Src MTU' not in copy_dest['hopError']:
-                                copy_dest['hopError'].append('Dst MTU != Src MTU')
+                            if ('Dst MTU != Src MTU' not in
+                                    copy_dest['hopError']):
+                                copy_dest['hopError']\
+                                    .append('Dst MTU != Src MTU')
                         # This is weird because we have no room to store the
                         # prev hop's outgoing IIF MTU on the last hop
                         copy_dest['outMtu'] = \
@@ -1026,7 +1030,8 @@ class PathObj(SqPandasEngine):
                         devices_iifs[devkey]['protocol'] = protocol
                     if not rt_ts:
                         devices_iifs[devkey]['timestamp'] = timestamp
-                    if errmsg and errmsg not in devices_iifs[devkey]['hopError']:
+                    if (errmsg and
+                            errmsg not in devices_iifs[devkey]['hopError']):
                         devices_iifs[devkey]['hopError'].append(errmsg)
 
                     if iface is not None:

--- a/suzieq/engines/rest/engineobj.py
+++ b/suzieq/engines/rest/engineobj.py
@@ -74,7 +74,8 @@ class SqRestEngine(SqEngineObj):
                                               self.iobj.namespace),
                       'hostname': kwargs.get('hostname', self.iobj.hostname)}
         kwargs.update(cmd_params)
-        kwargs = {k: v for k, v in kwargs.items() if v}
+        # Cannot drop values which are equal to 0 or False
+        kwargs = {k: v for k, v in kwargs.items() if v or v in [0, False]}
 
         query_params = urllib.parse.urlencode(kwargs, doseq=True)
 

--- a/suzieq/poller/controller/controller.py
+++ b/suzieq/poller/controller/controller.py
@@ -107,6 +107,14 @@ class Controller:
                     f'{self._input_dir} is not a valid directory'
                 )
 
+        # Get the maximum number of commands per second
+        max_cmd_pipeline = self._config.get('max-cmd-pipeline', 0)
+        if ((max_cmd_pipeline != 0) and
+                (max_cmd_pipeline % self._n_workers != 0)):
+            raise SqPollerConfError(
+                f'max-cmd-pipeline ({max_cmd_pipeline}) has to be a '
+                f'multiple of the number of worker ({self._n_workers})')
+
         source_args = {'single-run-mode': self._single_run_mode,
                        'path': inventory_file}
 
@@ -118,6 +126,7 @@ class Controller:
                         'no-coalescer': self._no_coalescer,
                         'output-dir': args.output_dir,
                         'outputs': args.outputs,
+                        'max-cmd-pipeline': max_cmd_pipeline,
                         # `single-run-mode` and `run-once` are different.
                         # The former is an internal variable telling the
                         # poller if it should run and terminate, the other

--- a/suzieq/poller/controller/manager/static.py
+++ b/suzieq/poller/controller/manager/static.py
@@ -42,15 +42,8 @@ class StaticManager(Manager, InventoryAsyncPlugin):
         self._workers_count = config_data.get("workers", 1)
 
         # We need a pipeline thats at least as big as the number of workers
-        self._max_cmd_pipeline = config_data['config-dict'] \
-            .get('poller', {}) \
-            .get('max-cmd-pipeline', 0)
-        if ((self._max_cmd_pipeline != 0) and
-                (self._max_cmd_pipeline % self._workers_count != 0)):
-            raise SqPollerConfError(
-                f'max-cmd-pipeline ({self._max_cmd_pipeline}) has to be a '
-                'multiple of be a multiple of the number of worker '
-                f'({self._workers_count})')
+        # We need a pipeline that is at least as big as the number of workers
+        self._max_cmd_pipeline = config_data.get('max-cmd-pipeline', 0)
 
         if self._max_cmd_pipeline:
             worker_cmd = int(self._max_cmd_pipeline / self._workers_count)

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -14,7 +14,6 @@ import asyncio
 from asyncio.subprocess import PIPE, DEVNULL
 # pylint: disable=redefined-builtin
 from concurrent.futures._base import TimeoutError
-from contextlib import asynccontextmanager
 
 from packaging import version as version_parse
 import xmltodict
@@ -113,9 +112,7 @@ class Node:
                                           or 0) + 1
         self._retry = self._max_retries_on_auth_fail
         self._discovery_lock = asyncio.Lock()
-        self._cmd_sem = kwargs.get('cmd_sem', None)
-        self._cmd_mutex = kwargs.get('cmd_mutex', None)
-        self._cmd_pacer_sleep = kwargs.get('cmd_pacer_sleep', None)
+        self._cmd_pacer = kwargs.get('cmd_pacer')
         self.per_cmd_auth = kwargs.get('per_cmd_auth', True)
 
         self.address = kwargs["address"]
@@ -154,7 +151,7 @@ class Node:
         self.ignore_known_hosts = kwargs.get('ignore_known_hosts', False)
         self.slow_host = kwargs.get('slow_host', False)
         # Number of commands to issue in parallel
-        if self._cmd_sem:
+        if self._cmd_pacer.max_cmds:
             # Limit the num of parallel cmds we can issue when we have limits
             self.batch_size = 1
         else:
@@ -244,37 +241,6 @@ class Node:
     def is_connected(self):
         '''Is there connectivity to the device at the transport level'''
         return self._conn is not None
-
-    @asynccontextmanager
-    async def cmd_pacer(self, use_sem: bool = True):
-        '''Context Manager to implement throttling of commands.
-
-        In many networks, backend authentication servers such as TACACS which
-        handle authentication of logins and even command execution, cannot
-        large volumes of authentication requests. Thanks to our use of
-        asyncio, we can easily sends hundreds of connection requests to such
-        servers, which effectively turns into authentication failures. To
-        handle this, we add a user-specified maximum of rate of cmds/sec
-        that the authentication can handle, and we pace it out. This code
-        implements that pacer.
-
-        Some networks communicate with a backend authentication server only
-        on login while others contact it for authorization of a command as
-        well. Its to handle this difference that we pass use_sem. Users set
-        the per_cmd_auth to True if authorization is used. The caller of this
-        function sets the use_sem apppropriately depending on when the context
-        is invoked.
-
-        Args:
-          use_sem(bool): True if you want to use the pacer
-        '''
-        if self._cmd_sem and use_sem:
-            async with self._cmd_sem:
-                async with self._cmd_mutex:
-                    await asyncio.sleep(self._cmd_pacer_sleep)
-                yield
-        else:
-            yield
 
     def _decrypt_pvtkey(self, pvtkey_file: str, passphrase: str) -> str:
         """Decrypt private key file"""
@@ -658,7 +624,7 @@ class Node:
                         self.ssh_ready.release()
                     return
 
-            async with self.cmd_pacer():
+            async with self._cmd_pacer.wait():
                 try:
                     if self._tunnel:
                         self._conn = await self._tunnel.connect_ssh(
@@ -809,7 +775,7 @@ class Node:
             cb_token.node_token = self.bootupTimestamp
 
         timeout = timeout or self.cmd_timeout
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             for cmd in cmd_list:
                 try:
                     output = await asyncio.wait_for(self._conn.run(cmd),
@@ -1180,7 +1146,7 @@ class EosNode(Node):
         output = []
         status = 200  # status OK
 
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             try:
                 async with aiohttp.ClientSession(
                         auth=auth, conn_timeout=self.connect_timeout,
@@ -1327,7 +1293,7 @@ class CumulusNode(Node):
         url = "https://{0}:{1}/nclu/v1/rpc".format(self.address, self.port)
         headers = {"Content-Type": "application/json"}
 
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             try:
                 async with aiohttp.ClientSession(
                         auth=auth, timeout=self.cmd_timeout,
@@ -1352,7 +1318,7 @@ class CumulusNode(Node):
         url = "https://{0}:{1}/nclu/v1/rpc".format(self.address, self.port)
         headers = {"Content-Type": "application/json"}
 
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             try:
                 async with aiohttp.ClientSession(
                         auth=auth,
@@ -1542,7 +1508,7 @@ class IosXENode(Node):
         if self.is_connected and not self._stdin:
             self.logger.info(
                 f'Trying to create Persistent SSH for {self.hostname}')
-            async with self.cmd_pacer(self.per_cmd_auth):
+            async with self._cmd_pacer.wait(self.per_cmd_auth):
                 try:
                     self._stdin, self._stdout, self._stderr = \
                         await self._conn.open_session(term_type='xterm')
@@ -1679,7 +1645,7 @@ class IosXENode(Node):
             return
 
         timeout = timeout or self.cmd_timeout
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             for cmd in cmd_list:
                 try:
                     if self.slow_host:
@@ -1908,7 +1874,7 @@ class PanosNode(Node):
         try:
             res = []
             # temporary hack to detect device info using ssh
-            async with self.cmd_pacer():
+            async with self._cmd_pacer.wait():
                 async with asyncssh.connect(
                         self.address, port=22, username=self.username,
                         password=self.password, known_hosts=None) as conn:
@@ -1951,7 +1917,7 @@ class PanosNode(Node):
 
         if not self._retry:
             return
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             async with self._session.get(url, timeout=self.connect_timeout) \
                     as response:
                 status, xml = response.status, await response.text()
@@ -2012,7 +1978,7 @@ class PanosNode(Node):
     async def _init_rest(self):
         # In case of PANOS, getting here means REST is up
         if not self._session:
-            async with self.cmd_pacer(self.per_cmd_auth):
+            async with self._cmd_pacer.wait(self.per_cmd_auth):
                 try:
                     self._session = aiohttp.ClientSession(
                         conn_timeout=self.connect_timeout,
@@ -2057,7 +2023,7 @@ class PanosNode(Node):
             await service_callback(result, cb_token)
             return
 
-        async with self.cmd_pacer(self.per_cmd_auth):
+        async with self._cmd_pacer.wait(self.per_cmd_auth):
             try:
                 for cmd in cmd_list:
                     url_cmd = f"{url}?type=op&cmd={cmd}&key={self.api_key}"

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -401,32 +401,34 @@ tests:
   data-directory: tests/data/eos/parquet-out/
   marks: path describe
   output: '[{"name": "hopCount", "type": "long", "key": "", "display": 2, "description":
-    "unique hop within a path, can be L2 or L3 path"}, {"name": "hostname", "type":
-    "string", "key": "", "display": 4, "description": "hostname associated with this
-    hop"}, {"name": "iif", "type": "string", "key": "", "display": 5, "description":
-    "incoming interface on the host"}, {"name": "inMtu", "type": "long", "key": "",
-    "display": 11, "description": "MTU of the incoming interface"}, {"name": "ipLookup",
-    "type": "string", "key": "", "display": 14, "description": "address used to lookup
-    routing table for nexthop"}, {"name": "isL2", "type": "boolean", "key": "", "display":
-    8, "description": "True if this is an L2 hop"}, {"name": "macLookup", "type":
-    "string", "key": "", "display": 16, "description": "MAC address used to lookup
-    for L2 nexthop"}, {"name": "mtuMatch", "type": "boolean", "key": "", "display":
-    10, "description": "True if the MTU of peering interfaces match"}, {"name": "namespace",
-    "type": "string", "key": "", "display": 3, "description": "namespace within which
-    path analysis is run"}, {"name": "nexthopIp", "type": "string", "key": "", "display":
-    14, "description": "IP address of routing nexthop"}, {"name": "oif", "type": "string",
-    "key": "", "display": 6, "description": "incoming interface on the host"}, {"name":
-    "outMtu", "type": "long", "key": "", "display": 12, "description": "MTU of the
-    outgoing interface"}, {"name": "overlay", "type": "boolean", "key": "", "display":
-    9, "description": "True if packet is tunneled"}, {"name": "pathid", "type": "long",
-    "key": "", "display": 1, "description": "identifies each unique path"}, {"name":
-    "protocol", "type": "string", "key": "", "display": 13, "description": "protocol
-    used to populate used route"}, {"name": "sqvers", "type": "string", "key": "",
-    "display": "", "description": "Schema version, not selectable"}, {"name": "timestamp",
-    "type": "timestamp", "key": "", "display": 17, "description": ""}, {"name": "vrf",
-    "type": "string", "key": "", "display": 7, "description": "VRF used to do lookup,
-    ignored on L2 hop"}, {"name": "vtepLookup", "type": "string", "key": "", "display":
-    15, "description": "vtep IP address used to lookup underlay route"}]'
+    "unique hop within a path, can be L2 or L3 path"}, {"name": "hopError", "type":
+    "string", "key": "", "display": 15, "description": "Hop-specific error such as
+    MTU mismatch"}, {"name": "hostname", "type": "string", "key": "", "display": 4,
+    "description": "hostname associated with this hop"}, {"name": "iif", "type": "string",
+    "key": "", "display": 5, "description": "incoming interface on the host"}, {"name":
+    "inMtu", "type": "long", "key": "", "display": 11, "description": "MTU of the
+    incoming interface"}, {"name": "ipLookup", "type": "string", "key": "", "display":
+    14, "description": "address used to lookup routing table for nexthop"}, {"name":
+    "isL2", "type": "boolean", "key": "", "display": 8, "description": "True if this
+    is an L2 hop"}, {"name": "macLookup", "type": "string", "key": "", "display":
+    16, "description": "MAC address used to lookup for L2 nexthop"}, {"name": "mtuMatch",
+    "type": "boolean", "key": "", "display": 10, "description": "True if the MTU of
+    peering interfaces match"}, {"name": "namespace", "type": "string", "key": "",
+    "display": 3, "description": "namespace within which path analysis is run"}, {"name":
+    "nexthopIp", "type": "string", "key": "", "display": 14, "description": "IP address
+    of routing nexthop"}, {"name": "oif", "type": "string", "key": "", "display":
+    6, "description": "incoming interface on the host"}, {"name": "outMtu", "type":
+    "long", "key": "", "display": 12, "description": "MTU of the outgoing interface"},
+    {"name": "overlay", "type": "boolean", "key": "", "display": 9, "description":
+    "True if packet is tunneled"}, {"name": "pathid", "type": "long", "key": "", "display":
+    1, "description": "identifies each unique path"}, {"name": "protocol", "type":
+    "string", "key": "", "display": 13, "description": "protocol used to populate
+    used route"}, {"name": "sqvers", "type": "string", "key": "", "display": "", "description":
+    "Schema version, not selectable"}, {"name": "timestamp", "type": "timestamp",
+    "key": "", "display": 17, "description": ""}, {"name": "vrf", "type": "string",
+    "key": "", "display": 7, "description": "VRF used to do lookup, ignored on L2
+    hop"}, {"name": "vtepLookup", "type": "string", "key": "", "display": 15, "description":
+    "vtep IP address used to lookup underlay route"}]'
 - command: ospf describe --format=json
   data-directory: tests/data/eos/parquet-out/
   marks: ospf describe

--- a/tests/integration/sqcmds/cumulus-samples/evpnVni.yml
+++ b/tests/integration/sqcmds/cumulus-samples/evpnVni.yml
@@ -136,64 +136,100 @@ tests:
     {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}]'
 - command: evpnVni assert --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24, "type": "L2",
+      "vrf": "evpn-vrf", "macaddr": "36:98:6e:0c:42:ae", "timestamp": 1616644822033,
+      "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast
+      MAC not unique across VNI"]}, {"namespace": "dual-evpn", "hostname": "exit02",
+      "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "36:98:6e:0c:42:ae",
+      "timestamp": 1616644822033, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822033, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 24, "type": "L2", "vrf":
+      "default", "macaddr": "44:38:39:00:00:33", "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001,
+      "type": "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname":
+      "leaf04", "vni": 13, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:33",
+      "timestamp": 1616644822167, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "leaf03", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822167, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 13, "type": "L2", "vrf":
+      "default", "macaddr": "44:38:39:00:00:51", "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24, "type":
+      "L2", "vrf": "default", "macaddr": "44:38:39:00:00:51", "timestamp": 1616644822167,
+      "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast
+      MAC not unique across VNI"]}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "vni": 24, "type": "L2", "vrf": "evpn-vrf", "macaddr": "26:75:f3:1b:fb:ca",
+      "timestamp": 1616644822168, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822168, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "exit01", "vni": 13, "type": "L2", "vrf":
+      "evpn-vrf", "macaddr": "26:75:f3:1b:fb:ca", "timestamp": 1616644822168, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001,
+      "type": "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822169, "result":
+      "fail", "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname":
+      "leaf01", "vni": 13, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:41",
+      "timestamp": 1616644822169, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "vni": 24, "type": "L2", "vrf": "default", "macaddr":
+      "44:38:39:00:00:41", "timestamp": 1616644822169, "result": "fail", "assertReason":
+      ["Inconsistent VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace":
+      "dual-evpn", "hostname": "leaf02", "vni": 13, "type": "L2", "vrf": "default",
+      "macaddr": "44:38:39:00:00:58", "timestamp": 1616644822253, "result": "fail",
+      "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique across
+      VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001, "type":
+      "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822253, "result": "fail",
+      "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "vni": 24, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:58", "timestamp":
+      1616644822253, "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping",
+      "anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf03", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:95",
+      "timestamp": 1616681581879, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni":
+      13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "52:54:00:30:f2:82", "timestamp":
+      1616681581879, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24, "type":
+      "L2", "vrf": "evpn-vrf", "macaddr": "52:54:00:30:f2:82", "timestamp": 1616681581879,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "vni": 24, "type": "L2", "vrf": "evpn-vrf",
+      "macaddr": "52:54:00:33:b7:b8", "timestamp": 1616681581987, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf02", "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+      "52:54:00:33:b7:b8", "timestamp": 1616681581987, "result": "fail", "assertReason":
+      ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf02", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:94",
+      "timestamp": 1616681581987, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni":
+      104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "92:0d:55:8d:b5:41", "timestamp":
+      1616681582166, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24, "type":
+      "L2", "vrf": "evpn-vrf", "macaddr": "48:47:00:e9:d5:41", "timestamp": 1616681582386,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf04", "vni": 104001, "type": "L3", "vrf": "evpn-vrf",
+      "macaddr": "44:39:39:ff:40:95", "timestamp": 1616681582386, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+      "48:47:00:e9:d5:41", "timestamp": 1616681582386, "result": "fail", "assertReason":
+      ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "exit02", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "ea:c9:a5:5f:c7:ca",
+      "timestamp": 1616681582523, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni":
+      13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "48:47:00:e9:d5:47", "timestamp":
+      1616681582726, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 104001, "type":
+      "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:94", "timestamp": 1616681582726,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "vni": 24, "type": "L2", "vrf": "evpn-vrf",
+      "macaddr": "48:47:00:e9:d5:47", "timestamp": 1616681582726, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}]'
   marks: evpnVni assert cumulus
-  output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24.0, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822033}, {"namespace":
-    "dual-evpn", "hostname": "exit02", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822168}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822169},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822253}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822253},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616681581879},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "vni": 104001.0, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1616681581987}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582166},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681582386}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582523},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681582726}]'
 - command: evpnVni show --columns='hostname vni' --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
@@ -317,129 +353,201 @@ tests:
     ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: evpnVni assert cumulus
-  output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24.0, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822033}, {"namespace":
-    "dual-evpn", "hostname": "exit02", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822168}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822169},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822253}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822253},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616681581879},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "vni": 104001.0, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1616681581987}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582166},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681582386}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582523},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681582726}]'
+  output: '[]'
 - command: evpnVni assert --result=fail --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24, "type": "L2",
+      "vrf": "evpn-vrf", "macaddr": "36:98:6e:0c:42:ae", "timestamp": 1616644822033,
+      "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast
+      MAC not unique across VNI"]}, {"namespace": "dual-evpn", "hostname": "exit02",
+      "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "36:98:6e:0c:42:ae",
+      "timestamp": 1616644822033, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822033, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 24, "type": "L2", "vrf":
+      "default", "macaddr": "44:38:39:00:00:33", "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001,
+      "type": "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname":
+      "leaf04", "vni": 13, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:33",
+      "timestamp": 1616644822167, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "leaf03", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822167, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 13, "type": "L2", "vrf":
+      "default", "macaddr": "44:38:39:00:00:51", "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24, "type":
+      "L2", "vrf": "default", "macaddr": "44:38:39:00:00:51", "timestamp": 1616644822167,
+      "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast
+      MAC not unique across VNI"]}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "vni": 24, "type": "L2", "vrf": "evpn-vrf", "macaddr": "26:75:f3:1b:fb:ca",
+      "timestamp": 1616644822168, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822168, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "exit01", "vni": 13, "type": "L2", "vrf":
+      "evpn-vrf", "macaddr": "26:75:f3:1b:fb:ca", "timestamp": 1616644822168, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001,
+      "type": "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822169, "result":
+      "fail", "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname":
+      "leaf01", "vni": 13, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:41",
+      "timestamp": 1616644822169, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "vni": 24, "type": "L2", "vrf": "default", "macaddr":
+      "44:38:39:00:00:41", "timestamp": 1616644822169, "result": "fail", "assertReason":
+      ["Inconsistent VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace":
+      "dual-evpn", "hostname": "leaf02", "vni": 13, "type": "L2", "vrf": "default",
+      "macaddr": "44:38:39:00:00:58", "timestamp": 1616644822253, "result": "fail",
+      "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique across
+      VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001, "type":
+      "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822253, "result": "fail",
+      "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "vni": 24, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:58", "timestamp":
+      1616644822253, "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping",
+      "anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf03", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:95",
+      "timestamp": 1616681581879, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni":
+      13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "52:54:00:30:f2:82", "timestamp":
+      1616681581879, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24, "type":
+      "L2", "vrf": "evpn-vrf", "macaddr": "52:54:00:30:f2:82", "timestamp": 1616681581879,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "vni": 24, "type": "L2", "vrf": "evpn-vrf",
+      "macaddr": "52:54:00:33:b7:b8", "timestamp": 1616681581987, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf02", "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+      "52:54:00:33:b7:b8", "timestamp": 1616681581987, "result": "fail", "assertReason":
+      ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf02", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:94",
+      "timestamp": 1616681581987, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni":
+      104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "92:0d:55:8d:b5:41", "timestamp":
+      1616681582166, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24, "type":
+      "L2", "vrf": "evpn-vrf", "macaddr": "48:47:00:e9:d5:41", "timestamp": 1616681582386,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf04", "vni": 104001, "type": "L3", "vrf": "evpn-vrf",
+      "macaddr": "44:39:39:ff:40:95", "timestamp": 1616681582386, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+      "48:47:00:e9:d5:41", "timestamp": 1616681582386, "result": "fail", "assertReason":
+      ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "exit02", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "ea:c9:a5:5f:c7:ca",
+      "timestamp": 1616681582523, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni":
+      13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "48:47:00:e9:d5:47", "timestamp":
+      1616681582726, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 104001, "type":
+      "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:94", "timestamp": 1616681582726,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "vni": 24, "type": "L2", "vrf": "evpn-vrf",
+      "macaddr": "48:47:00:e9:d5:47", "timestamp": 1616681582726, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}]'
   marks: evpnVni assert cumulus
-  output: '[]'
 - command: evpnVni assert --result=all --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
+  error:
+    error: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24, "type": "L2",
+      "vrf": "evpn-vrf", "macaddr": "36:98:6e:0c:42:ae", "timestamp": 1616644822033,
+      "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast
+      MAC not unique across VNI"]}, {"namespace": "dual-evpn", "hostname": "exit02",
+      "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "36:98:6e:0c:42:ae",
+      "timestamp": 1616644822033, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "exit02", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822033, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 24, "type": "L2", "vrf":
+      "default", "macaddr": "44:38:39:00:00:33", "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001,
+      "type": "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname":
+      "leaf04", "vni": 13, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:33",
+      "timestamp": 1616644822167, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "leaf03", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822167, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 13, "type": "L2", "vrf":
+      "default", "macaddr": "44:38:39:00:00:51", "timestamp": 1616644822167, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24, "type":
+      "L2", "vrf": "default", "macaddr": "44:38:39:00:00:51", "timestamp": 1616644822167,
+      "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast
+      MAC not unique across VNI"]}, {"namespace": "dual-evpn", "hostname": "exit01",
+      "vni": 24, "type": "L2", "vrf": "evpn-vrf", "macaddr": "26:75:f3:1b:fb:ca",
+      "timestamp": 1616644822168, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "exit01", "vni": 104001, "type": "L3", "vrf": null, "macaddr": null,
+      "timestamp": 1616644822168, "result": "fail", "assertReason": ["vni down"]},
+      {"namespace": "dual-evpn", "hostname": "exit01", "vni": 13, "type": "L2", "vrf":
+      "evpn-vrf", "macaddr": "26:75:f3:1b:fb:ca", "timestamp": 1616644822168, "result":
+      "fail", "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique
+      across VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001,
+      "type": "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822169, "result":
+      "fail", "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname":
+      "leaf01", "vni": 13, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:41",
+      "timestamp": 1616644822169, "result": "fail", "assertReason": ["Inconsistent
+      VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace": "dual-evpn",
+      "hostname": "leaf01", "vni": 24, "type": "L2", "vrf": "default", "macaddr":
+      "44:38:39:00:00:41", "timestamp": 1616644822169, "result": "fail", "assertReason":
+      ["Inconsistent VNI-VRF mapping", "anycast MAC not unique across VNI"]}, {"namespace":
+      "dual-evpn", "hostname": "leaf02", "vni": 13, "type": "L2", "vrf": "default",
+      "macaddr": "44:38:39:00:00:58", "timestamp": 1616644822253, "result": "fail",
+      "assertReason": ["Inconsistent VNI-VRF mapping", "anycast MAC not unique across
+      VNI"]}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001, "type":
+      "L3", "vrf": null, "macaddr": null, "timestamp": 1616644822253, "result": "fail",
+      "assertReason": ["vni down"]}, {"namespace": "dual-evpn", "hostname": "leaf02",
+      "vni": 24, "type": "L2", "vrf": "default", "macaddr": "44:38:39:00:00:58", "timestamp":
+      1616644822253, "result": "fail", "assertReason": ["Inconsistent VNI-VRF mapping",
+      "anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf03", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:95",
+      "timestamp": 1616681581879, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni":
+      13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "52:54:00:30:f2:82", "timestamp":
+      1616681581879, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24, "type":
+      "L2", "vrf": "evpn-vrf", "macaddr": "52:54:00:30:f2:82", "timestamp": 1616681581879,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf02", "vni": 24, "type": "L2", "vrf": "evpn-vrf",
+      "macaddr": "52:54:00:33:b7:b8", "timestamp": 1616681581987, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf02", "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+      "52:54:00:33:b7:b8", "timestamp": 1616681581987, "result": "fail", "assertReason":
+      ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "leaf02", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:94",
+      "timestamp": 1616681581987, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni":
+      104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "92:0d:55:8d:b5:41", "timestamp":
+      1616681582166, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24, "type":
+      "L2", "vrf": "evpn-vrf", "macaddr": "48:47:00:e9:d5:41", "timestamp": 1616681582386,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf04", "vni": 104001, "type": "L3", "vrf": "evpn-vrf",
+      "macaddr": "44:39:39:ff:40:95", "timestamp": 1616681582386, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp",
+      "hostname": "leaf04", "vni": 13, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+      "48:47:00:e9:d5:41", "timestamp": 1616681582386, "result": "fail", "assertReason":
+      ["anycast MAC not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname":
+      "exit02", "vni": 104001, "type": "L3", "vrf": "evpn-vrf", "macaddr": "ea:c9:a5:5f:c7:ca",
+      "timestamp": 1616681582523, "result": "fail", "assertReason": ["anycast MAC
+      not unique across VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni":
+      13, "type": "L2", "vrf": "evpn-vrf", "macaddr": "48:47:00:e9:d5:47", "timestamp":
+      1616681582726, "result": "fail", "assertReason": ["anycast MAC not unique across
+      VNI"]}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 104001, "type":
+      "L3", "vrf": "evpn-vrf", "macaddr": "44:39:39:ff:40:94", "timestamp": 1616681582726,
+      "result": "fail", "assertReason": ["anycast MAC not unique across VNI"]}, {"namespace":
+      "ospf-ibgp", "hostname": "leaf01", "vni": 24, "type": "L2", "vrf": "evpn-vrf",
+      "macaddr": "48:47:00:e9:d5:47", "timestamp": 1616681582726, "result": "fail",
+      "assertReason": ["anycast MAC not unique across VNI"]}]'
   marks: evpnVni assert cumulus
-  output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vni": 24.0, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822033}, {"namespace":
-    "dual-evpn", "hostname": "exit02", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn",
-    "hostname": "exit02", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822033}, {"namespace": "dual-evpn", "hostname": "leaf04",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822167}, {"namespace": "dual-evpn", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616644822167},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn",
-    "hostname": "exit01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822168}, {"namespace": "dual-evpn", "hostname": "exit01",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822168}, {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822169},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn",
-    "hostname": "leaf01", "vni": 24.0, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1616644822169}, {"namespace": "dual-evpn", "hostname": "leaf02",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616644822253}, {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616644822253},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616644822253}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf03", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681581879}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vni": 24.0,
-    "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1616681581879},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf02", "vni": 13.0, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681581987}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
-    "vni": 104001.0, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1616681581987}, {"namespace": "ospf-ibgp", "hostname": "exit01", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582166},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vni": 24.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf04", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681582386}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
-    "vni": 13.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681582386}, {"namespace": "ospf-ibgp", "hostname": "exit02", "vni": 104001.0,
-    "type": "L3", "assertReason": "-", "result": "pass", "timestamp": 1616681582523},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vni": 13.0, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
-    "hostname": "leaf01", "vni": 104001.0, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
-    "vni": 24.0, "type": "L2", "assertReason": "-", "result": "pass", "timestamp":
-    1616681582726}]'
 - command: evpnVni assert --result=whatever --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/cumulus-samples/path.yml
+++ b/tests/integration/sqcmds/cumulus-samples/path.yml
@@ -3,509 +3,504 @@ tests:
 - command: path show --dest=172.16.2.104 --src=172.16.1.101 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 1, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp1",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 1, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp":
-      1616644822008}, {"pathid": 1, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 1, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf03", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.104", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821713}, {"pathid":
-      1, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server104", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822255}, {"pathid": 2, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      2, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 2, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      2, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 2, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 3, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      3, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 3, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      3, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 3, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 4, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      4, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 4, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      4, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 4, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 5, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      5, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 5, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      5, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 5, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 6, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      6, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 6, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      6, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 6, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 7, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      7, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 7, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      7, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 7, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 8, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      8, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 8, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      8, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 8, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 9, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      9, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 9, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      9, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821714}, {"pathid": 9, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 10, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644822007}, {"pathid": 10, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 10, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 10, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine01",
-      "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf04", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.104", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821714}, {"pathid":
-      10, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server104", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822255}, {"pathid": 11, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      11, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 11, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      11, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821714}, {"pathid": 11, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 12, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644822007}, {"pathid": 12, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 12, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 12, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine01",
-      "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf04", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.104", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821714}, {"pathid":
-      12, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server104", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822255}, {"pathid": 13, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      13, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 13, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      13, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821714}, {"pathid": 13, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 14, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644822007}, {"pathid": 14, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 14, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 14, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine02",
-      "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf04", "iif": "swp2", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.104", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821714}, {"pathid":
-      14, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server104", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822255}, {"pathid": 15, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid":
-      15, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 15, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      15, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.104", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821714}, {"pathid": 15, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822255}, {"pathid": 16, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644822007}, {"pathid": 16, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 16, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 16, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine02",
-      "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf04", "iif": "swp2", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.104", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821714}, {"pathid":
-      16, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server104", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822255}]'
   marks: path show cumulus
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1",
+    "hopError": "", "timestamp": 1616644822007}, {"pathid": 1, "hopCount": 1, "namespace":
+    "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 1, "hopCount": 2, "namespace": "dual-evpn", "hostname": "spine01",
+    "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
+    3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
+    "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616644822008}, {"pathid": 1, "hopCount": 4, "namespace": "dual-evpn", "hostname":
+    "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 1, "hopCount": 5, "namespace":
+    "dual-evpn", "hostname": "leaf03", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.2.104", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644821713},
+    {"pathid": 1, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server104",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616644822255}, {"pathid": 2, "hopCount": 0, "namespace": "dual-evpn", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
+    "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid": 2, "hopCount":
+    1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01", "oif": "swp1",
+    "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
+    "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 2, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 2, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01", "iif":
+    "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 4, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    2, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 2, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 3, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    3, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 3, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    3, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 3, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 4, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    4, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 4, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    4, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 4, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 5, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    5, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 5, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    5, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 5, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 6, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    6, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 6, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    6, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 6, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 7, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    7, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 7, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    7, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 7, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 8, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    8, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 8, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    8, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 8, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 9, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    9, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 9, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    9, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 9, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 10, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    10, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 10, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    10, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 10, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 11, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    11, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 11, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    11, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 11, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 12, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    12, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 12, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    12, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 12, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 13, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    13, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 13, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    13, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 13, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 14, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    14, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 14, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    14, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 14, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 15, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    15, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 15, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    15, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 15, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}, {"pathid": 16, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    16, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 16, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    16, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.104", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821714}, {"pathid": 16, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822255}]'
 - command: path show --dest=172.16.2.104 --src=172.16.1.104 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/parquet/
@@ -518,288 +513,289 @@ tests:
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "ospf-single", "hostname": "leaf04",
     "iif": "lo", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "timestamp":
-    1616352402798}, {"pathid": 1, "hopCount": 1, "namespace": "ospf-single", "hostname":
-    "spine01", "iif": "swp4", "oif": "swp1", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp":
-    1616352402846}, {"pathid": 1, "hopCount": 2, "namespace": "ospf-single", "hostname":
-    "leaf01", "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616352404640},
-    {"pathid": 2, "hopCount": 0, "namespace": "ospf-single", "hostname": "leaf04",
-    "iif": "lo", "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "timestamp":
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1616352402798}, {"pathid": 1, "hopCount": 1, "namespace": "ospf-single",
+    "hostname": "spine01", "iif": "swp4", "oif": "swp1", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.0.0.11", "hopError": "", "timestamp": 1616352402846}, {"pathid": 1, "hopCount":
+    2, "namespace": "ospf-single", "hostname": "leaf01", "iif": "swp1", "oif": "lo",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1616352404640}, {"pathid": 2,
+    "hopCount": 0, "namespace": "ospf-single", "hostname": "leaf04", "iif": "lo",
+    "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 65536, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.11/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
     1616352402798}, {"pathid": 2, "hopCount": 1, "namespace": "ospf-single", "hostname":
     "spine02", "iif": "swp4", "oif": "swp1", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp":
-    1616352402876}, {"pathid": 2, "hopCount": 2, "namespace": "ospf-single", "hostname":
-    "leaf01", "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616352404640}]'
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "hopError":
+    "", "timestamp": 1616352402876}, {"pathid": 2, "hopCount": 2, "namespace": "ospf-single",
+    "hostname": "leaf01", "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616352404640}]'
 - command: path show --src=172.16.1.101 --dest=172.16.253.1 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 1, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp1",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 1, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 1, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 1, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp1", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 2, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 2, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01", "oif": "swp1",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 2, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 2, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 2, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 2, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 2, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp1", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 3, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 3, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp2",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 3, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 3, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 3, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp1", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 4, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 4, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01", "oif": "swp2",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 4, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 4, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 4, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp1", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 5, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 5, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp1",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 5, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 5, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 5, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 5, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822167}, {"pathid": 5, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp2", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 6, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 6, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01", "oif": "swp1",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 6, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 6, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 6, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 6, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822167}, {"pathid": 6, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp2", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 7, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 7, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp2",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 7, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 7, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 7, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 7, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822167}, {"pathid": 7, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp2", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003},
-      {"pathid": 8, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644822007}, {"pathid": 8, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01", "oif": "swp2",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 8, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 8, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp5.3",
-      "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.6", "error": "", "timestamp":
-      1616644822008}, {"pathid": 8, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 8, "hopCount": 5, "namespace": "dual-evpn", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
-      "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822167}, {"pathid": 8, "hopCount":
-      6, "namespace": "dual-evpn", "hostname": "internet", "iif": "swp2", "oif": "lo",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1616644823003}]'
   marks: path show cumulus
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1",
+    "hopError": "", "timestamp": 1616644822007}, {"pathid": 1, "hopCount": 1, "namespace":
+    "dual-evpn", "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 1, "hopCount": 2, "namespace": "dual-evpn", "hostname": "spine01",
+    "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
+    3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp5.3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.254.6", "hopError": "", "timestamp":
+    1616644822008}, {"pathid": 1, "hopCount": 4, "namespace": "dual-evpn", "hostname":
+    "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "186", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.9",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
+    5, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp5.4", "oif": "swp6",
+    "vrf": "internet-vrf", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.253.1", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644822008}, {"pathid": 1, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "internet", "iif": "swp1", "oif": "lo", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "Dst MTU != Src MTU", "timestamp": 1616644823003}, {"pathid": 2, "hopCount": 0,
+    "namespace": "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
+    "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
+    "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "hopError": "", "timestamp":
+    1616644822007}, {"pathid": 2, "hopCount": 1, "namespace": "dual-evpn", "hostname":
+    "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216,
+    "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101",
+    "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 3, "namespace": "dual-evpn",
+    "hostname": "exit01", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.254.6", "hopError": "", "timestamp": 1616644822008}, {"pathid": 2, "hopCount":
+    4, "namespace": "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth1.4",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.254.9", "hopError": "Hop MTU < Src
+    Mtu", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 5, "namespace": "dual-evpn",
+    "hostname": "exit01", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 2, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}, {"pathid": 3, "hopCount": 0, "namespace":
+    "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    3, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 3, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.6",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.254.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 3, "hopCount": 5, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 3, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}, {"pathid": 4, "hopCount": 0, "namespace":
+    "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    4, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 4, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.6",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth1.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.254.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 4, "hopCount": 5, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 4, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}, {"pathid": 5, "hopCount": 0, "namespace":
+    "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    5, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 5, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.6",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 5, "hopCount": 5, "namespace": "dual-evpn", "hostname":
+    "exit02", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822167},
+    {"pathid": 5, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}, {"pathid": 6, "hopCount": 0, "namespace":
+    "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    6, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 6, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.6",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 6, "hopCount": 5, "namespace": "dual-evpn", "hostname":
+    "exit02", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822167},
+    {"pathid": 6, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}, {"pathid": 7, "hopCount": 0, "namespace":
+    "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    7, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp1", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 7, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.6",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 7, "hopCount": 5, "namespace": "dual-evpn", "hostname":
+    "exit02", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822167},
+    {"pathid": 7, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}, {"pathid": 8, "hopCount": 0, "namespace":
+    "dual-evpn", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644822007}, {"pathid":
+    8, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 8, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.6",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "edge01", "iif": "eth1.3", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 8, "hopCount": 5, "namespace": "dual-evpn", "hostname":
+    "exit02", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822167},
+    {"pathid": 8, "hopCount": 6, "namespace": "dual-evpn", "hostname": "internet",
+    "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616644823003}]'
 - command: path summarize --dest=172.16.2.104 --src=172.16.1.101 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/parquet/
@@ -814,208 +810,205 @@ tests:
   marks: path show cumulus
 - command: path show --dest=172.16.4.104 --src=172.16.1.101 --namespace=dual-bgp --format=json
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 1, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.0.1", "error": "", "timestamp": 1616638470284}, {"pathid": 1, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "spine01", "iif": "swp2", "oif": "swp3",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638469538},
-      {"pathid": 1, "hopCount": 3, "namespace": "dual-bgp", "hostname": "leaf03",
-      "iif": "swp1", "oif": "bond02", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.4.104", "error": "", "timestamp": 1616638471226}, {"pathid": 1, "hopCount":
-      4, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0", "oif":
-      "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
-      "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 2, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 2, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.0.1", "error": "", "timestamp": 1616638470284}, {"pathid": 2, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "spine02", "iif": "swp2", "oif": "swp3",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638469514},
-      {"pathid": 2, "hopCount": 3, "namespace": "dual-bgp", "hostname": "leaf03",
-      "iif": "swp2", "oif": "bond02", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.4.104", "error": "", "timestamp": 1616638471226}, {"pathid": 2, "hopCount":
-      4, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0", "oif":
-      "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
-      "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 3, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 3, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.0.1", "error": "", "timestamp": 1616638470284}, {"pathid": 3, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "spine01", "iif": "swp2", "oif": "swp4",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638469538},
-      {"pathid": 3, "hopCount": 3, "namespace": "dual-bgp", "hostname": "leaf04",
-      "iif": "swp1", "oif": "bond02", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.4.104", "error": "", "timestamp": 1616638471165}, {"pathid": 3, "hopCount":
-      4, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0", "oif":
-      "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
-      "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 4, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 4, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.0.1", "error": "", "timestamp": 1616638470284}, {"pathid": 4, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "spine02", "iif": "swp2", "oif": "swp4",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638469514},
-      {"pathid": 4, "hopCount": 3, "namespace": "dual-bgp", "hostname": "leaf04",
-      "iif": "swp2", "oif": "bond02", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel",
-      "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.4.104", "error": "", "timestamp": 1616638471165}, {"pathid": 4, "hopCount":
-      4, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0", "oif":
-      "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
-      "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 5, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 5, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616638470427}, {"pathid": 5, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp1",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638470284},
-      {"pathid": 5, "hopCount": 3, "namespace": "dual-bgp", "hostname": "spine01",
-      "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616638469538}, {"pathid": 5, "hopCount": 4, "namespace":
-      "dual-bgp", "hostname": "leaf03", "iif": "swp1", "oif": "bond02", "vrf": "default",
-      "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
-      9216, "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "172.16.4.104", "error": "", "timestamp": 1616638471226}, {"pathid":
-      5, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 6, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 6, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616638470427}, {"pathid": 6, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp2",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638470284},
-      {"pathid": 6, "hopCount": 3, "namespace": "dual-bgp", "hostname": "spine02",
-      "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616638469514}, {"pathid": 6, "hopCount": 4, "namespace":
-      "dual-bgp", "hostname": "leaf03", "iif": "swp2", "oif": "bond02", "vrf": "default",
-      "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
-      9216, "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "172.16.4.104", "error": "", "timestamp": 1616638471226}, {"pathid":
-      6, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 7, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 7, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616638470427}, {"pathid": 7, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp1",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638470284},
-      {"pathid": 7, "hopCount": 3, "namespace": "dual-bgp", "hostname": "spine01",
-      "iif": "swp2", "oif": "swp4", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616638469538}, {"pathid": 7, "hopCount": 4, "namespace":
-      "dual-bgp", "hostname": "leaf04", "iif": "swp1", "oif": "bond02", "vrf": "default",
-      "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
-      9216, "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "172.16.4.104", "error": "", "timestamp": 1616638471165}, {"pathid":
-      7, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002},
-      {"pathid": 8, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "Possible anycast IP without anycast MAC", "timestamp":
-      1616638469517}, {"pathid": 8, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-      "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616638470427}, {"pathid": 8, "hopCount":
-      2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp2",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616638470284},
-      {"pathid": 8, "hopCount": 3, "namespace": "dual-bgp", "hostname": "spine02",
-      "iif": "swp2", "oif": "swp4", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616638469514}, {"pathid": 8, "hopCount": 4, "namespace":
-      "dual-bgp", "hostname": "leaf04", "iif": "swp2", "oif": "bond02", "vrf": "default",
-      "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
-      9216, "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "172.16.4.104", "error": "", "timestamp": 1616638471165}, {"pathid":
-      8, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1616638470002}]'
   marks: path show cumulus
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp": "172.16.1.1",
+    "hopError": "Possible anycast IP without anycast MAC", "timestamp": 1616638469517},
+    {"pathid": 1, "hopCount": 1, "namespace": "dual-bgp", "hostname": "leaf02", "iif":
+    "bond01", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "",
+    "timestamp": 1616638470284}, {"pathid": 1, "hopCount": 2, "namespace": "dual-bgp",
+    "hostname": "spine01", "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.0.1", "hopError": "", "timestamp": 1616638469538}, {"pathid": 1, "hopCount":
+    3, "namespace": "dual-bgp", "hostname": "leaf03", "iif": "swp1", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.4.104", "hopError": "", "timestamp":
+    1616638471226}, {"pathid": 1, "hopCount": 4, "namespace": "dual-bgp", "hostname":
+    "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616638470002}, {"pathid": 2, "hopCount": 0, "namespace": "dual-bgp",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e",
+    "nexthopIp": "172.16.1.1", "hopError": "Possible anycast IP without anycast MAC",
+    "timestamp": 1616638469517}, {"pathid": 2, "hopCount": 1, "namespace": "dual-bgp",
+    "hostname": "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.0.1", "hopError": "", "timestamp": 1616638470284}, {"pathid": 2, "hopCount":
+    2, "namespace": "dual-bgp", "hostname": "spine02", "iif": "swp2", "oif": "swp3",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616638469514}, {"pathid": 2, "hopCount": 3, "namespace": "dual-bgp", "hostname":
+    "leaf03", "iif": "swp2", "oif": "bond02", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel",
+    "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.4.104",
+    "hopError": "", "timestamp": 1616638471226}, {"pathid": 2, "hopCount": 4, "namespace":
+    "dual-bgp", "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1616638470002}, {"pathid": 3, "hopCount": 0,
+    "namespace": "dual-bgp", "hostname": "server101", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 1500, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
+    "macLookup": "52:54:00:61:91:8e", "nexthopIp": "172.16.1.1", "hopError": "Possible
+    anycast IP without anycast MAC", "timestamp": 1616638469517}, {"pathid": 3, "hopCount":
+    1, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp1",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616638470284}, {"pathid": 3, "hopCount": 2, "namespace": "dual-bgp", "hostname":
+    "spine01", "iif": "swp2", "oif": "swp4", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616638469538}, {"pathid": 3, "hopCount": 3, "namespace":
+    "dual-bgp", "hostname": "leaf04", "iif": "swp1", "oif": "bond02", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.4.104", "hopError": "", "timestamp": 1616638471165},
+    {"pathid": 3, "hopCount": 4, "namespace": "dual-bgp", "hostname": "server104",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616638470002}, {"pathid": 4, "hopCount": 0, "namespace": "dual-bgp", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "Possible anycast IP without anycast MAC", "timestamp":
+    1616638469517}, {"pathid": 4, "hopCount": 1, "namespace": "dual-bgp", "hostname":
+    "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616638470284}, {"pathid": 4, "hopCount": 2, "namespace":
+    "dual-bgp", "hostname": "spine02", "iif": "swp2", "oif": "swp4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616638469514}, {"pathid":
+    4, "hopCount": 3, "namespace": "dual-bgp", "hostname": "leaf04", "iif": "swp2",
+    "oif": "bond02", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.4.0/24",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.4.104", "hopError": "",
+    "timestamp": 1616638471165}, {"pathid": 4, "hopCount": 4, "namespace": "dual-bgp",
+    "hostname": "server104", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616638470002}, {"pathid": 5, "hopCount": 0, "namespace": "dual-bgp",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e",
+    "nexthopIp": "172.16.1.1", "hopError": "Possible anycast IP without anycast MAC",
+    "timestamp": 1616638469517}, {"pathid": 5, "hopCount": 1, "namespace": "dual-bgp",
+    "hostname": "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "", "timestamp": 1616638470427}, {"pathid": 5, "hopCount":
+    2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp1",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616638470284}, {"pathid": 5, "hopCount": 3, "namespace": "dual-bgp", "hostname":
+    "spine01", "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616638469538}, {"pathid": 5, "hopCount": 4, "namespace":
+    "dual-bgp", "hostname": "leaf03", "iif": "swp1", "oif": "bond02", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.4.104", "hopError": "", "timestamp": 1616638471226},
+    {"pathid": 5, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616638470002}, {"pathid": 6, "hopCount": 0, "namespace": "dual-bgp", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "Possible anycast IP without anycast MAC", "timestamp":
+    1616638469517}, {"pathid": 6, "hopCount": 1, "namespace": "dual-bgp", "hostname":
+    "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "", "timestamp": 1616638470427}, {"pathid": 6, "hopCount":
+    2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp2",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616638470284}, {"pathid": 6, "hopCount": 3, "namespace": "dual-bgp", "hostname":
+    "spine02", "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616638469514}, {"pathid": 6, "hopCount": 4, "namespace":
+    "dual-bgp", "hostname": "leaf03", "iif": "swp2", "oif": "bond02", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.4.104", "hopError": "", "timestamp": 1616638471226},
+    {"pathid": 6, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616638470002}, {"pathid": 7, "hopCount": 0, "namespace": "dual-bgp", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "Possible anycast IP without anycast MAC", "timestamp":
+    1616638469517}, {"pathid": 7, "hopCount": 1, "namespace": "dual-bgp", "hostname":
+    "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "", "timestamp": 1616638470427}, {"pathid": 7, "hopCount":
+    2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp1",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616638470284}, {"pathid": 7, "hopCount": 3, "namespace": "dual-bgp", "hostname":
+    "spine01", "iif": "swp2", "oif": "swp4", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616638469538}, {"pathid": 7, "hopCount": 4, "namespace":
+    "dual-bgp", "hostname": "leaf04", "iif": "swp1", "oif": "bond02", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.4.104", "hopError": "", "timestamp": 1616638471165},
+    {"pathid": 7, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616638470002}, {"pathid": 8, "hopCount": 0, "namespace": "dual-bgp", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "Possible anycast IP without anycast MAC", "timestamp":
+    1616638469517}, {"pathid": 8, "hopCount": 1, "namespace": "dual-bgp", "hostname":
+    "leaf01", "iif": "bond01", "oif": "peerlink", "vrf": "default", "isL2": true,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "l2", "ipLookup": "", "vtepLookup": "", "macLookup": "52:54:00:61:91:8e", "nexthopIp":
+    "172.16.1.1", "hopError": "", "timestamp": 1616638470427}, {"pathid": 8, "hopCount":
+    2, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13", "oif": "swp2",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.4.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616638470284}, {"pathid": 8, "hopCount": 3, "namespace": "dual-bgp", "hostname":
+    "spine02", "iif": "swp2", "oif": "swp4", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.4.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616638469514}, {"pathid": 8, "hopCount": 4, "namespace":
+    "dual-bgp", "hostname": "leaf04", "iif": "swp2", "oif": "bond02", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "kernel", "ipLookup": "172.16.4.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.4.104", "hopError": "", "timestamp": 1616638471165},
+    {"pathid": 8, "hopCount": 5, "namespace": "dual-bgp", "hostname": "server104",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616638470002}]'
 - command: path show --src='2001:db8:0:1::101' --dest='2001:db8:0:4::104' --namespace=dual-bgp
     --format=json
   data-directory: tests/data/parquet
@@ -1023,7 +1016,8 @@ tests:
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-bgp", "hostname": "server101",
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "2001:db8::/32",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616638469517}]'
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616638469517}]'
 - command: path show --src='2001:db8::11' --dest='2001:db8::12' --namespace=dual-bgp
     --format=json
   data-directory: tests/data/parquet
@@ -1032,77 +1026,80 @@ tests:
     "iif": "lo", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol": "bgp", "ipLookup":
     "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fef1:8d28",
-    "timestamp": 1616638470002}, {"pathid": 1, "hopCount": 1, "namespace": "dual-bgp",
-    "hostname": "spine01", "iif": "swp1", "oif": "swp2", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "2001:db8::12", "timestamp": 1616638469538}, {"pathid": 1, "hopCount": 2, "namespace":
-    "dual-bgp", "hostname": "leaf02", "iif": "swp1", "oif": "lo", "vrf": "default",
-    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536,
-    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1616638471112}, {"pathid": 2, "hopCount": 0, "namespace": "dual-bgp",
-    "hostname": "leaf01", "iif": "lo", "oif": "swp1", "vrf": "default", "isL2": false,
-    "overlay": false, "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol":
-    "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "fe80::5054:ff:fef1:8d28", "timestamp": 1616638470002}, {"pathid": 2, "hopCount":
-    1, "namespace": "dual-bgp", "hostname": "spine01", "iif": "swp1", "oif": "swp3",
-    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "2001:db8::12", "timestamp": 1616638469538},
-    {"pathid": 2, "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif":
+    "hopError": "", "timestamp": 1616638470002}, {"pathid": 1, "hopCount": 1, "namespace":
+    "dual-bgp", "hostname": "spine01", "iif": "swp1", "oif": "swp2", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "2001:db8::12", "hopError": "", "timestamp": 1616638469538},
+    {"pathid": 1, "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf02", "iif":
     "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1616638471859}, {"pathid":
-    3, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf01", "iif": "lo",
-    "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1616638471112},
+    {"pathid": 2, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf01", "iif":
+    "lo", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 65536, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fef1:8d28", "timestamp":
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fef1:8d28", "hopError":
+    "", "timestamp": 1616638470002}, {"pathid": 2, "hopCount": 1, "namespace": "dual-bgp",
+    "hostname": "spine01", "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "2001:db8::12", "hopError": "", "timestamp": 1616638469538}, {"pathid": 2, "hopCount":
+    2, "namespace": "dual-bgp", "hostname": "leaf03", "iif": "swp1", "oif": "lo",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1616638471859}, {"pathid": 3,
+    "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf01", "iif": "lo", "oif":
+    "swp1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    65536, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fef1:8d28", "hopError": "", "timestamp":
     1616638470002}, {"pathid": 3, "hopCount": 1, "namespace": "dual-bgp", "hostname":
     "spine01", "iif": "swp1", "oif": "swp4", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
     "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp": "2001:db8::12",
-    "timestamp": 1616638469538}, {"pathid": 3, "hopCount": 2, "namespace": "dual-bgp",
-    "hostname": "leaf04", "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false,
-    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol":
-    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp":
-    1616638471115}, {"pathid": 4, "hopCount": 0, "namespace": "dual-bgp", "hostname":
-    "leaf01", "iif": "lo", "oif": "swp2", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329",
-    "timestamp": 1616638470002}, {"pathid": 4, "hopCount": 1, "namespace": "dual-bgp",
-    "hostname": "spine02", "iif": "swp1", "oif": "swp2", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "2001:db8::12", "timestamp": 1616638469514}, {"pathid": 4, "hopCount": 2, "namespace":
+    "hopError": "", "timestamp": 1616638469538}, {"pathid": 3, "hopCount": 2, "namespace":
+    "dual-bgp", "hostname": "leaf04", "iif": "swp1", "oif": "lo", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1616638471115}, {"pathid": 4, "hopCount": 0,
+    "namespace": "dual-bgp", "hostname": "leaf01", "iif": "lo", "oif": "swp2", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65536,
+    "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329", "hopError": "", "timestamp":
+    1616638470002}, {"pathid": 4, "hopCount": 1, "namespace": "dual-bgp", "hostname":
+    "spine02", "iif": "swp1", "oif": "swp2", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp": "2001:db8::12",
+    "hopError": "", "timestamp": 1616638469514}, {"pathid": 4, "hopCount": 2, "namespace":
     "dual-bgp", "hostname": "leaf02", "iif": "swp2", "oif": "lo", "vrf": "default",
     "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536,
     "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1616638471112}, {"pathid": 5, "hopCount": 0, "namespace": "dual-bgp",
-    "hostname": "leaf01", "iif": "lo", "oif": "swp2", "vrf": "default", "isL2": false,
-    "overlay": false, "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol":
-    "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "fe80::5054:ff:fe38:a329", "timestamp": 1616638470002}, {"pathid": 5, "hopCount":
-    1, "namespace": "dual-bgp", "hostname": "spine02", "iif": "swp1", "oif": "swp3",
-    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "2001:db8::12", "timestamp": 1616638469514},
-    {"pathid": 5, "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif":
-    "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1616638471859}, {"pathid":
-    6, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf01", "iif": "lo",
-    "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 65536, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329", "timestamp":
+    "", "hopError": "", "timestamp": 1616638471112}, {"pathid": 5, "hopCount": 0,
+    "namespace": "dual-bgp", "hostname": "leaf01", "iif": "lo", "oif": "swp2", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65536,
+    "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329", "hopError": "", "timestamp":
+    1616638470002}, {"pathid": 5, "hopCount": 1, "namespace": "dual-bgp", "hostname":
+    "spine02", "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp": "2001:db8::12",
+    "hopError": "", "timestamp": 1616638469514}, {"pathid": 5, "hopCount": 2, "namespace":
+    "dual-bgp", "hostname": "leaf03", "iif": "swp2", "oif": "lo", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1616638471859}, {"pathid": 6, "hopCount": 0,
+    "namespace": "dual-bgp", "hostname": "leaf01", "iif": "lo", "oif": "swp2", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65536,
+    "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8::12/128", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329", "hopError": "", "timestamp":
     1616638470002}, {"pathid": 6, "hopCount": 1, "namespace": "dual-bgp", "hostname":
     "spine02", "iif": "swp1", "oif": "swp4", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
     "2001:db8::12/128", "vtepLookup": "", "macLookup": "", "nexthopIp": "2001:db8::12",
-    "timestamp": 1616638469514}, {"pathid": 6, "hopCount": 2, "namespace": "dual-bgp",
-    "hostname": "leaf04", "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false,
-    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol":
-    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp":
-    1616638471115}]'
+    "hopError": "", "timestamp": 1616638469514}, {"pathid": 6, "hopCount": 2, "namespace":
+    "dual-bgp", "hostname": "leaf04", "iif": "swp2", "oif": "lo", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1616638471115}]'
 - command: path show --src='2001:db8:0:1::1' --dest='2001:db8:0:4::1' --namespace=dual-bgp
     --format=json
   data-directory: tests/data/parquet
@@ -1111,820 +1108,811 @@ tests:
     "iif": "vlan13", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
     "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe6c:9df3",
-    "timestamp": 1616638470284}, {"pathid": 1, "hopCount": 1, "namespace": "dual-bgp",
-    "hostname": "spine01", "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "2001:db8:0:4::1", "timestamp": 1616638469538}, {"pathid": 1, "hopCount": 2, "namespace":
-    "dual-bgp", "hostname": "leaf03", "iif": "swp1", "oif": "vlan24", "vrf": "default",
+    "hopError": "", "timestamp": 1616638470284}, {"pathid": 1, "hopCount": 1, "namespace":
+    "dual-bgp", "hostname": "spine01", "iif": "swp2", "oif": "swp3", "vrf": "default",
     "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1616638471859}, {"pathid": 2, "hopCount": 0, "namespace": "dual-bgp",
-    "hostname": "leaf01", "iif": "vlan13", "oif": "swp1", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "fe80::5054:ff:fef1:8d28", "timestamp": 1616638470002}, {"pathid": 2, "hopCount":
-    1, "namespace": "dual-bgp", "hostname": "spine01", "iif": "swp1", "oif": "swp3",
-    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "2001:db8:0:4::1", "timestamp": 1616638469538},
-    {"pathid": 2, "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif":
+    "protocol": "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "2001:db8:0:4::1", "hopError": "", "timestamp": 1616638469538},
+    {"pathid": 1, "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif":
     "swp1", "oif": "vlan24", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1616638471859}, {"pathid":
-    3, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf02", "iif": "vlan13",
-    "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1616638471859},
+    {"pathid": 2, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf01", "iif":
+    "vlan13", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8:0:4::/64",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fea1:3072", "timestamp":
-    1616638470284}, {"pathid": 3, "hopCount": 1, "namespace": "dual-bgp", "hostname":
-    "spine02", "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp": "2001:db8:0:4::1",
-    "timestamp": 1616638469514}, {"pathid": 3, "hopCount": 2, "namespace": "dual-bgp",
-    "hostname": "leaf03", "iif": "swp2", "oif": "vlan24", "vrf": "default", "isL2":
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fef1:8d28", "hopError":
+    "", "timestamp": 1616638470002}, {"pathid": 2, "hopCount": 1, "namespace": "dual-bgp",
+    "hostname": "spine01", "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2":
     false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp":
-    1616638471859}, {"pathid": 4, "hopCount": 0, "namespace": "dual-bgp", "hostname":
-    "leaf01", "iif": "vlan13", "oif": "swp2", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329",
-    "timestamp": 1616638470002}, {"pathid": 4, "hopCount": 1, "namespace": "dual-bgp",
+    "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "2001:db8:0:4::1", "hopError": "", "timestamp": 1616638469538}, {"pathid": 2,
+    "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif": "swp1", "oif":
+    "vlan24", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1616638471859},
+    {"pathid": 3, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf02", "iif":
+    "vlan13", "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8:0:4::/64",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fea1:3072", "hopError":
+    "", "timestamp": 1616638470284}, {"pathid": 3, "hopCount": 1, "namespace": "dual-bgp",
+    "hostname": "spine02", "iif": "swp2", "oif": "swp3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "2001:db8:0:4::1", "hopError": "", "timestamp": 1616638469514}, {"pathid": 3,
+    "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif": "swp2", "oif":
+    "vlan24", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1616638471859},
+    {"pathid": 4, "hopCount": 0, "namespace": "dual-bgp", "hostname": "leaf01", "iif":
+    "vlan13", "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "2001:db8:0:4::/64",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "fe80::5054:ff:fe38:a329", "hopError":
+    "", "timestamp": 1616638470002}, {"pathid": 4, "hopCount": 1, "namespace": "dual-bgp",
     "hostname": "spine02", "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2":
     false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
     "bgp", "ipLookup": "2001:db8:0:4::/64", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "2001:db8:0:4::1", "timestamp": 1616638469514}, {"pathid": 4, "hopCount": 2, "namespace":
-    "dual-bgp", "hostname": "leaf03", "iif": "swp2", "oif": "vlan24", "vrf": "default",
-    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1616638471859}]'
+    "2001:db8:0:4::1", "hopError": "", "timestamp": 1616638469514}, {"pathid": 4,
+    "hopCount": 2, "namespace": "dual-bgp", "hostname": "leaf03", "iif": "swp2", "oif":
+    "vlan24", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1616638471859}]'
 - command: path show --dest=172.16.2.102 --src=172.16.1.103 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server103",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid": 1, "hopCount":
-      1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01", "oif": "swp1",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp":
-      1616644822008}, {"pathid": 1, "hopCount": 2, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
-      3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp":
-      1616644822008}, {"pathid": 1, "hopCount": 4, "namespace": "dual-evpn", "hostname":
-      "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 1, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf01", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.102", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821712}, {"pathid":
-      1, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server102", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822254}, {"pathid": 2, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      2, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 2, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      2, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 2, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 3, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      3, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 3, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      3, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 3, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 4, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      4, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 4, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      4, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 4, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 5, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      5, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 5, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      5, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 5, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 6, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      6, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 6, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      6, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 6, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 7, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      7, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 7, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      7, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 7, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 8, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      8, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 8, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      8, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821712}, {"pathid": 8, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 9, "hopCount": 0, "namespace": "dual-evpn",
-      "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      9, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 9, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp2", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      9, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 9, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 10, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644821893}, {"pathid": 10, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf04", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 10, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 10, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine01",
-      "iif": "swp6", "oif": "swp2", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf02", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.102", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821713}, {"pathid":
-      10, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server102", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822254}, {"pathid": 11, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      11, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 11, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp2", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      11, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp1",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 11, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 12, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644821893}, {"pathid": 12, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf04", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 12, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 12, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine01",
-      "iif": "swp6", "oif": "swp2", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf02", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.102", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821713}, {"pathid":
-      12, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server102", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822254}, {"pathid": 13, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      13, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 13, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp2", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      13, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 13, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 14, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644821893}, {"pathid": 14, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf04", "iif": "bond01", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 14, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 14, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine02",
-      "iif": "swp6", "oif": "swp2", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf02", "iif": "swp2", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.102", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821713}, {"pathid":
-      14, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server102", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822254}, {"pathid": 15, "hopCount": 0, "namespace": "dual-evpn", "hostname":
-      "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
-      "nexthopIp": "172.16.1.1", "error": "", "timestamp": 1616644821893}, {"pathid":
-      15, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
-      "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 2, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
-      {"pathid": 15, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01",
-      "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
-      "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 4, "namespace":
-      "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp2", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008}, {"pathid":
-      15, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp2",
-      "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.102", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1616644821713}, {"pathid": 15, "hopCount": 6, "namespace": "dual-evpn",
-      "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1616644822254}, {"pathid": 16, "hopCount": 0, "namespace":
-      "dual-evpn", "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf":
-      "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000,
-      "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "",
-      "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1", "error": "", "timestamp":
-      1616644821893}, {"pathid": 16, "hopCount": 1, "namespace": "dual-evpn", "hostname":
-      "leaf04", "iif": "bond01", "oif": "swp2", "vrf": "default", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "bgp",
-      "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 16, "hopCount":
-      2, "namespace": "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup":
-      "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 3, "namespace":
-      "dual-evpn", "hostname": "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "169.254.0.1", "error": "", "timestamp": 1616644822008},
-      {"pathid": 16, "hopCount": 4, "namespace": "dual-evpn", "hostname": "spine02",
-      "iif": "swp6", "oif": "swp2", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
-      "error": "", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 5, "namespace":
-      "dual-evpn", "hostname": "leaf02", "iif": "swp2", "oif": "bond02", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu":
-      1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.102", "error": "Hop MTU < Src Mtu", "timestamp": 1616644821713}, {"pathid":
-      16, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server102", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1616644822254}]'
   marks: path show cumulus bridged
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "server103",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp": "172.16.1.1",
+    "hopError": "", "timestamp": 1616644821893}, {"pathid": 1, "hopCount": 1, "namespace":
+    "dual-evpn", "hostname": "leaf03", "iif": "bond01", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 1, "hopCount": 2, "namespace": "dual-evpn", "hostname": "spine01",
+    "iif": "swp3", "oif": "swp6", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
+    3, "namespace": "dual-evpn", "hostname": "exit01", "iif": "swp1", "oif": "swp1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
+    "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp":
+    1616644822008}, {"pathid": 1, "hopCount": 4, "namespace": "dual-evpn", "hostname":
+    "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 1, "hopCount": 5, "namespace":
+    "dual-evpn", "hostname": "leaf01", "iif": "swp1", "oif": "bond02", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.2.102", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644821712},
+    {"pathid": 1, "hopCount": 6, "namespace": "dual-evpn", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1616644822254}, {"pathid": 2, "hopCount": 0, "namespace": "dual-evpn", "hostname":
+    "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay":
+    false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13", "nexthopIp":
+    "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid": 2, "hopCount":
+    1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01", "oif": "swp1",
+    "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup": "10.0.0.101",
+    "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 2, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp4", "oif": "swp6", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616644822008},
+    {"pathid": 2, "hopCount": 3, "namespace": "dual-evpn", "hostname": "exit01", "iif":
+    "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 4, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
+    "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    2, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 2, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 3, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    3, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 3, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    3, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 3, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 4, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    4, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 4, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    4, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 4, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 5, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    5, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 5, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    5, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 5, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 6, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    6, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 6, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    6, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 6, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 7, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    7, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 7, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    7, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 7, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 8, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    8, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 8, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp1", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    8, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf01", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821712}, {"pathid": 8, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 9, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    9, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 9, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 9, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    9, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 9, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 10, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    10, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 10, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 10, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    10, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 10, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 11, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    11, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 11, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 11, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    11, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 11, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 12, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    12, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 12, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 12, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    12, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp1",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 12, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 13, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    13, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 13, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 13, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    13, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 13, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 14, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    14, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 14, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp1", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 14, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    14, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 14, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 15, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    15, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp3", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 15, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 15, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    15, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 15, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}, {"pathid": 16, "hopCount": 0, "namespace": "dual-evpn",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "44:39:39:ff:00:13",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616644821893}, {"pathid":
+    16, "hopCount": 1, "namespace": "dual-evpn", "hostname": "leaf04", "iif": "bond01",
+    "oif": "swp2", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "", "vtepLookup":
+    "10.0.0.101", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 2, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp4", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.101", "vtepLookup": "10.0.0.101", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616644822008}, {"pathid": 16, "hopCount": 3, "namespace": "dual-evpn", "hostname":
+    "exit01", "iif": "swp2", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 16, "hopCount": 4, "namespace":
+    "dual-evpn", "hostname": "spine02", "iif": "swp6", "oif": "swp2", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup":
+    "", "nexthopIp": "169.254.0.1", "hopError": "", "timestamp": 1616644822008}, {"pathid":
+    16, "hopCount": 5, "namespace": "dual-evpn", "hostname": "leaf02", "iif": "swp2",
+    "oif": "bond02", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    false, "inMtu": 1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.102", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1616644821713}, {"pathid": 16, "hopCount": 6, "namespace": "dual-evpn",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616644822254}]'
 - command: path show --src=172.16.1.101 --dest=172.16.253.1 --namespace=ospf-ibgp
     --format=json
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.1",
-      "error": "", "timestamp": 1616681581586}, {"pathid": 1, "hopCount": 1, "namespace":
-      "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "10.0.0.102",
-      "macLookup": "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1616681581705},
-      {"pathid": 1, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine01",
-      "iif": "swp1", "oif": "swp5", "vrf": "default", "isL2": true, "overlay": true,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 1, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 1, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth1.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 1, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      1, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp1",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 2, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 2, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "", "timestamp":
-      1616681581651}, {"pathid": 2, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine01", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 2, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 2, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth1.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 2, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      2, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp1",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 3, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 3, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp2",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "", "timestamp":
-      1616681581705}, {"pathid": 3, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine02", "iif": "swp1", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 3, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 3, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth1.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 3, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      3, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp1",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 4, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 4, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp2",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "", "timestamp":
-      1616681581651}, {"pathid": 4, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine02", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 4, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 4, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth1.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 4, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit01",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      4, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp1",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 5, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 5, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "", "timestamp":
-      1616681581705}, {"pathid": 5, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine01", "iif": "swp1", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 5, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 5, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth2.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 5, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      5, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp2",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 6, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 6, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "", "timestamp":
-      1616681581651}, {"pathid": 6, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine01", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 6, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 6, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth2.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 6, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      6, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp2",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 7, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 7, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp2",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "", "timestamp":
-      1616681581705}, {"pathid": 7, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine02", "iif": "swp1", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 7, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 7, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth2.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 7, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      7, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp2",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}, {"pathid": 8, "hopCount": 0, "namespace": "ospf-ibgp", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.1", "error": "", "timestamp": 1616681581586}, {"pathid": 8, "hopCount":
-      1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp2",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup":
-      "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "", "timestamp":
-      1616681581651}, {"pathid": 8, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
-      "spine02", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102",
-      "error": "", "timestamp": 1616681581652}, {"pathid": 8, "hopCount": 3, "namespace":
-      "ospf-ibgp", "hostname": "exit02", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "169.254.253.6", "error": "", "timestamp": 1616681581649},
-      {"pathid": 8, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "edge01",
-      "iif": "eth2.3", "oif": "eth2.4", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol": "186",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.253.9", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
-      {"pathid": 8, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit02",
-      "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay":
-      false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.253.1", "error": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid":
-      8, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp2",
-      "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1616681582344}]'
   marks: path show cumulus
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.1", "hopError": "",
+    "timestamp": 1616681581586}, {"pathid": 1, "hopCount": 1, "namespace": "ospf-ibgp",
+    "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "10.0.0.102", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1616681581705}, {"pathid":
+    1, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp1",
+    "oif": "swp5", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.102", "vtepLookup":
+    "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 1, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "exit02", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6",
+    "hopError": "", "timestamp": 1616681581649}, {"pathid": 1, "hopCount": 4, "namespace":
+    "ospf-ibgp", "hostname": "edge01", "iif": "eth2.3", "oif": "eth1.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.254.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616681581704}, {"pathid": 1, "hopCount": 5, "namespace": "ospf-ibgp", "hostname":
+    "exit01", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649},
+    {"pathid": 1, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet",
+    "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616681582344}, {"pathid": 2, "hopCount": 0, "namespace":
+    "ospf-ibgp", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616681581586}, {"pathid":
+    2, "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "", "timestamp": 1616681581651}, {"pathid": 2, "hopCount": 2, "namespace": "ospf-ibgp",
+    "hostname": "spine01", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "",
+    "nexthopIp": "10.0.0.102", "hopError": "", "timestamp": 1616681581652}, {"pathid":
+    2, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "exit02", "iif": "swp1",
+    "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6", "hopError": "",
+    "timestamp": 1616681581649}, {"pathid": 2, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "edge01", "iif": "eth2.3", "oif": "eth1.4", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.254.9", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
+    {"pathid": 2, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit01", "iif":
+    "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid": 2, "hopCount":
+    6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp1", "oif": "lo",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616681582344},
+    {"pathid": 3, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.1", "hopError": "",
+    "timestamp": 1616681581586}, {"pathid": 3, "hopCount": 1, "namespace": "ospf-ibgp",
+    "hostname": "leaf01", "iif": "bond01", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "10.0.0.102", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1616681581705}, {"pathid":
+    3, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp1",
+    "oif": "swp5", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.102", "vtepLookup":
+    "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 3, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "exit02", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6",
+    "hopError": "", "timestamp": 1616681581649}, {"pathid": 3, "hopCount": 4, "namespace":
+    "ospf-ibgp", "hostname": "edge01", "iif": "eth2.3", "oif": "eth1.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.254.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616681581704}, {"pathid": 3, "hopCount": 5, "namespace": "ospf-ibgp", "hostname":
+    "exit01", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649},
+    {"pathid": 3, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet",
+    "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616681582344}, {"pathid": 4, "hopCount": 0, "namespace":
+    "ospf-ibgp", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616681581586}, {"pathid":
+    4, "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1616681581651}, {"pathid": 4, "hopCount": 2, "namespace": "ospf-ibgp",
+    "hostname": "spine02", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "",
+    "nexthopIp": "10.0.0.102", "hopError": "", "timestamp": 1616681581652}, {"pathid":
+    4, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "exit02", "iif": "swp2",
+    "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6", "hopError": "",
+    "timestamp": 1616681581649}, {"pathid": 4, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "edge01", "iif": "eth2.3", "oif": "eth1.4", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.254.9", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
+    {"pathid": 4, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit01", "iif":
+    "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid": 4, "hopCount":
+    6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp1", "oif": "lo",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616681582344},
+    {"pathid": 5, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.1", "hopError": "",
+    "timestamp": 1616681581586}, {"pathid": 5, "hopCount": 1, "namespace": "ospf-ibgp",
+    "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "10.0.0.102", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1616681581705}, {"pathid":
+    5, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp1",
+    "oif": "swp5", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.102", "vtepLookup":
+    "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 5, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "exit02", "iif": "swp1", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6",
+    "hopError": "", "timestamp": 1616681581649}, {"pathid": 5, "hopCount": 4, "namespace":
+    "ospf-ibgp", "hostname": "edge01", "iif": "eth2.3", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616681581704}, {"pathid": 5, "hopCount": 5, "namespace": "ospf-ibgp", "hostname":
+    "exit02", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649},
+    {"pathid": 5, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet",
+    "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616681582344}, {"pathid": 6, "hopCount": 0, "namespace":
+    "ospf-ibgp", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616681581586}, {"pathid":
+    6, "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "", "timestamp": 1616681581651}, {"pathid": 6, "hopCount": 2, "namespace": "ospf-ibgp",
+    "hostname": "spine01", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "",
+    "nexthopIp": "10.0.0.102", "hopError": "", "timestamp": 1616681581652}, {"pathid":
+    6, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "exit02", "iif": "swp1",
+    "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6", "hopError": "",
+    "timestamp": 1616681581649}, {"pathid": 6, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "edge01", "iif": "eth2.3", "oif": "eth2.4", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
+    {"pathid": 6, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit02", "iif":
+    "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid": 6, "hopCount":
+    6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp2", "oif": "lo",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616681582344},
+    {"pathid": 7, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.1", "hopError": "",
+    "timestamp": 1616681581586}, {"pathid": 7, "hopCount": 1, "namespace": "ospf-ibgp",
+    "hostname": "leaf01", "iif": "bond01", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "10.0.0.102", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1616681581705}, {"pathid":
+    7, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp1",
+    "oif": "swp5", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.102", "vtepLookup":
+    "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.102", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 7, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "exit02", "iif": "swp2", "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6",
+    "hopError": "", "timestamp": 1616681581649}, {"pathid": 7, "hopCount": 4, "namespace":
+    "ospf-ibgp", "hostname": "edge01", "iif": "eth2.3", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1616681581704}, {"pathid": 7, "hopCount": 5, "namespace": "ospf-ibgp", "hostname":
+    "exit02", "iif": "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false,
+    "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.253.1", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649},
+    {"pathid": 7, "hopCount": 6, "namespace": "ospf-ibgp", "hostname": "internet",
+    "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1616681582344}, {"pathid": 8, "hopCount": 0, "namespace":
+    "ospf-ibgp", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.1", "hopError": "", "timestamp": 1616681581586}, {"pathid":
+    8, "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf02", "iif": "bond01",
+    "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "10.0.0.102", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1616681581651}, {"pathid": 8, "hopCount": 2, "namespace": "ospf-ibgp",
+    "hostname": "spine02", "iif": "swp2", "oif": "swp5", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.102", "vtepLookup": "10.0.0.102", "macLookup": "",
+    "nexthopIp": "10.0.0.102", "hopError": "", "timestamp": 1616681581652}, {"pathid":
+    8, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "exit02", "iif": "swp2",
+    "oif": "swp5.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.253.1/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.6", "hopError": "",
+    "timestamp": 1616681581649}, {"pathid": 8, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "edge01", "iif": "eth2.3", "oif": "eth2.4", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 1500, "protocol":
+    "186", "ipLookup": "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.253.9", "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581704},
+    {"pathid": 8, "hopCount": 5, "namespace": "ospf-ibgp", "hostname": "exit02", "iif":
+    "swp5.4", "oif": "swp6", "vrf": "internet-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.253.1/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.253.1",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1616681581649}, {"pathid": 8, "hopCount":
+    6, "namespace": "ospf-ibgp", "hostname": "internet", "iif": "swp2", "oif": "lo",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616681582344}]'
 - command: path show --src=172.16.1.101 --dest=172.16.1.103 --namespace=ospf-ibgp
     --format=json
   data-directory: tests/data/parquet/
@@ -1933,170 +1921,175 @@ tests:
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
     "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
     "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 1, "hopCount": 1, "namespace":
-    "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf",
-    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.22", "timestamp": 1616681581705}, {"pathid": 1, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp1", "oif": "swp3",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.13", "timestamp": 1616681581652}, {"pathid":
-    1, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf03", "iif": "swp1",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581517},
-    {"pathid": 1, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 2, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 2, "hopCount": 1, "namespace":
+    "172.16.1.103", "hopError": "", "timestamp": null}, {"pathid": 1, "hopCount":
+    1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
+    9000, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1616681581705},
+    {"pathid": 1, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine01",
+    "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1616681581652}, {"pathid": 1, "hopCount": 3, "namespace":
+    "ospf-ibgp", "hostname": "leaf03", "iif": "swp1", "oif": "bond01", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000,
+    "protocol": "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1616681581517}, {"pathid": 1, "hopCount":
+    4, "namespace": "ospf-ibgp", "hostname": "server103", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9000, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1616681581509}, {"pathid": 2,
+    "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
+    "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp": "172.16.1.103",
+    "hopError": "", "timestamp": null}, {"pathid": 2, "hopCount": 1, "namespace":
     "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf",
     "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
     "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.22", "timestamp": 1616681581651}, {"pathid": 2, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp2", "oif": "swp3",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.13", "timestamp": 1616681581652}, {"pathid":
-    2, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf03", "iif": "swp1",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581517},
-    {"pathid": 2, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 3, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 3, "hopCount": 1, "namespace":
-    "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp2", "vrf": "evpn-vrf",
-    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.21", "timestamp": 1616681581705}, {"pathid": 3, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp1", "oif": "swp3",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.13", "timestamp": 1616681581652}, {"pathid":
-    3, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf03", "iif": "swp2",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581517},
-    {"pathid": 3, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 4, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 4, "hopCount": 1, "namespace":
+    "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1616681581651}, {"pathid":
+    2, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp2",
+    "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 2, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "leaf03", "iif": "swp1", "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup":
+    "172.16.1.103", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581517}, {"pathid": 2, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581509}, {"pathid": 3, "hopCount": 0, "namespace": "ospf-ibgp",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca",
+    "nexthopIp": "172.16.1.103", "hopError": "", "timestamp": null}, {"pathid": 3,
+    "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp":
+    1616681581705}, {"pathid": 3, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
+    "spine02", "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1616681581652}, {"pathid": 3, "hopCount": 3, "namespace":
+    "ospf-ibgp", "hostname": "leaf03", "iif": "swp2", "oif": "bond01", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000,
+    "protocol": "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1616681581517}, {"pathid": 3, "hopCount":
+    4, "namespace": "ospf-ibgp", "hostname": "server103", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9000, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1616681581509}, {"pathid": 4,
+    "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
+    "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp": "172.16.1.103",
+    "hopError": "", "timestamp": null}, {"pathid": 4, "hopCount": 1, "namespace":
     "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "evpn-vrf",
     "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
     "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.21", "timestamp": 1616681581651}, {"pathid": 4, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp2", "oif": "swp3",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.13", "timestamp": 1616681581652}, {"pathid":
-    4, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf03", "iif": "swp2",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581517},
-    {"pathid": 4, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 5, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 5, "hopCount": 1, "namespace":
-    "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf",
-    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.22", "timestamp": 1616681581705}, {"pathid": 5, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp1", "oif": "swp4",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.14", "timestamp": 1616681581652}, {"pathid":
-    5, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf04", "iif": "swp1",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581649},
-    {"pathid": 5, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 6, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 6, "hopCount": 1, "namespace":
+    "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1616681581651}, {"pathid":
+    4, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp2",
+    "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 4, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "leaf03", "iif": "swp2", "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup":
+    "172.16.1.103", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581517}, {"pathid": 4, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581509}, {"pathid": 5, "hopCount": 0, "namespace": "ospf-ibgp",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca",
+    "nexthopIp": "172.16.1.103", "hopError": "", "timestamp": null}, {"pathid": 5,
+    "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
+    1616681581705}, {"pathid": 5, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
+    "spine01", "iif": "swp1", "oif": "swp4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1616681581652}, {"pathid": 5, "hopCount": 3, "namespace":
+    "ospf-ibgp", "hostname": "leaf04", "iif": "swp1", "oif": "bond01", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000,
+    "protocol": "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1616681581649}, {"pathid": 5, "hopCount":
+    4, "namespace": "ospf-ibgp", "hostname": "server103", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9000, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1616681581509}, {"pathid": 6,
+    "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
+    "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp": "172.16.1.103",
+    "hopError": "", "timestamp": null}, {"pathid": 6, "hopCount": 1, "namespace":
     "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp1", "vrf": "evpn-vrf",
     "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
     "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.22", "timestamp": 1616681581651}, {"pathid": 6, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp2", "oif": "swp4",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.14", "timestamp": 1616681581652}, {"pathid":
-    6, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf04", "iif": "swp1",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581649},
-    {"pathid": 6, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 7, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 7, "hopCount": 1, "namespace":
-    "ospf-ibgp", "hostname": "leaf01", "iif": "bond01", "oif": "swp2", "vrf": "evpn-vrf",
-    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.21", "timestamp": 1616681581705}, {"pathid": 7, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp1", "oif": "swp4",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.14", "timestamp": 1616681581652}, {"pathid":
-    7, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf04", "iif": "swp2",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581649},
-    {"pathid": 7, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509},
-    {"pathid": 8, "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup":
-    "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp":
-    "172.16.1.103", "timestamp": null}, {"pathid": 8, "hopCount": 1, "namespace":
+    "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1616681581651}, {"pathid":
+    6, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine01", "iif": "swp2",
+    "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 6, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "leaf04", "iif": "swp1", "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup":
+    "172.16.1.103", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581649}, {"pathid": 6, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581509}, {"pathid": 7, "hopCount": 0, "namespace": "ospf-ibgp",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": "52:54:00:24:64:ca",
+    "nexthopIp": "172.16.1.103", "hopError": "", "timestamp": null}, {"pathid": 7,
+    "hopCount": 1, "namespace": "ospf-ibgp", "hostname": "leaf01", "iif": "bond01",
+    "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp":
+    1616681581705}, {"pathid": 7, "hopCount": 2, "namespace": "ospf-ibgp", "hostname":
+    "spine02", "iif": "swp1", "oif": "swp4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1616681581652}, {"pathid": 7, "hopCount": 3, "namespace":
+    "ospf-ibgp", "hostname": "leaf04", "iif": "swp2", "oif": "bond01", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000,
+    "protocol": "l2", "ipLookup": "172.16.1.103", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1616681581649}, {"pathid": 7, "hopCount":
+    4, "namespace": "ospf-ibgp", "hostname": "server103", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9000, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1616681581509}, {"pathid": 8,
+    "hopCount": 0, "namespace": "ospf-ibgp", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
+    "vtepLookup": "", "macLookup": "52:54:00:24:64:ca", "nexthopIp": "172.16.1.103",
+    "hopError": "", "timestamp": null}, {"pathid": 8, "hopCount": 1, "namespace":
     "ospf-ibgp", "hostname": "leaf02", "iif": "bond01", "oif": "swp2", "vrf": "evpn-vrf",
     "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216,
     "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.134", "macLookup": "",
-    "nexthopIp": "10.0.0.21", "timestamp": 1616681581651}, {"pathid": 8, "hopCount":
-    2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp2", "oif": "swp4",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-    "macLookup": "", "nexthopIp": "10.0.0.14", "timestamp": 1616681581652}, {"pathid":
-    8, "hopCount": 3, "namespace": "ospf-ibgp", "hostname": "leaf04", "iif": "swp2",
-    "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup": "172.16.1.103",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1616681581649},
-    {"pathid": 8, "hopCount": 4, "namespace": "ospf-ibgp", "hostname": "server103",
-    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1616681581509}]'
+    "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1616681581651}, {"pathid":
+    8, "hopCount": 2, "namespace": "ospf-ibgp", "hostname": "spine02", "iif": "swp2",
+    "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "", "timestamp":
+    1616681581652}, {"pathid": 8, "hopCount": 3, "namespace": "ospf-ibgp", "hostname":
+    "leaf04", "iif": "swp2", "oif": "bond01", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "l2", "ipLookup":
+    "172.16.1.103", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581649}, {"pathid": 8, "hopCount": 4, "namespace": "ospf-ibgp",
+    "hostname": "server103", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1616681581509}]'
 - command: path unique --dest=172.16.2.104 --src=172.16.1.101 --namespace=dual-evpn
     --count=True --format=json
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/eos-samples/evpnVni.yml
+++ b/tests/integration/sqcmds/eos-samples/evpnVni.yml
@@ -76,29 +76,38 @@ tests:
 - command: evpnVni assert --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: evpnVni assert eos
-  output: '[{"namespace": "eos", "hostname": "leaf02", "vni": 10, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1623025177153}, {"namespace": "eos", "hostname":
-    "leaf02", "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1623025177153}, {"namespace": "eos", "hostname": "leaf02", "vni": 30, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177153}, {"namespace":
-    "eos", "hostname": "leaf03", "vni": 20, "type": "L2", "assertReason": "-", "result":
-    "pass", "timestamp": 1623025177155}, {"namespace": "eos", "hostname": "leaf03",
-    "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1623025177155}, {"namespace": "eos", "hostname": "leaf03", "vni": 30, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177155}, {"namespace":
-    "eos", "hostname": "exit02", "vni": 999, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1623025177256}, {"namespace": "eos", "hostname": "exit01",
-    "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1623025177350}, {"namespace": "eos", "hostname": "leaf01", "vni": 10, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177459}, {"namespace":
-    "eos", "hostname": "leaf01", "vni": 999, "type": "L3", "assertReason": "-", "result":
-    "pass", "timestamp": 1623025177459}, {"namespace": "eos", "hostname": "leaf01",
-    "vni": 30, "type": "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177459},
-    {"namespace": "eos", "hostname": "leaf04", "vni": 20, "type": "L2", "assertReason":
-    "-", "result": "pass", "timestamp": 1623025177461}, {"namespace": "eos", "hostname":
-    "leaf04", "vni": 999, "type": "L3", "assertReason": "-", "result": "pass", "timestamp":
-    1623025177461}, {"namespace": "eos", "hostname": "leaf04", "vni": 30, "type":
-    "L2", "assertReason": "-", "result": "pass", "timestamp": 1623025177461}]'
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vni": 10, "type": "L2", "vrf":
+    "evpn-vrf", "macaddr": "00:00:00:11:12:10", "timestamp": 1623025177153, "result":
+    "pass", "assertReason": []}, {"namespace": "eos", "hostname": "leaf02", "vni":
+    999, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:38:39:99:c7:9e", "timestamp":
+    1623025177153, "result": "pass", "assertReason": []}, {"namespace": "eos", "hostname":
+    "leaf02", "vni": 30, "type": "L2", "vrf": "evpn-vrf", "macaddr": "00:00:00:11:12:10",
+    "timestamp": 1623025177153, "result": "pass", "assertReason": []}, {"namespace":
+    "eos", "hostname": "leaf03", "vni": 20, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+    "00:00:00:11:12:10", "timestamp": 1623025177155, "result": "pass", "assertReason":
+    []}, {"namespace": "eos", "hostname": "leaf03", "vni": 999, "type": "L3", "vrf":
+    "evpn-vrf", "macaddr": "44:38:39:24:3f:16", "timestamp": 1623025177155, "result":
+    "pass", "assertReason": []}, {"namespace": "eos", "hostname": "leaf03", "vni":
+    30, "type": "L2", "vrf": "evpn-vrf", "macaddr": "00:00:00:11:12:10", "timestamp":
+    1623025177155, "result": "pass", "assertReason": []}, {"namespace": "eos", "hostname":
+    "exit02", "vni": 999, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:38:39:c3:55:cb",
+    "timestamp": 1623025177256, "result": "pass", "assertReason": []}, {"namespace":
+    "eos", "hostname": "exit01", "vni": 999, "type": "L3", "vrf": "evpn-vrf", "macaddr":
+    "44:38:39:33:d8:43", "timestamp": 1623025177350, "result": "pass", "assertReason":
+    []}, {"namespace": "eos", "hostname": "leaf01", "vni": 10, "type": "L2", "vrf":
+    "evpn-vrf", "macaddr": "00:00:00:11:12:10", "timestamp": 1623025177459, "result":
+    "pass", "assertReason": []}, {"namespace": "eos", "hostname": "leaf01", "vni":
+    999, "type": "L3", "vrf": "evpn-vrf", "macaddr": "44:38:39:e3:19:2e", "timestamp":
+    1623025177459, "result": "pass", "assertReason": []}, {"namespace": "eos", "hostname":
+    "leaf01", "vni": 30, "type": "L2", "vrf": "evpn-vrf", "macaddr": "00:00:00:11:12:10",
+    "timestamp": 1623025177459, "result": "pass", "assertReason": []}, {"namespace":
+    "eos", "hostname": "leaf04", "vni": 20, "type": "L2", "vrf": "evpn-vrf", "macaddr":
+    "00:00:00:11:12:10", "timestamp": 1623025177461, "result": "pass", "assertReason":
+    []}, {"namespace": "eos", "hostname": "leaf04", "vni": 999, "type": "L3", "vrf":
+    "evpn-vrf", "macaddr": "44:38:39:81:30:22", "timestamp": 1623025177461, "result":
+    "pass", "assertReason": []}, {"namespace": "eos", "hostname": "leaf04", "vni":
+    30, "type": "L2", "vrf": "evpn-vrf", "macaddr": "00:00:00:11:12:10", "timestamp":
+    1623025177461, "result": "pass", "assertReason": []}]'
 - command: evpnVni show --priVtepIp='10.0.0.112' --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: evpnVni show eos filter

--- a/tests/integration/sqcmds/eos-samples/path.yml
+++ b/tests/integration/sqcmds/eos-samples/path.yml
@@ -7,160 +7,152 @@ tests:
   marks: path show eos
 - command: path show --dest=172.16.2.104 --src=172.16.1.101 --format=json --namespace=eos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174542}, {"pathid": 1, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet3", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 1, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf03", "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
-      {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 2, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174530}, {"pathid": 2, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 2, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf03", "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
-      {"pathid": 3, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 3, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174542}, {"pathid": 3, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 3, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf04", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 4, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174530}, {"pathid": 4, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 4, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf04", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 5, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 5, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174542}, {"pathid": 5, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174549}, {"pathid": 5, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf03", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
-      {"pathid": 6, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 6, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174530}, {"pathid": 6, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet3", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174549}, {"pathid": 6, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf03", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174540},
-      {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 7, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174542}, {"pathid": 7, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet4", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174549}, {"pathid": 7, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf04", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 8, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 8, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174530}, {"pathid": 8, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174549}, {"pathid": 8, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf04", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543}]'
   marks: path show eos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174542},
+    {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "spine01", "iif":
+    "Ethernet1", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 1, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet1", "oif": "Ethernet3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 2, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174530},
+    {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname": "spine01", "iif":
+    "Ethernet2", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 2, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet1", "oif": "Ethernet3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 3, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 3, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174542},
+    {"pathid": 3, "hopCount": 2, "namespace": "eos", "hostname": "spine01", "iif":
+    "Ethernet1", "oif": "Ethernet4", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 3, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf04", "iif": "Ethernet1", "oif": "Ethernet4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 4, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174530},
+    {"pathid": 4, "hopCount": 2, "namespace": "eos", "hostname": "spine01", "iif":
+    "Ethernet2", "oif": "Ethernet4", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 4, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf04", "iif": "Ethernet1", "oif": "Ethernet4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 5, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 5, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174542},
+    {"pathid": 5, "hopCount": 2, "namespace": "eos", "hostname": "spine02", "iif":
+    "Ethernet1", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 5, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Ethernet3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 6, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 6, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174530},
+    {"pathid": 6, "hopCount": 2, "namespace": "eos", "hostname": "spine02", "iif":
+    "Ethernet2", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 6, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Ethernet3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 7, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174542},
+    {"pathid": 7, "hopCount": 2, "namespace": "eos", "hostname": "spine02", "iif":
+    "Ethernet1", "oif": "Ethernet4", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 7, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Ethernet4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 8, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 8, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174530},
+    {"pathid": 8, "hopCount": 2, "namespace": "eos", "hostname": "spine02", "iif":
+    "Ethernet2", "oif": "Ethernet4", "vrf": "default", "isL2": true, "overlay": true,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 8, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Ethernet4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 1500, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   error:
@@ -168,634 +160,616 @@ tests:
   marks: path show eos
 - command: path show --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=eos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174542}, {"pathid": 1, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet3", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 1, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf03", "iif": "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
-      "connected", "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu", "timestamp": 1623025175569},
-      {"pathid": 1, "hopCount": 4, "namespace": "eos", "hostname": "server302", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1623025175379}, {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 2, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 2, "hopCount":
-      2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174547}, {"pathid": 2, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf03", "iif": "Ethernet1", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025175569}, {"pathid": 2, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 3, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 3, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 3, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 3, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025175569}, {"pathid": 3, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 4, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 4, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 4, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 4, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025175569}, {"pathid": 4, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 5, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 5, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif":
-      "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 5, "hopCount":
-      2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174547}, {"pathid": 5, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet1", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 5, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 6, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 6, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 6, "hopCount":
-      2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174547}, {"pathid": 6, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet1", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 6, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 7, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 7, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 7, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 7, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 7, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 8, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 8, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 8, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 8, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Port-Channel4", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.3.202", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 8, "hopCount": 4, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}]'
   marks: path show eos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174542}, {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "spine01",
+    "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 1, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet1", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.3.202", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1623025175569}, {"pathid": 1, "hopCount": 4, "namespace": "eos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025175379}, {"pathid": 2, "hopCount": 0, "namespace": "eos",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1623025174997}, {"pathid": 2, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1623025174530}, {"pathid": 2, "hopCount": 2, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 2, "hopCount": 3, "namespace": "eos", "hostname": "leaf03", "iif":
+    "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569}, {"pathid": 2, "hopCount":
+    4, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379}, {"pathid": 3,
+    "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1623025174997}, {"pathid": 3, "hopCount": 1, "namespace": "eos", "hostname": "leaf01",
+    "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 3, "hopCount":
+    2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174549}, {"pathid": 3, "hopCount": 3, "namespace": "eos", "hostname": "leaf03",
+    "iif": "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false,
+    "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
+    "connected", "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.3.202", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569},
+    {"pathid": 3, "hopCount": 4, "namespace": "eos", "hostname": "server302", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379},
+    {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 4, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174530}, {"pathid": 4, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 4, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.3.202", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1623025175569}, {"pathid": 4, "hopCount": 4, "namespace": "eos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025175379}, {"pathid": 5, "hopCount": 0, "namespace": "eos",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1623025174997}, {"pathid": 5, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1623025174542}, {"pathid": 5, "hopCount": 2, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 5, "hopCount": 3, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 5, "hopCount":
+    4, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379}, {"pathid": 6,
+    "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1623025174997}, {"pathid": 6, "hopCount": 1, "namespace": "eos", "hostname": "leaf02",
+    "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 6, "hopCount":
+    2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174547}, {"pathid": 6, "hopCount": 3, "namespace": "eos", "hostname": "leaf04",
+    "iif": "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false,
+    "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
+    "connected", "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.3.202", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019},
+    {"pathid": 6, "hopCount": 4, "namespace": "eos", "hostname": "server302", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379},
+    {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 7, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174542}, {"pathid": 7, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 7, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.3.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.3.202", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1623025176019}, {"pathid": 7, "hopCount": 4, "namespace": "eos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025175379}, {"pathid": 8, "hopCount": 0, "namespace": "eos",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1623025174997}, {"pathid": 8, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.3.202/32", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1623025174530}, {"pathid": 8, "hopCount": 2, "namespace":
+    "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549},
+    {"pathid": 8, "hopCount": 3, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 8, "hopCount":
+    4, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379}]'
 - command: path show --dest=172.16.2.201 --src=172.16.1.101 --format=json --namespace=eos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace":
-      "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214,
-      "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174542}, {"pathid": 1, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet3", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 1, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf03", "iif": "Ethernet1", "oif": "Port-Channel3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
-      "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "",
-      "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu", "timestamp": 1623025175569},
-      {"pathid": 1, "hopCount": 4, "namespace": "eos", "hostname": "server301", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp":
-      1623025175379}, {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 2, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 2, "hopCount":
-      2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174547}, {"pathid": 2, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf03", "iif": "Ethernet1", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025175569}, {"pathid": 2, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 3, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 3, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 3, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 3, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025175569}, {"pathid": 3, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 4, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 4, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 4, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 4, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025175569}, {"pathid": 4, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 5, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 5, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif":
-      "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 5, "hopCount":
-      2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174547}, {"pathid": 5, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet1", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 5, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 6, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 6, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 6, "hopCount":
-      2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174547}, {"pathid": 6, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet1", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 6, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 7, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 7, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 7, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 7, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 7, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}, {"pathid": 8, "hopCount": 0, "namespace": "eos",
-      "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1623025174997}, {"pathid": 8, "hopCount":
-      1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif":
-      "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32",
-      "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 8, "hopCount":
-      2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174549}, {"pathid": 8, "hopCount": 3, "namespace":
-      "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Port-Channel3", "vrf":
-      "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.2.201", "error": "Hop MTU < Src Mtu",
-      "timestamp": 1623025176019}, {"pathid": 8, "hopCount": 4, "namespace": "eos",
-      "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175379}]'
   marks: path show eos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 1, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174542}, {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "spine01",
+    "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 1, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet1", "oif": "Port-Channel3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.201", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1623025175569}, {"pathid": 1, "hopCount": 4, "namespace": "eos",
+    "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025175379}, {"pathid": 2, "hopCount": 0, "namespace": "eos",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1623025174997}, {"pathid": 2, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1623025174530}, {"pathid": 2, "hopCount": 2, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 2, "hopCount": 3, "namespace": "eos", "hostname": "leaf03", "iif":
+    "Ethernet1", "oif": "Port-Channel3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.2.201",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569}, {"pathid": 2, "hopCount":
+    4, "namespace": "eos", "hostname": "server301", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379}, {"pathid": 3,
+    "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1623025174997}, {"pathid": 3, "hopCount": 1, "namespace": "eos", "hostname": "leaf01",
+    "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174542}, {"pathid": 3, "hopCount":
+    2, "namespace": "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174549}, {"pathid": 3, "hopCount": 3, "namespace": "eos", "hostname": "leaf03",
+    "iif": "Ethernet2", "oif": "Port-Channel3", "vrf": "evpn-vrf", "isL2": false,
+    "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
+    "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.2.201", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569},
+    {"pathid": 3, "hopCount": 4, "namespace": "eos", "hostname": "server301", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379},
+    {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 4, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174530}, {"pathid": 4, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 4, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf03", "iif": "Ethernet2", "oif": "Port-Channel3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.201", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1623025175569}, {"pathid": 4, "hopCount": 4, "namespace": "eos",
+    "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025175379}, {"pathid": 5, "hopCount": 0, "namespace": "eos",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1623025174997}, {"pathid": 5, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1623025174542}, {"pathid": 5, "hopCount": 2, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 5, "hopCount": 3, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet1", "oif": "Port-Channel3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.2.201",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 5, "hopCount":
+    4, "namespace": "eos", "hostname": "server301", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379}, {"pathid": 6,
+    "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1623025174997}, {"pathid": 6, "hopCount": 1, "namespace": "eos", "hostname": "leaf02",
+    "iif": "Port-Channel3", "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174530}, {"pathid": 6, "hopCount":
+    2, "namespace": "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 1500, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174547}, {"pathid": 6, "hopCount": 3, "namespace": "eos", "hostname": "leaf04",
+    "iif": "Ethernet1", "oif": "Port-Channel3", "vrf": "evpn-vrf", "isL2": false,
+    "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
+    "connected", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.2.201", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019},
+    {"pathid": 6, "hopCount": 4, "namespace": "eos", "hostname": "server301", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379},
+    {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025174997}, {"pathid": 7, "hopCount": 1, "namespace": "eos",
+    "hostname": "leaf01", "iif": "Port-Channel3", "oif": "Ethernet2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu": 1500,
+    "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174542}, {"pathid": 7, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 7, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf04", "iif": "Ethernet2", "oif": "Port-Channel3",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    1500, "outMtu": 9214, "protocol": "connected", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.2.201", "hopError": "Hop MTU < Src Mtu",
+    "timestamp": 1623025176019}, {"pathid": 7, "hopCount": 4, "namespace": "eos",
+    "hostname": "server301", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025175379}, {"pathid": 8, "hopCount": 0, "namespace": "eos",
+    "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1623025174997}, {"pathid": 8, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf02", "iif": "Port-Channel3", "oif": "Ethernet2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ibgp", "ipLookup": "172.16.2.201/32", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1623025174530}, {"pathid": 8, "hopCount": 2, "namespace":
+    "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549},
+    {"pathid": 8, "hopCount": 3, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet2", "oif": "Port-Channel3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.2.201",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 8, "hopCount":
+    4, "namespace": "eos", "hostname": "server301", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1623025175379}]'
 - command: path show --src=172.16.3.202 --dest=172.16.3.102 --format=json --namespace=eos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server302",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
-      "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
-      "172.16.3.102", "error": "", "timestamp": null}, {"pathid": 1, "hopCount": 1,
-      "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4", "oif": "Ethernet1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174540}, {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname":
-      "spine01", "iif": "Ethernet3", "oif": "Ethernet1", "vrf": "default", "isL2":
-      true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
-      "nexthopIp": "10.0.0.11", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
-      {"pathid": 1, "hopCount": 3, "namespace": "eos", "hostname": "leaf01", "iif":
-      "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "l2", "ipLookup":
-      "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025175375}, {"pathid": 1, "hopCount":
-      4, "namespace": "eos", "hostname": "server102", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "", "timestamp": 1623025175575}, {"pathid": 2,
-      "hopCount": 0, "namespace": "eos", "hostname": "server302", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-      "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp": "172.16.3.102",
-      "error": "", "timestamp": null}, {"pathid": 2, "hopCount": 1, "namespace": "eos",
-      "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname": "spine01", "iif":
-      "Ethernet4", "oif": "Ethernet1", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 2, "hopCount":
-      3, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet1", "oif": "Port-Channel4",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup":
-      "", "macLookup": null, "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025175375}, {"pathid": 2, "hopCount": 4, "namespace": "eos", "hostname":
-      "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175575}, {"pathid": 3, "hopCount": 0, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72",
-      "nexthopIp": "172.16.3.102", "error": "", "timestamp": null}, {"pathid": 3,
-      "hopCount": 1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4",
-      "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup":
-      "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174540}, {"pathid": 3, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine02", "iif": "Ethernet3", "oif": "Ethernet1", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "10.0.0.11", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174549}, {"pathid": 3, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf01", "iif": "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
-      "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp":
-      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025175375}, {"pathid": 3,
-      "hopCount": 4, "namespace": "eos", "hostname": "server102", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025175575},
-      {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server302", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-      "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp": "172.16.3.102",
-      "error": "", "timestamp": null}, {"pathid": 4, "hopCount": 1, "namespace": "eos",
-      "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet2", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 4, "hopCount": 2, "namespace": "eos", "hostname": "spine02", "iif":
-      "Ethernet4", "oif": "Ethernet1", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 4, "hopCount":
-      3, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet2", "oif": "Port-Channel4",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup":
-      "", "macLookup": null, "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025175375}, {"pathid": 4, "hopCount": 4, "namespace": "eos", "hostname":
-      "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175575}, {"pathid": 5, "hopCount": 0, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72",
-      "nexthopIp": "172.16.3.102", "error": "", "timestamp": null}, {"pathid": 5,
-      "hopCount": 1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4",
-      "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup":
-      "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174540}, {"pathid": 5, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine01", "iif": "Ethernet3", "oif": "Ethernet2", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174547}, {"pathid": 5, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf02", "iif": "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
-      "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp":
-      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025175378}, {"pathid": 5,
-      "hopCount": 4, "namespace": "eos", "hostname": "server102", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025175575},
-      {"pathid": 6, "hopCount": 0, "namespace": "eos", "hostname": "server302", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-      "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp": "172.16.3.102",
-      "error": "", "timestamp": null}, {"pathid": 6, "hopCount": 1, "namespace": "eos",
-      "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 6, "hopCount": 2, "namespace": "eos", "hostname": "spine01", "iif":
-      "Ethernet4", "oif": "Ethernet2", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.12",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 6, "hopCount":
-      3, "namespace": "eos", "hostname": "leaf02", "iif": "Ethernet1", "oif": "Port-Channel4",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup":
-      "", "macLookup": null, "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025175378}, {"pathid": 6, "hopCount": 4, "namespace": "eos", "hostname":
-      "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175575}, {"pathid": 7, "hopCount": 0, "namespace": "eos",
-      "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
-      true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72",
-      "nexthopIp": "172.16.3.102", "error": "", "timestamp": null}, {"pathid": 7,
-      "hopCount": 1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4",
-      "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
-      false, "inMtu": 9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup":
-      "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025174540}, {"pathid": 7, "hopCount": 2, "namespace":
-      "eos", "hostname": "spine02", "iif": "Ethernet3", "oif": "Ethernet2", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025174549}, {"pathid": 7, "hopCount": 3, "namespace": "eos", "hostname":
-      "leaf02", "iif": "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol":
-      "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp":
-      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025175378}, {"pathid": 7,
-      "hopCount": 4, "namespace": "eos", "hostname": "server102", "iif": "bond0",
-      "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025175575},
-      {"pathid": 8, "hopCount": 0, "namespace": "eos", "hostname": "server302", "iif":
-      "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-      "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp": "172.16.3.102",
-      "error": "", "timestamp": null}, {"pathid": 8, "hopCount": 1, "namespace": "eos",
-      "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet2", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9214, "outMtu":
-      1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1623025174543},
-      {"pathid": 8, "hopCount": 2, "namespace": "eos", "hostname": "spine02", "iif":
-      "Ethernet4", "oif": "Ethernet2", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-      "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.12",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 8, "hopCount":
-      3, "namespace": "eos", "hostname": "leaf02", "iif": "Ethernet2", "oif": "Port-Channel4",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup":
-      "", "macLookup": null, "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025175378}, {"pathid": 8, "hopCount": 4, "namespace": "eos", "hostname":
-      "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025175575}]'
   marks: path show eos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 1, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "spine01",
+    "iif": "Ethernet3", "oif": "Ethernet1", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 1, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet1", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175375}, {"pathid": 1, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 2, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname": "spine01",
+    "iif": "Ethernet4", "oif": "Ethernet1", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 2, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet1", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175375}, {"pathid": 2, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 3, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 3, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4", "oif": "Ethernet2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 3, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet3", "oif": "Ethernet1", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 3, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet2", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175375}, {"pathid": 3, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 4, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 4, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet4", "oif": "Ethernet1", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 4, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet2", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175375}, {"pathid": 4, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 5, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 5, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 5, "hopCount": 2, "namespace": "eos", "hostname": "spine01",
+    "iif": "Ethernet3", "oif": "Ethernet2", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.12",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 5, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf02", "iif": "Ethernet1", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175378}, {"pathid": 5, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 6, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 6, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 6, "hopCount": 2, "namespace": "eos", "hostname": "spine01",
+    "iif": "Ethernet4", "oif": "Ethernet2", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.12",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547}, {"pathid": 6, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf02", "iif": "Ethernet1", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175378}, {"pathid": 6, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 7, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf03", "iif": "Port-Channel4", "oif": "Ethernet2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174540}, {"pathid": 7, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet3", "oif": "Ethernet2", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.12",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 7, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf02", "iif": "Ethernet2", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175378}, {"pathid": 7, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}, {"pathid": 8, "hopCount": 0, "namespace": "eos", "hostname": "server302",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "b2:8f:7e:c3:49:72", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 8, "hopCount":
+    1, "namespace": "eos", "hostname": "leaf04", "iif": "Port-Channel4", "oif": "Ethernet2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9214, "outMtu": 1500, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025174543}, {"pathid": 8, "hopCount": 2, "namespace": "eos", "hostname": "spine02",
+    "iif": "Ethernet4", "oif": "Ethernet2", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.12",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549}, {"pathid": 8, "hopCount":
+    3, "namespace": "eos", "hostname": "leaf02", "iif": "Ethernet2", "oif": "Port-Channel4",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500,
+    "outMtu": 9214, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "",
+    "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025175378}, {"pathid": 8, "hopCount": 4, "namespace": "eos", "hostname": "server102",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1623025175575}]'
 - command: path show --dest=10.0.0.11 --src=10.0.0.14 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: path show eos
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "leaf04",
     "iif": "Loopback0", "oif": "Ethernet1", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "timestamp":
-    1623025174543}, {"pathid": 1, "hopCount": 1, "namespace": "eos", "hostname": "spine01",
-    "iif": "Ethernet4", "oif": "Ethernet1", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp":
-    null}, {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "leaf01",
-    "iif": "Ethernet1", "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1623025176024},
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1623025174543}, {"pathid": 1, "hopCount": 1, "namespace": "eos",
+    "hostname": "spine01", "iif": "Ethernet4", "oif": "Ethernet1", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": null}, {"pathid": 1,
+    "hopCount": 2, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet1", "oif":
+    "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025176024},
     {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "leaf04", "iif":
     "Loopback0", "oif": "Ethernet2", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "timestamp":
-    1623025174543}, {"pathid": 2, "hopCount": 1, "namespace": "eos", "hostname": "spine02",
-    "iif": "Ethernet4", "oif": "Ethernet1", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp":
-    null}, {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname": "leaf01",
-    "iif": "Ethernet2", "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1623025176024}]'
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "", "timestamp": 1623025174543}, {"pathid": 2, "hopCount": 1, "namespace": "eos",
+    "hostname": "spine02", "iif": "Ethernet4", "oif": "Ethernet1", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": null}, {"pathid": 2,
+    "hopCount": 2, "namespace": "eos", "hostname": "leaf01", "iif": "Ethernet2", "oif":
+    "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025176024}]'
 - command: path show --src=10.0.0.31 --dest=10.0.0.41 --format=json --namespace=eos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "exit01",
-      "iif": "Loopback0", "oif": "Ethernet3.2", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ebgp",
-      "ipLookup": "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.2", "error": "", "timestamp": 1623025174546}, {"pathid": 1, "hopCount":
-      1, "namespace": "eos", "hostname": "firewall01", "iif": "eth1.2", "oif": "eth1.4",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "10.0.0.41/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.254.9", "error": "", "timestamp":
-      1623025175208}, {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname":
-      "exit01", "iif": "Ethernet3.4", "oif": "Ethernet4", "vrf": "internet-vrf", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "ebgp", "ipLookup": "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "10.0.0.41", "error": "", "timestamp": 1623025174546}, {"pathid": 1, "hopCount":
-      3, "namespace": "eos", "hostname": "dcedge01", "iif": "xe-0/0/0.0", "oif": "lo0.0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "no reverse path", "timestamp": 1623025179345},
-      {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "exit01", "iif":
-      "Loopback0", "oif": "Ethernet3.2", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ebgp",
-      "ipLookup": "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.2", "error": "", "timestamp": 1623025174546}, {"pathid": 2, "hopCount":
-      1, "namespace": "eos", "hostname": "firewall01", "iif": "eth1.2", "oif": "eth2.4",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "bgp", "ipLookup": "10.0.0.41/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "169.254.253.9", "error": "", "timestamp":
-      1623025175208}, {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname":
-      "exit02", "iif": "Ethernet3.4", "oif": "Ethernet4", "vrf": "internet-vrf", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "ebgp", "ipLookup": "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "10.0.0.41", "error": "", "timestamp": 1623025174538}, {"pathid": 2, "hopCount":
-      3, "namespace": "eos", "hostname": "dcedge01", "iif": "xe-0/0/1.0", "oif": "lo0.0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "no reverse path", "timestamp": 1623025179345}]'
   marks: path show eos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "exit01",
+    "iif": "Loopback0", "oif": "Ethernet3.2", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ebgp", "ipLookup":
+    "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.2",
+    "hopError": "", "timestamp": 1623025174546}, {"pathid": 1, "hopCount": 1, "namespace":
+    "eos", "hostname": "firewall01", "iif": "eth1.2", "oif": "eth1.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "bgp", "ipLookup": "10.0.0.41/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.254.9", "hopError": "", "timestamp": 1623025175208},
+    {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "exit01", "iif":
+    "Ethernet3.4", "oif": "Ethernet4", "vrf": "internet-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ebgp", "ipLookup":
+    "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.41", "hopError":
+    "", "timestamp": 1623025174546}, {"pathid": 1, "hopCount": 3, "namespace": "eos",
+    "hostname": "dcedge01", "iif": "xe-0/0/0.0", "oif": "lo0.0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 65536,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path", "timestamp": 1623025179345}, {"pathid": 2,
+    "hopCount": 0, "namespace": "eos", "hostname": "exit01", "iif": "Loopback0", "oif":
+    "Ethernet3.2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 65535, "outMtu": 1500, "protocol": "ebgp", "ipLookup": "10.0.0.41/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.2", "hopError": "",
+    "timestamp": 1623025174546}, {"pathid": 2, "hopCount": 1, "namespace": "eos",
+    "hostname": "firewall01", "iif": "eth1.2", "oif": "eth2.4", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "bgp", "ipLookup": "10.0.0.41/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "169.254.253.9", "hopError": "", "timestamp": 1623025175208},
+    {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname": "exit02", "iif":
+    "Ethernet3.4", "oif": "Ethernet4", "vrf": "internet-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol": "ebgp", "ipLookup":
+    "10.0.0.41/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.41", "hopError":
+    "", "timestamp": 1623025174538}, {"pathid": 2, "hopCount": 3, "namespace": "eos",
+    "hostname": "dcedge01", "iif": "xe-0/0/1.0", "oif": "lo0.0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 65536,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path", "timestamp": 1623025179345}]'
 - command: path summarize --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: path summarize eos

--- a/tests/integration/sqcmds/junos-samples/path.yml
+++ b/tests/integration/sqcmds/junos-samples/path.yml
@@ -7,46 +7,44 @@ tests:
   marks: path show junos
 - command: path show --dest=172.16.2.104 --src=172.16.1.101 --format=json --namespace=junos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
-      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace":
-      "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
-      "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025801173}, {"pathid": 1, "hopCount": 2, "namespace":
-      "junos", "hostname": "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
-      9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025802890}, {"pathid": 1, "hopCount": 3, "namespace": "junos", "hostname":
-      "leaf02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
-      "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802263}, {"pathid": 2,
-      "hopCount": 0, "namespace": "junos", "hostname": "server101", "iif": "eth1",
-      "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "",
-      "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 1, "namespace": "junos",
-      "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514, "outMtu":
-      9200, "protocol": "evpn", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.12",
-      "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025801173}, {"pathid": 2, "hopCount": 2, "namespace": "junos", "hostname":
-      "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2":
-      true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
-      "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12", "macLookup": "",
-      "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802688},
-      {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname": "leaf02", "iif":
-      "xe-0/0/1.0", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2": false, "overlay":
-      true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol": "direct",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802263}]'
   marks: path show junos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
+    "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace": "junos",
+    "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514, "outMtu": 9200,
+    "protocol": "evpn", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.12", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025801173},
+    {"pathid": 1, "hopCount": 2, "namespace": "junos", "hostname": "spine01", "iif":
+    "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol": "ospf", "ipLookup":
+    "10.0.0.12", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.12",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025802890}, {"pathid": 1, "hopCount":
+    3, "namespace": "junos", "hostname": "leaf02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
+    9200, "outMtu": 9200, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025802263}, {"pathid": 2, "hopCount": 0, "namespace": "junos", "hostname":
+    "server101", "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
+    "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
+    "hopError": "", "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 1, "namespace":
+    "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf":
+    "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
+    "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU <
+    Src Mtu", "timestamp": 1623025801173}, {"pathid": 2, "hopCount": 2, "namespace":
+    "junos", "hostname": "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
+    9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.12", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025802688}, {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname":
+    "leaf02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
+    "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025802263}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   error:
@@ -54,182 +52,177 @@ tests:
   marks: path show junos
 - command: path show --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=junos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
-      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace":
-      "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
-      "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.3.202/32", "vtepLookup":
-      "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025801173}, {"pathid": 1, "hopCount": 2, "namespace":
-      "junos", "hostname": "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
-      9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025802890}, {"pathid": 1, "hopCount": 3, "namespace": "junos", "hostname":
-      "leaf02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
-      "evpn", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.3.202", "error": "Hop MTU < Src Mtu", "timestamp": 1623025797587}, {"pathid":
-      1, "hopCount": 4, "namespace": "junos", "hostname": "server202", "iif": "eth1",
-      "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025795928},
-      {"pathid": 2, "hopCount": 0, "namespace": "junos", "hostname": "server101",
-      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 1, "namespace":
-      "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
-      "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.3.202/32", "vtepLookup":
-      "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025801173}, {"pathid": 2, "hopCount": 2, "namespace":
-      "junos", "hostname": "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
-      9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025802688}, {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname":
-      "leaf02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
-      "evpn", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.3.202", "error": "Hop MTU < Src Mtu", "timestamp": 1623025797587}, {"pathid":
-      2, "hopCount": 4, "namespace": "junos", "hostname": "server202", "iif": "eth1",
-      "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025795928}]'
   marks: path show junos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
+    "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace": "junos",
+    "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514, "outMtu": 9200,
+    "protocol": "evpn", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025801173}, {"pathid": 1, "hopCount": 2, "namespace": "junos", "hostname":
+    "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
+    "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp":
+    "10.0.0.12", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025802890}, {"pathid":
+    1, "hopCount": 3, "namespace": "junos", "hostname": "leaf02", "iif": "xe-0/0/0.0",
+    "oif": "xe-0/0/3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    true, "inMtu": 9200, "outMtu": 1514, "protocol": "evpn", "ipLookup": "172.16.3.202/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202", "hopError": "Hop
+    MTU < Src Mtu", "timestamp": 1623025797587}, {"pathid": 1, "hopCount": 4, "namespace":
+    "junos", "hostname": "server202", "iif": "eth1", "oif": "eth1", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 0,
+    "namespace": "junos", "hostname": "server101", "iif": "eth1", "oif": "eth1", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp": 1623025795928},
+    {"pathid": 2, "hopCount": 1, "namespace": "junos", "hostname": "leaf01", "iif":
+    "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2": true, "overlay": false,
+    "mtuMatch": false, "inMtu": 1514, "outMtu": 9200, "protocol": "evpn", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025801173}, {"pathid": 2, "hopCount":
+    2, "namespace": "junos", "hostname": "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200,
+    "outMtu": 9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.12", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025802688}, {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname":
+    "leaf02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/3", "vrf": "evpn-vrf", "isL2": false,
+    "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
+    "evpn", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.3.202", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025797587},
+    {"pathid": 2, "hopCount": 4, "namespace": "junos", "hostname": "server202", "iif":
+    "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025795928}]'
 - command: path show --dest=172.16.2.201 --src=172.16.1.101 --format=json --namespace=junos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
-      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace":
-      "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
-      "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.2.201/32", "vtepLookup":
-      "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025801173}, {"pathid": 1, "hopCount": 2, "namespace":
-      "junos", "hostname": "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
-      9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025802890}, {"pathid": 1, "hopCount": 3, "namespace": "junos", "hostname":
-      "leaf02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/2", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
-      "evpn", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.201", "error": "Hop MTU < Src Mtu", "timestamp": 1623025797587}, {"pathid":
-      1, "hopCount": 4, "namespace": "junos", "hostname": "server201", "iif": "eth1",
-      "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025795928},
-      {"pathid": 2, "hopCount": 0, "namespace": "junos", "hostname": "server101",
-      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 1, "namespace":
-      "junos", "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf":
-      "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514,
-      "outMtu": 9200, "protocol": "evpn", "ipLookup": "172.16.2.201/32", "vtepLookup":
-      "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1623025801173}, {"pathid": 2, "hopCount": 2, "namespace":
-      "junos", "hostname": "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
-      "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
-      9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
-      "macLookup": "", "nexthopIp": "10.0.0.12", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025802688}, {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname":
-      "leaf02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/2", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
-      "evpn", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.2.201", "error": "Hop MTU < Src Mtu", "timestamp": 1623025797587}, {"pathid":
-      2, "hopCount": 4, "namespace": "junos", "hostname": "server201", "iif": "eth1",
-      "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "", "timestamp": 1623025795928}]'
   marks: path show junos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server101",
+    "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1623025795928}, {"pathid": 1, "hopCount": 1, "namespace": "junos",
+    "hostname": "leaf01", "iif": "xe-0/0/2", "oif": "xe-0/0/0.0", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514, "outMtu": 9200,
+    "protocol": "evpn", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025801173}, {"pathid": 1, "hopCount": 2, "namespace": "junos", "hostname":
+    "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
+    "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp":
+    "10.0.0.12", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025802890}, {"pathid":
+    1, "hopCount": 3, "namespace": "junos", "hostname": "leaf02", "iif": "xe-0/0/0.0",
+    "oif": "xe-0/0/2", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
+    true, "inMtu": 9200, "outMtu": 1514, "protocol": "evpn", "ipLookup": "172.16.2.201/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.2.201", "hopError": "Hop
+    MTU < Src Mtu", "timestamp": 1623025797587}, {"pathid": 1, "hopCount": 4, "namespace":
+    "junos", "hostname": "server201", "iif": "eth1", "oif": "eth1", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 0,
+    "namespace": "junos", "hostname": "server101", "iif": "eth1", "oif": "eth1", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp": 1623025795928},
+    {"pathid": 2, "hopCount": 1, "namespace": "junos", "hostname": "leaf01", "iif":
+    "xe-0/0/2", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2": true, "overlay": false,
+    "mtuMatch": false, "inMtu": 1514, "outMtu": 9200, "protocol": "evpn", "ipLookup":
+    "172.16.2.201/32", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025801173}, {"pathid": 2, "hopCount":
+    2, "namespace": "junos", "hostname": "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200,
+    "outMtu": 9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.12", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025802688}, {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname":
+    "leaf02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/2", "vrf": "evpn-vrf", "isL2": false,
+    "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
+    "evpn", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.2.201", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025797587},
+    {"pathid": 2, "hopCount": 4, "namespace": "junos", "hostname": "server201", "iif":
+    "eth1", "oif": "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    false, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025795928}]'
 - command: path show --src=172.16.3.202 --dest=172.16.3.102 --format=json --namespace=junos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server202",
-      "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": true, "overlay": false,
-      "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
-      "172.16.3.102", "vtepLookup": "", "macLookup": "28:b7:ad:82:67:e5", "nexthopIp":
-      "172.16.3.102", "error": "", "timestamp": null}, {"pathid": 1, "hopCount": 1,
-      "namespace": "junos", "hostname": "leaf02", "iif": "xe-0/0/3", "oif": "xe-0/0/0.0",
-      "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      1514, "outMtu": 9200, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.11",
-      "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025802263}, {"pathid": 1, "hopCount": 2, "namespace": "junos", "hostname":
-      "spine01", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2":
-      true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
-      "ospf", "ipLookup": "10.0.0.11", "vtepLookup": "10.0.0.11", "macLookup": "",
-      "nexthopIp": "10.0.0.11", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802890},
-      {"pathid": 1, "hopCount": 3, "namespace": "junos", "hostname": "leaf01", "iif":
-      "xe-0/0/0.0", "oif": "xe-0/0/3", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol": "l2", "ipLookup":
-      "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error":
-      "Hop MTU < Src Mtu", "timestamp": 1623025798828}, {"pathid": 1, "hopCount":
-      4, "namespace": "junos", "hostname": "server102", "iif": "eth1", "oif": "eth1",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "", "timestamp": 1623025795928}, {"pathid": 2,
-      "hopCount": 0, "namespace": "junos", "hostname": "server202", "iif": "eth1",
-      "oif": "eth1", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-      "vtepLookup": "", "macLookup": "28:b7:ad:82:67:e5", "nexthopIp": "172.16.3.102",
-      "error": "", "timestamp": null}, {"pathid": 2, "hopCount": 1, "namespace": "junos",
-      "hostname": "leaf02", "iif": "xe-0/0/3", "oif": "xe-0/0/1.0", "vrf": "default",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 1514, "outMtu":
-      9200, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.11", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1623025802263},
-      {"pathid": 2, "hopCount": 2, "namespace": "junos", "hostname": "spine02", "iif":
-      "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol": "ospf", "ipLookup":
-      "10.0.0.11", "vtepLookup": "10.0.0.11", "macLookup": "", "nexthopIp": "10.0.0.11",
-      "error": "Hop MTU < Src Mtu", "timestamp": 1623025802688}, {"pathid": 2, "hopCount":
-      3, "namespace": "junos", "hostname": "leaf01", "iif": "xe-0/0/1.0", "oif": "xe-0/0/3",
-      "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu":
-      9200, "outMtu": 1514, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup":
-      "", "macLookup": null, "nexthopIp": "", "error": "Hop MTU < Src Mtu", "timestamp":
-      1623025798828}, {"pathid": 2, "hopCount": 4, "namespace": "junos", "hostname":
-      "server102", "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "", "timestamp": 1623025795928}]'
   marks: path show junos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "server202",
+    "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2": true, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": "28:b7:ad:82:67:e5", "nexthopIp":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 1, "hopCount":
+    1, "namespace": "junos", "hostname": "leaf02", "iif": "xe-0/0/3", "oif": "xe-0/0/0.0",
+    "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    1514, "outMtu": 9200, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.11",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025802263}, {"pathid": 1, "hopCount": 2, "namespace": "junos", "hostname":
+    "spine01", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
+    "ospf", "ipLookup": "10.0.0.11", "vtepLookup": "10.0.0.11", "macLookup": "", "nexthopIp":
+    "10.0.0.11", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025802890}, {"pathid":
+    1, "hopCount": 3, "namespace": "junos", "hostname": "leaf01", "iif": "xe-0/0/0.0",
+    "oif": "xe-0/0/3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9200, "outMtu": 1514, "protocol": "l2", "ipLookup": "172.16.3.102",
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "Hop MTU < Src
+    Mtu", "timestamp": 1623025798828}, {"pathid": 1, "hopCount": 4, "namespace": "junos",
+    "hostname": "server102", "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1623025795928}, {"pathid": 2, "hopCount": 0, "namespace": "junos",
+    "hostname": "server202", "iif": "eth1", "oif": "eth1", "vrf": "default", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "28:b7:ad:82:67:e5",
+    "nexthopIp": "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 2,
+    "hopCount": 1, "namespace": "junos", "hostname": "leaf02", "iif": "xe-0/0/3",
+    "oif": "xe-0/0/1.0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
+    false, "inMtu": 1514, "outMtu": 9200, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.11", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU <
+    Src Mtu", "timestamp": 1623025802263}, {"pathid": 2, "hopCount": 2, "namespace":
+    "junos", "hostname": "spine02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
+    9200, "protocol": "ospf", "ipLookup": "10.0.0.11", "vtepLookup": "10.0.0.11",
+    "macLookup": "", "nexthopIp": "10.0.0.11", "hopError": "Hop MTU < Src Mtu", "timestamp":
+    1623025802688}, {"pathid": 2, "hopCount": 3, "namespace": "junos", "hostname":
+    "leaf01", "iif": "xe-0/0/1.0", "oif": "xe-0/0/3", "vrf": "default", "isL2": true,
+    "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025798828}, {"pathid": 2,
+    "hopCount": 4, "namespace": "junos", "hostname": "server102", "iif": "eth1", "oif":
+    "eth1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025795928}]'
 - command: path show --dest=10.0.0.11 --src=10.0.0.12 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: path show junos
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "leaf02",
     "iif": "xe-0/0/0.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "timestamp":
-    1623025802263}, {"pathid": 1, "hopCount": 1, "namespace": "junos", "hostname":
-    "spine01", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol":
-    "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "10.0.0.11", "timestamp": 1623025802890}, {"pathid": 1, "hopCount": 2, "namespace":
-    "junos", "hostname": "leaf01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/0.0", "vrf":
-    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9200, "outMtu":
-    65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1623025803099}, {"pathid": 2, "hopCount": 0, "namespace": "junos",
-    "hostname": "leaf02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default",
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1623025802263}, {"pathid": 1, "hopCount": 1, "namespace": "junos",
+    "hostname": "spine01", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf": "default",
     "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200,
     "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup":
-    "", "nexthopIp": "10.0.0.22", "timestamp": 1623025802263}, {"pathid": 2, "hopCount":
-    1, "namespace": "junos", "hostname": "spine02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0",
-    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-    9200, "outMtu": 9200, "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1623025802688}, {"pathid":
+    "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": 1623025802890}, {"pathid":
+    1, "hopCount": 2, "namespace": "junos", "hostname": "leaf01", "iif": "xe-0/0/0.0",
+    "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9200, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025803099},
+    {"pathid": 2, "hopCount": 0, "namespace": "junos", "hostname": "leaf02", "iif":
+    "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200, "protocol": "ospf", "ipLookup":
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "", "timestamp": 1623025802263}, {"pathid": 2, "hopCount": 1, "namespace": "junos",
+    "hostname": "spine02", "iif": "xe-0/0/1.0", "oif": "xe-0/0/0.0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9200, "outMtu": 9200,
+    "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": 1623025802688}, {"pathid":
     2, "hopCount": 2, "namespace": "junos", "hostname": "leaf01", "iif": "xe-0/0/1.0",
     "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9200, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1623025803099}]'
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1623025803099}]'
 - command: path summarize --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: path summarize junos

--- a/tests/integration/sqcmds/mixed-samples/path.yml
+++ b/tests/integration/sqcmds/mixed-samples/path.yml
@@ -2,124 +2,123 @@ description: Testing path across mixed nodes
 tests:
 - command: path show --src='1.1.1.1' --dest='6.6.6.6' --format=json --namespace=mixed
   data-directory: tests/data/parquet
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios",
-      "iif": "Loopback0", "oif": "GigabitEthernet0/0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1514, "outMtu": 1500, "protocol":
-      "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "10.1.1.1", "error": "", "timestamp": 1627395444959}, {"pathid": 1, "hopCount":
-      1, "namespace": "mixed", "hostname": "spine1-nxos", "iif": "Ethernet1/1", "oif":
-      "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
-      "mixed", "hostname": "leaf6-eos", "iif": "Ethernet1", "oif": "Loopback0", "vrf":
-      "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1627395434695},
-      {"pathid": 2, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios",
-      "iif": "Loopback0", "oif": "GigabitEthernet0/1", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1514, "outMtu": 1500, "protocol":
-      "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "10.2.1.1", "error": "", "timestamp": 1627395444959}, {"pathid": 2, "hopCount":
-      1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/1", "oif":
-      "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "error": "Hop MTU
-      < Src Mtu", "timestamp": 1627395440281}, {"pathid": 2, "hopCount": 2, "namespace":
-      "mixed", "hostname": "leaf6-eos", "iif": "Ethernet2", "oif": "Loopback0", "vrf":
-      "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500,
-      "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp": 1627395434695}]'
   marks: path show all mixed
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios",
+    "iif": "Loopback0", "oif": "GigabitEthernet0/0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 1514, "outMtu": 1500, "protocol":
+    "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.1.1.1", "hopError": "", "timestamp": 1627395444959}, {"pathid": 1, "hopCount":
+    1, "namespace": "mixed", "hostname": "spine1-nxos", "iif": "Ethernet1/1", "oif":
+    "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
+    "mixed", "hostname": "leaf6-eos", "iif": "Ethernet1", "oif": "Loopback0", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "Dst MTU != Src MTU", "timestamp": 1627395434695}, {"pathid":
+    2, "hopCount": 0, "namespace": "mixed", "hostname": "leaf1-ios", "iif": "Loopback0",
+    "oif": "GigabitEthernet0/1", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1514, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.2.1.1", "hopError":
+    "", "timestamp": 1627395444959}, {"pathid": 2, "hopCount": 1, "namespace": "mixed",
+    "hostname": "spine2-nxos", "iif": "Ethernet1/1", "oif": "Ethernet1/6", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "6.6.6.6", "hopError": "Hop MTU < Src Mtu", "timestamp": 1627395440281},
+    {"pathid": 2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf6-eos", "iif":
+    "Ethernet2", "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1627395434695}]'
 - command: path show --src='4.4.4.4' --dest='6.6.6.6' --format=json --namespace=mixed
   data-directory: tests/data/parquet
   marks: path show all mixed
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf4-qfx",
     "iif": "lo0.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-    "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.4.1", "timestamp":
-    1627395438426}, {"pathid": 1, "hopCount": 1, "namespace": "mixed", "hostname":
-    "spine1-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/6", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-    "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "6.6.6.6", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
-    "mixed", "hostname": "leaf6-eos", "iif": "Ethernet1", "oif": "Loopback0", "vrf":
+    "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.4.1", "hopError":
+    "", "timestamp": 1627395438426}, {"pathid": 1, "hopCount": 1, "namespace": "mixed",
+    "hostname": "spine1-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/6", "vrf":
     "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
-    65535, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1627395434695}, {"pathid": 2, "hopCount": 0, "namespace": "mixed",
-    "hostname": "leaf4-qfx", "iif": "lo0.0", "oif": "xe-0/0/1.0", "vrf": "default",
-    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500,
-    "protocol": "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup": "",
-    "nexthopIp": "10.2.4.1", "timestamp": 1627395438426}, {"pathid": 2, "hopCount":
-    1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/4", "oif":
-    "Ethernet1/6", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "6.6.6.6", "timestamp": 1627395440281},
-    {"pathid": 2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf6-eos", "iif":
-    "Ethernet2", "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1627395434695}]'
+    1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "6.6.6.6", "hopError": "", "timestamp": 1627395439859}, {"pathid":
+    1, "hopCount": 2, "namespace": "mixed", "hostname": "leaf6-eos", "iif": "Ethernet1",
+    "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1627395434695},
+    {"pathid": 2, "hopCount": 0, "namespace": "mixed", "hostname": "leaf4-qfx", "iif":
+    "lo0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "6.6.6.6/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.2.4.1", "hopError":
+    "", "timestamp": 1627395438426}, {"pathid": 2, "hopCount": 1, "namespace": "mixed",
+    "hostname": "spine2-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/6", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    1500, "protocol": "ospf", "ipLookup": "6.6.6.6/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "6.6.6.6", "hopError": "", "timestamp": 1627395440281}, {"pathid":
+    2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf6-eos", "iif": "Ethernet2",
+    "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 65535, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1627395434695}]'
 - command: path show --src='4.4.4.4' --dest='2.2.2.2' --format=json --namespace=mixed
   data-directory: tests/data/parquet
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf4-qfx",
-      "iif": "lo0.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol": "ospf",
-      "ipLookup": "2.2.2.2/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.4.1",
-      "error": "", "timestamp": 1627395438426}, {"pathid": 1, "hopCount": 1, "namespace":
-      "mixed", "hostname": "spine1-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/2",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "2.2.2.2", "error": "", "timestamp": 1627395439859},
-      {"pathid": 1, "hopCount": 2, "namespace": "mixed", "hostname": "leaf2-ios",
-      "iif": "GigabitEthernet0/0", "oif": "Loopback0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1514, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1627395437566}, {"pathid": 2, "hopCount":
-      0, "namespace": "mixed", "hostname": "leaf4-qfx", "iif": "lo0.0", "oif": "xe-0/0/1.0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      65536, "outMtu": 1500, "protocol": "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "10.2.4.1", "error": "", "timestamp": 1627395438426},
-      {"pathid": 2, "hopCount": 1, "namespace": "mixed", "hostname": "spine2-nxos",
-      "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-      "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "2.2.2.2", "error": "", "timestamp": 1627395440281}, {"pathid": 2, "hopCount":
-      2, "namespace": "mixed", "hostname": "leaf2-ios", "iif": "GigabitEthernet0/1",
-      "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 1500, "outMtu": 1514, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1627395437566}]'
   marks: path show all mixed
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf4-qfx",
+    "iif": "lo0.0", "oif": "xe-0/0/0.0", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "2.2.2.2/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.4.1", "hopError":
+    "", "timestamp": 1627395438426}, {"pathid": 1, "hopCount": 1, "namespace": "mixed",
+    "hostname": "spine1-nxos", "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    1500, "protocol": "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "2.2.2.2", "hopError": "", "timestamp": 1627395439859}, {"pathid":
+    1, "hopCount": 2, "namespace": "mixed", "hostname": "leaf2-ios", "iif": "GigabitEthernet0/0",
+    "oif": "Loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 1514, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1627395437566}, {"pathid": 2, "hopCount": 0, "namespace": "mixed", "hostname":
+    "leaf4-qfx", "iif": "lo0.0", "oif": "xe-0/0/1.0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 65536, "outMtu": 1500, "protocol":
+    "ospf", "ipLookup": "2.2.2.2/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.2.4.1", "hopError": "", "timestamp": 1627395438426}, {"pathid": 2, "hopCount":
+    1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/4", "oif":
+    "Ethernet1/2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "2.2.2.2/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "2.2.2.2", "hopError": "", "timestamp":
+    1627395440281}, {"pathid": 2, "hopCount": 2, "namespace": "mixed", "hostname":
+    "leaf2-ios", "iif": "GigabitEthernet0/1", "oif": "Loopback0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1514,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "Dst MTU != Src MTU", "timestamp": 1627395437566}]'
 - command: path show --src='5.5.5.5' --dest='3.3.3.3' --format=json --namespace=mixed
   data-directory: tests/data/parquet
   marks: path show all mixed
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "mixed", "hostname": "leaf5-eos",
     "iif": "Loopback0", "oif": "Ethernet1", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ospf", "ipLookup":
-    "3.3.3.3/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.5.1", "timestamp":
-    1627395437620}, {"pathid": 1, "hopCount": 1, "namespace": "mixed", "hostname":
-    "spine1-nxos", "iif": "Ethernet1/5", "oif": "Ethernet1/3", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
-    "ospf", "ipLookup": "3.3.3.3/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "3.3.3.3", "timestamp": 1627395439859}, {"pathid": 1, "hopCount": 2, "namespace":
-    "mixed", "hostname": "leaf3-qfx", "iif": "xe-0/0/0.0", "oif": "lo0.0", "vrf":
+    "3.3.3.3/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.1.5.1", "hopError":
+    "", "timestamp": 1627395437620}, {"pathid": 1, "hopCount": 1, "namespace": "mixed",
+    "hostname": "spine1-nxos", "iif": "Ethernet1/5", "oif": "Ethernet1/3", "vrf":
     "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
-    65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1627395435943}, {"pathid": 2, "hopCount": 0, "namespace": "mixed",
-    "hostname": "leaf5-eos", "iif": "Loopback0", "oif": "Ethernet2", "vrf": "default",
-    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65535, "outMtu": 1500,
-    "protocol": "ospf", "ipLookup": "3.3.3.3/32", "vtepLookup": "", "macLookup": "",
-    "nexthopIp": "10.2.5.1", "timestamp": 1627395437620}, {"pathid": 2, "hopCount":
-    1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/5", "oif":
-    "Ethernet1/3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 1500, "outMtu": 1500, "protocol": "ospf", "ipLookup": "3.3.3.3/32",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "3.3.3.3", "timestamp": 1627395440281},
-    {"pathid": 2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf3-qfx", "iif":
-    "xe-0/0/1.0", "oif": "lo0.0", "vrf": "default", "isL2": false, "overlay": false,
-    "mtuMatch": true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1627395435943}]'
+    1500, "protocol": "ospf", "ipLookup": "3.3.3.3/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "3.3.3.3", "hopError": "", "timestamp": 1627395439859}, {"pathid":
+    1, "hopCount": 2, "namespace": "mixed", "hostname": "leaf3-qfx", "iif": "xe-0/0/0.0",
+    "oif": "lo0.0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1627395435943},
+    {"pathid": 2, "hopCount": 0, "namespace": "mixed", "hostname": "leaf5-eos", "iif":
+    "Loopback0", "oif": "Ethernet2", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 65535, "outMtu": 1500, "protocol": "ospf", "ipLookup":
+    "3.3.3.3/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.2.5.1", "hopError":
+    "", "timestamp": 1627395437620}, {"pathid": 2, "hopCount": 1, "namespace": "mixed",
+    "hostname": "spine2-nxos", "iif": "Ethernet1/5", "oif": "Ethernet1/3", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu":
+    1500, "protocol": "ospf", "ipLookup": "3.3.3.3/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "3.3.3.3", "hopError": "", "timestamp": 1627395440281}, {"pathid":
+    2, "hopCount": 2, "namespace": "mixed", "hostname": "leaf3-qfx", "iif": "xe-0/0/1.0",
+    "oif": "lo0.0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 1500, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1627395435943}]'
 - command: path show --src='10.1.1.2' --dest='10.2.6.2' --format=json --namespace=mixed
   data-directory: tests/data/parquet
   marks: path show all mixed
@@ -127,8 +126,9 @@ tests:
     "iif": "GigabitEthernet0/0", "oif": "GigabitEthernet0/1", "vrf": "default", "isL2":
     false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500, "protocol":
     "ospf", "ipLookup": "10.2.6.0/30", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "10.2.1.1", "timestamp": 1627395444959}, {"pathid": 1, "hopCount": 1, "namespace":
-    "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/1", "oif": "Ethernet2",
-    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-    1500, "outMtu": 1500, "protocol": "direct", "ipLookup": "10.2.6.0/30", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1627395440281}]'
+    "10.2.1.1", "hopError": "", "timestamp": 1627395444959}, {"pathid": 1, "hopCount":
+    1, "namespace": "mixed", "hostname": "spine2-nxos", "iif": "Ethernet1/1", "oif":
+    "Ethernet2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 1500, "outMtu": 1500, "protocol": "direct", "ipLookup": "10.2.6.0/30",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1627395440281}]'

--- a/tests/integration/sqcmds/nxos-samples/path.yml
+++ b/tests/integration/sqcmds/nxos-samples/path.yml
@@ -11,139 +11,147 @@ tests:
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "nxos", "hostname": "server101",
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 1, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257674}, {"pathid": 1, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 1, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "Ethernet1/3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
-    2, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 2, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257446}, {"pathid": 2, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 2, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "Ethernet1/3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
-    3, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257674}, {"pathid": 3, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 3, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "Ethernet1/4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}, {"pathid":
-    4, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 4, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257446}, {"pathid": 4, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 4, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "Ethernet1/4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}, {"pathid":
-    5, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 5, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257674}, {"pathid": 5, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 5, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "Ethernet1/3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
-    6, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 6, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257446}, {"pathid": 6, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 6, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "Ethernet1/3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257228}, {"pathid":
-    7, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 7, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257674}, {"pathid": 7, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 7, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "Ethernet1/4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}, {"pathid":
-    8, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 8, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257446}, {"pathid": 8, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 8, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "Ethernet1/4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275257671}]'
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 1, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257674}, {"pathid":
+    1, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif": "Ethernet1/1",
+    "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "hopError":
+    "", "timestamp": 1619275257467}, {"pathid": 1, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257228}, {"pathid": 2,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 2, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf02", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257446}, {"pathid":
+    2, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif": "Ethernet1/2",
+    "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "hopError":
+    "", "timestamp": 1619275257467}, {"pathid": 2, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257228}, {"pathid": 3,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf01", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257674}, {"pathid":
+    3, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif": "Ethernet1/1",
+    "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "hopError":
+    "", "timestamp": 1619275257467}, {"pathid": 3, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257671}, {"pathid": 4,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 4, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf02", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257446}, {"pathid":
+    4, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif": "Ethernet1/2",
+    "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "hopError":
+    "", "timestamp": 1619275257467}, {"pathid": 4, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257671}, {"pathid": 5,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 5, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf01", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257674}, {"pathid":
+    5, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif": "Ethernet1/1",
+    "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "hopError":
+    "", "timestamp": 1619275257123}, {"pathid": 5, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257228}, {"pathid": 6,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 6, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf02", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257446}, {"pathid":
+    6, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif": "Ethernet1/2",
+    "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13", "hopError":
+    "", "timestamp": 1619275257123}, {"pathid": 6, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257228}, {"pathid": 7,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 7, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf01", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257674}, {"pathid":
+    7, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif": "Ethernet1/1",
+    "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "hopError":
+    "", "timestamp": 1619275257123}, {"pathid": 7, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257671}, {"pathid": 8,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "", "timestamp":
+    1619275256085}, {"pathid": 8, "hopCount": 1, "namespace": "nxos", "hostname":
+    "leaf02", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257446}, {"pathid":
+    8, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif": "Ethernet1/2",
+    "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14", "hopError":
+    "", "timestamp": 1619275257123}, {"pathid": 8, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "direct", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257671}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   error:
@@ -155,342 +163,358 @@ tests:
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "nxos", "hostname": "server101",
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 1, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257674}, {"pathid": 1, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 1, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 1, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 1, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 1, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 1, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    2, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 2, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 2, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257446}, {"pathid": 2, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 2, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 2, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 2, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 2, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 2, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    3, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 3, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257674}, {"pathid": 3, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 3, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 3, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 3, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 3, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 3, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    4, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 4, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 4, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257446}, {"pathid": 4, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 4, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 4, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 4, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 4, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 4, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    5, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 5, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 5, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257674}, {"pathid": 5, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 5, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 5, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 5, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 5, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 5, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    6, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 6, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 6, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257446}, {"pathid": 6, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 6, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 6, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 6, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 6, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 6, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    7, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 7, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 7, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257674}, {"pathid": 7, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 7, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 7, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 7, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 7, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 7, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}, {"pathid":
-    8, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321},
+    {"pathid": 8, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 8, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257446}, {"pathid": 8, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 8, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel4",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.3.202", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 8, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.3.202/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 8, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 8, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.3.202/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.3.202", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 8, "hopCount": 4, "namespace": "nxos", "hostname": "server302", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256321}]'
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256321}]'
 - command: path show --dest=172.16.2.201 --src=172.16.1.101 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: path show nxos
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "nxos", "hostname": "server101",
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 1, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257674}, {"pathid": 1, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 1, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 1, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 1, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 1, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 1, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    2, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 2, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 2, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257446}, {"pathid": 2, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257467}, {"pathid": 2, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 2, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 2, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 2, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/1", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 2, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    3, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 3, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257674}, {"pathid": 3, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 3, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 3, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 3, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 3, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 3, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    4, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 4, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 4, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257446}, {"pathid": 4, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.13", "timestamp": 1619275257123}, {"pathid": 4, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257018},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 4, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 4, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.13",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 4, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf03", "iif": "Ethernet1/2", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257018},
     {"pathid": 4, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    5, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 5, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 5, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257674}, {"pathid": 5, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 5, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 5, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 5, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 5, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 5, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    6, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 6, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 6, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
-    "timestamp": 1619275257446}, {"pathid": 6, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257467}, {"pathid": 6, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 6, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 6, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 6, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/1", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 6, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    7, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 7, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 7, "hopCount": 1, "namespace": "nxos", "hostname": "leaf01", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257674}, {"pathid": 7, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 7, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 7, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257674},
+    {"pathid": 7, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/1", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 7, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 7, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}, {"pathid":
-    8, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205},
+    {"pathid": 8, "hopCount": 0, "namespace": "nxos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "timestamp": 1619275256085},
-    {"pathid": 8, "hopCount": 1, "namespace": "nxos", "hostname": "leaf02", "iif":
-    "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
-    "172.16.2.201/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
-    "timestamp": 1619275257446}, {"pathid": 8, "hopCount": 2, "namespace": "nxos",
-    "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default",
-    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
-    "", "nexthopIp": "10.0.0.14", "timestamp": 1619275257123}, {"pathid": 8, "hopCount":
-    3, "namespace": "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel3",
-    "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "172.16.2.201", "timestamp": 1619275257479},
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1619275256085}, {"pathid": 8, "hopCount": 1, "namespace": "nxos",
+    "hostname": "leaf02", "iif": "port-channel3", "oif": "Ethernet1/2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.201/32", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1619275257446},
+    {"pathid": 8, "hopCount": 2, "namespace": "nxos", "hostname": "spine02", "iif":
+    "Ethernet1/2", "oif": "Ethernet1/4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.14",
+    "hopError": "", "timestamp": 1619275257123}, {"pathid": 8, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "Ethernet1/2", "oif": "port-channel3", "vrf":
+    "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "hmm", "ipLookup": "172.16.2.201/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "172.16.2.201", "hopError": "", "timestamp": 1619275257479},
     {"pathid": 8, "hopCount": 4, "namespace": "nxos", "hostname": "server301", "iif":
     "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256205}]'
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256205}]'
 - command: path show --src=172.16.3.202 --dest=172.16.3.102 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: path show nxos
@@ -498,198 +522,207 @@ tests:
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false,
     "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
     "172.16.3.102", "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp":
-    "172.16.3.102", "timestamp": null}, {"pathid": 1, "hopCount": 1, "namespace":
-    "nxos", "hostname": "leaf03", "iif": "port-channel4", "oif": "Ethernet1/1", "vrf":
+    "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 1, "hopCount":
+    1, "namespace": "nxos", "hostname": "leaf03", "iif": "port-channel4", "oif": "Ethernet1/1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257228},
+    {"pathid": 1, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif":
+    "Ethernet1/3", "oif": "Ethernet1/1", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11",
+    "hopError": "", "timestamp": 1619275257467}, {"pathid": 1, "hopCount": 3, "namespace":
+    "nxos", "hostname": "leaf01", "iif": "Ethernet1/1", "oif": "port-channel4", "vrf":
+    "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup":
+    null, "nexthopIp": "", "hopError": "", "timestamp": 1619275257166}, {"pathid":
+    1, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256204},
+    {"pathid": 2, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
+    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
+    "hopError": "", "timestamp": null}, {"pathid": 2, "hopCount": 1, "namespace":
+    "nxos", "hostname": "leaf04", "iif": "port-channel4", "oif": "Ethernet1/1", "vrf":
     "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
     9216, "protocol": "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup":
-    "", "nexthopIp": "10.0.0.21", "timestamp": 1619275257228}, {"pathid": 1, "hopCount":
-    2, "namespace": "nxos", "hostname": "spine01", "iif": "Ethernet1/3", "oif": "Ethernet1/1",
-    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
-    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1619275257467}, {"pathid":
-    1, "hopCount": 3, "namespace": "nxos", "hostname": "leaf01", "iif": "Ethernet1/1",
-    "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257166},
-    {"pathid": 1, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    2, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 2, "hopCount": 1, "namespace": "nxos", "hostname":
-    "leaf04", "iif": "port-channel4", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2":
-    true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.21", "timestamp": 1619275257671}, {"pathid": 2, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine01", "iif": "Ethernet1/4", "oif": "Ethernet1/1", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1619275257467}, {"pathid":
-    2, "hopCount": 3, "namespace": "nxos", "hostname": "leaf01", "iif": "Ethernet1/1",
-    "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257166},
-    {"pathid": 2, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    3, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname":
+    "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1619275257671}, {"pathid":
+    2, "hopCount": 2, "namespace": "nxos", "hostname": "spine01", "iif": "Ethernet1/4",
+    "oif": "Ethernet1/1", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.112",
+    "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.11", "hopError":
+    "", "timestamp": 1619275257467}, {"pathid": 2, "hopCount": 3, "namespace": "nxos",
+    "hostname": "leaf01", "iif": "Ethernet1/1", "oif": "port-channel4", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1619275257166}, {"pathid": 2, "hopCount":
+    4, "namespace": "nxos", "hostname": "server102", "iif": "bond0", "oif": "bond0",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "", "timestamp": 1619275256204}, {"pathid": 3,
+    "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0", "oif":
+    "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102", "vtepLookup":
+    "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102", "hopError":
+    "", "timestamp": null}, {"pathid": 3, "hopCount": 1, "namespace": "nxos", "hostname":
     "leaf03", "iif": "port-channel4", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
     true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
     "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.22", "timestamp": 1619275257228}, {"pathid": 3, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine02", "iif": "Ethernet1/3", "oif": "Ethernet1/1", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1619275257123}, {"pathid":
-    3, "hopCount": 3, "namespace": "nxos", "hostname": "leaf01", "iif": "Ethernet1/2",
-    "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257166},
-    {"pathid": 3, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    4, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 4, "hopCount": 1, "namespace": "nxos", "hostname":
-    "leaf04", "iif": "port-channel4", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    "10.0.0.22", "hopError": "", "timestamp": 1619275257228}, {"pathid": 3, "hopCount":
+    2, "namespace": "nxos", "hostname": "spine02", "iif": "Ethernet1/3", "oif": "Ethernet1/1",
+    "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216,
+    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
+    "macLookup": "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": 1619275257123},
+    {"pathid": 3, "hopCount": 3, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "Ethernet1/2", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup":
+    "172.16.3.102", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275257166}, {"pathid": 3, "hopCount": 4, "namespace": "nxos",
+    "hostname": "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275256204}, {"pathid": 4, "hopCount": 0, "namespace": "nxos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
     true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.22", "timestamp": 1619275257671}, {"pathid": 4, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine02", "iif": "Ethernet1/4", "oif": "Ethernet1/1", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1619275257123}, {"pathid":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a",
+    "nexthopIp": "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 4,
+    "hopCount": 1, "namespace": "nxos", "hostname": "leaf04", "iif": "port-channel4",
+    "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
+    1619275257671}, {"pathid": 4, "hopCount": 2, "namespace": "nxos", "hostname":
+    "spine02", "iif": "Ethernet1/4", "oif": "Ethernet1/1", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
+    "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": 1619275257123}, {"pathid":
     4, "hopCount": 3, "namespace": "nxos", "hostname": "leaf01", "iif": "Ethernet1/2",
     "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257166},
-    {"pathid": 4, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    5, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 5, "hopCount": 1, "namespace": "nxos", "hostname":
-    "leaf03", "iif": "port-channel4", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2":
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1619275257166}, {"pathid": 4, "hopCount": 4, "namespace": "nxos", "hostname":
+    "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275256204}, {"pathid": 5, "hopCount": 0, "namespace": "nxos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
     true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.21", "timestamp": 1619275257228}, {"pathid": 5, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine01", "iif": "Ethernet1/3", "oif": "Ethernet1/2", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.12", "timestamp": 1619275257467}, {"pathid":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a",
+    "nexthopIp": "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 5,
+    "hopCount": 1, "namespace": "nxos", "hostname": "leaf03", "iif": "port-channel4",
+    "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp":
+    1619275257228}, {"pathid": 5, "hopCount": 2, "namespace": "nxos", "hostname":
+    "spine01", "iif": "Ethernet1/3", "oif": "Ethernet1/2", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
+    "nexthopIp": "10.0.0.12", "hopError": "", "timestamp": 1619275257467}, {"pathid":
     5, "hopCount": 3, "namespace": "nxos", "hostname": "leaf02", "iif": "Ethernet1/1",
     "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257446},
-    {"pathid": 5, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    6, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 6, "hopCount": 1, "namespace": "nxos", "hostname":
-    "leaf04", "iif": "port-channel4", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2":
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1619275257446}, {"pathid": 5, "hopCount": 4, "namespace": "nxos", "hostname":
+    "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275256204}, {"pathid": 6, "hopCount": 0, "namespace": "nxos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
     true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.21", "timestamp": 1619275257671}, {"pathid": 6, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine01", "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.12", "timestamp": 1619275257467}, {"pathid":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a",
+    "nexthopIp": "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 6,
+    "hopCount": 1, "namespace": "nxos", "hostname": "leaf04", "iif": "port-channel4",
+    "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp":
+    1619275257671}, {"pathid": 6, "hopCount": 2, "namespace": "nxos", "hostname":
+    "spine01", "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
+    "nexthopIp": "10.0.0.12", "hopError": "", "timestamp": 1619275257467}, {"pathid":
     6, "hopCount": 3, "namespace": "nxos", "hostname": "leaf02", "iif": "Ethernet1/1",
     "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257446},
-    {"pathid": 6, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    7, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 7, "hopCount": 1, "namespace": "nxos", "hostname":
-    "leaf03", "iif": "port-channel4", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1619275257446}, {"pathid": 6, "hopCount": 4, "namespace": "nxos", "hostname":
+    "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275256204}, {"pathid": 7, "hopCount": 0, "namespace": "nxos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
     true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.22", "timestamp": 1619275257228}, {"pathid": 7, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine02", "iif": "Ethernet1/3", "oif": "Ethernet1/2", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.12", "timestamp": 1619275257123}, {"pathid":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a",
+    "nexthopIp": "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 7,
+    "hopCount": 1, "namespace": "nxos", "hostname": "leaf03", "iif": "port-channel4",
+    "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
+    1619275257228}, {"pathid": 7, "hopCount": 2, "namespace": "nxos", "hostname":
+    "spine02", "iif": "Ethernet1/3", "oif": "Ethernet1/2", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
+    "nexthopIp": "10.0.0.12", "hopError": "", "timestamp": 1619275257123}, {"pathid":
     7, "hopCount": 3, "namespace": "nxos", "hostname": "leaf02", "iif": "Ethernet1/2",
     "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257446},
-    {"pathid": 7, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}, {"pathid":
-    8, "hopCount": 0, "namespace": "nxos", "hostname": "server302", "iif": "bond0",
-    "oif": "bond0", "vrf": "default", "isL2": true, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a", "nexthopIp": "172.16.3.102",
-    "timestamp": null}, {"pathid": 8, "hopCount": 1, "namespace": "nxos", "hostname":
-    "leaf04", "iif": "port-channel4", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2":
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1619275257446}, {"pathid": 7, "hopCount": 4, "namespace": "nxos", "hostname":
+    "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275256204}, {"pathid": 8, "hopCount": 0, "namespace": "nxos",
+    "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2":
     true, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "", "vtepLookup": "10.0.0.112", "macLookup": "", "nexthopIp":
-    "10.0.0.22", "timestamp": 1619275257671}, {"pathid": 8, "hopCount": 2, "namespace":
-    "nxos", "hostname": "spine02", "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf":
-    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    9216, "protocol": "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112",
-    "macLookup": "", "nexthopIp": "10.0.0.12", "timestamp": 1619275257123}, {"pathid":
+    "l2", "ipLookup": "172.16.3.102", "vtepLookup": "", "macLookup": "da:bf:63:c6:2f:0a",
+    "nexthopIp": "172.16.3.102", "hopError": "", "timestamp": null}, {"pathid": 8,
+    "hopCount": 1, "namespace": "nxos", "hostname": "leaf04", "iif": "port-channel4",
+    "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "", "vtepLookup":
+    "10.0.0.112", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
+    1619275257671}, {"pathid": 8, "hopCount": 2, "namespace": "nxos", "hostname":
+    "spine02", "iif": "Ethernet1/4", "oif": "Ethernet1/2", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.112", "vtepLookup": "10.0.0.112", "macLookup": "",
+    "nexthopIp": "10.0.0.12", "hopError": "", "timestamp": 1619275257123}, {"pathid":
     8, "hopCount": 3, "namespace": "nxos", "hostname": "leaf02", "iif": "Ethernet1/2",
     "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": true, "overlay": true, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "l2", "ipLookup": "172.16.3.102",
-    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "timestamp": 1619275257446},
-    {"pathid": 8, "hopCount": 4, "namespace": "nxos", "hostname": "server102", "iif":
-    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275256204}]'
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1619275257446}, {"pathid": 8, "hopCount": 4, "namespace": "nxos", "hostname":
+    "server102", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "", "timestamp": 1619275256204}]'
 - command: path show --dest=10.0.0.11 --src=10.0.0.14 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: path show nxos
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "nxos", "hostname": "leaf04",
     "iif": "loopback0", "oif": "Ethernet1/1", "vrf": "default", "isL2": false, "overlay":
     false, "mtuMatch": true, "inMtu": 1500, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "timestamp":
-    1619275257671}, {"pathid": 1, "hopCount": 1, "namespace": "nxos", "hostname":
-    "spine01", "iif": "Ethernet1/4", "oif": "Ethernet1/1", "vrf": "default", "isL2":
-    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-    "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "10.0.0.11", "timestamp": 1619275257467}, {"pathid": 1, "hopCount": 2, "namespace":
-    "nxos", "hostname": "leaf01", "iif": "Ethernet1/1", "oif": "loopback0", "vrf":
-    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
-    1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
-    "", "timestamp": 1619275258762}, {"pathid": 2, "hopCount": 0, "namespace": "nxos",
-    "hostname": "leaf04", "iif": "loopback0", "oif": "Ethernet1/2", "vrf": "default",
-    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 1500, "outMtu": 9216,
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1619275257671}, {"pathid": 1, "hopCount": 1, "namespace": "nxos",
+    "hostname": "spine01", "iif": "Ethernet1/4", "oif": "Ethernet1/1", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
     "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup":
-    "", "nexthopIp": "10.0.0.22", "timestamp": 1619275257671}, {"pathid": 2, "hopCount":
-    1, "namespace": "nxos", "hostname": "spine02", "iif": "Ethernet1/4", "oif": "Ethernet1/1",
-    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-    9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1619275257123}, {"pathid":
+    "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": 1619275257467}, {"pathid":
+    1, "hopCount": 2, "namespace": "nxos", "hostname": "leaf01", "iif": "Ethernet1/1",
+    "oif": "loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275258762},
+    {"pathid": 2, "hopCount": 0, "namespace": "nxos", "hostname": "leaf04", "iif":
+    "loopback0", "oif": "Ethernet1/2", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "", "timestamp": 1619275257671}, {"pathid": 2, "hopCount": 1, "namespace": "nxos",
+    "hostname": "spine02", "iif": "Ethernet1/4", "oif": "Ethernet1/1", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp": 1619275257123}, {"pathid":
     2, "hopCount": 2, "namespace": "nxos", "hostname": "leaf01", "iif": "Ethernet1/2",
     "oif": "loopback0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1619275258762}]'
+    "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp": 1619275258762}]'
 - command: path summarize --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: path summarize nxos

--- a/tests/integration/sqcmds/panos-samples/path.yml
+++ b/tests/integration/sqcmds/panos-samples/path.yml
@@ -197,97 +197,96 @@ tests:
     7}, {"panos": 9000}, {"panos": true}, {"panos": true}]'
 - command: path show --src=172.16.1.101 --dest=10.0.0.200 --format=json --namespace=panos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "10.0.0.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1639476253490}, {"pathid": 1, "hopCount": 1, "namespace":
-      "panos", "hostname": "leaf01", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu":
-      9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "10.0.0.32",
-      "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp":
-      1639476253487}, {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname":
-      "spine01", "iif": "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.32", "vtepLookup": "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.32",
-      "error": "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount": 3, "namespace":
-      "panos", "hostname": "exit02", "iif": "swp1", "oif": "swp3.3", "vrf": "evpn-vrf",
-      "isL2": false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "", "macLookup":
-      "", "nexthopIp": "10.0.0.200", "error": "", "timestamp": 1639476253487}, {"pathid":
-      1, "hopCount": 4, "namespace": "panos", "hostname": "firewall01", "iif": "ethernet1/2",
-      "oif": "loopback", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      false, "inMtu": 1500, "outMtu": 0, "protocol": "", "ipLookup": "", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1639476254171}, {"pathid": 2, "hopCount": 0, "namespace": "panos", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "10.0.0.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1639476253490}, {"pathid": 2, "hopCount":
-      1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup":
-      "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1639476253487}, {"pathid": 2, "hopCount": 2, "namespace":
-      "panos", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "ospf", "ipLookup": "10.0.0.32", "vtepLookup": "10.0.0.32", "macLookup":
-      "", "nexthopIp": "10.0.0.32", "error": "", "timestamp": 1639476253487}, {"pathid":
-      2, "hopCount": 3, "namespace": "panos", "hostname": "exit02", "iif": "swp1",
-      "oif": "swp3.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.200", "error": "", "timestamp":
-      1639476253487}, {"pathid": 2, "hopCount": 4, "namespace": "panos", "hostname":
-      "firewall01", "iif": "ethernet1/2", "oif": "loopback", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 0, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254171}, {"pathid": 3, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "10.0.0.0/24", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 3, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf01", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "10.0.0.200/32", "vtepLookup": "10.0.0.32", "macLookup": "", "nexthopIp":
-      "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      3, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp1",
-      "oif": "swp6", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.32",
-      "vtepLookup": "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.32", "error":
-      "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount": 3, "namespace": "panos",
-      "hostname": "exit02", "iif": "swp2", "oif": "swp3.3", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "10.0.0.200", "error": "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount":
-      4, "namespace": "panos", "hostname": "firewall01", "iif": "ethernet1/2", "oif":
-      "loopback", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
-      "inMtu": 1500, "outMtu": 0, "protocol": "", "ipLookup": "", "vtepLookup": "",
-      "macLookup": "", "nexthopIp": "", "error": "Dst MTU != Src MTU", "timestamp":
-      1639476254171}, {"pathid": 4, "hopCount": 0, "namespace": "panos", "hostname":
-      "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "", "ipLookup": "10.0.0.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "172.16.1.254", "error": "", "timestamp": 1639476253490}, {"pathid": 4, "hopCount":
-      1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10", "oif": "swp2",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup":
-      "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.22", "error": "Hop MTU <
-      Src Mtu", "timestamp": 1639476253487}, {"pathid": 4, "hopCount": 2, "namespace":
-      "panos", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
-      "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
-      "protocol": "ospf", "ipLookup": "10.0.0.32", "vtepLookup": "10.0.0.32", "macLookup":
-      "", "nexthopIp": "10.0.0.32", "error": "", "timestamp": 1639476253487}, {"pathid":
-      4, "hopCount": 3, "namespace": "panos", "hostname": "exit02", "iif": "swp2",
-      "oif": "swp3.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.200", "error": "", "timestamp":
-      1639476253487}, {"pathid": 4, "hopCount": 4, "namespace": "panos", "hostname":
-      "firewall01", "iif": "ethernet1/2", "oif": "loopback", "vrf": "default", "isL2":
-      false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 0, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254171}]'
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "10.0.0.0/24",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1639476253490}, {"pathid": 1, "hopCount": 1, "namespace": "panos",
+    "hostname": "leaf01", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "10.0.0.32", "macLookup": "",
+    "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1639476253487},
+    {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif":
+    "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.32",
+    "vtepLookup": "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.32", "hopError":
+    "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount": 3, "namespace": "panos",
+    "hostname": "exit02", "iif": "swp1", "oif": "swp3.3", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.0.0.200", "hopError": "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount":
+    4, "namespace": "panos", "hostname": "firewall01", "iif": "ethernet1/2", "oif":
+    "loopback", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 0, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254171}, {"pathid": 2, "hopCount": 0, "namespace": "panos", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "10.0.0.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid": 2, "hopCount":
+    1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10", "oif": "swp1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup":
+    "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU <
+    Src Mtu", "timestamp": 1639476253487}, {"pathid": 2, "hopCount": 2, "namespace":
+    "panos", "hostname": "spine01", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.32", "vtepLookup": "10.0.0.32", "macLookup":
+    "", "nexthopIp": "10.0.0.32", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    2, "hopCount": 3, "namespace": "panos", "hostname": "exit02", "iif": "swp1", "oif":
+    "swp3.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.200", "hopError": "",
+    "timestamp": 1639476253487}, {"pathid": 2, "hopCount": 4, "namespace": "panos",
+    "hostname": "firewall01", "iif": "ethernet1/2", "oif": "loopback", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 0,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "Dst MTU != Src MTU", "timestamp": 1639476254171}, {"pathid":
+    3, "hopCount": 0, "namespace": "panos", "hostname": "server101", "iif": "bond0",
+    "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "10.0.0.0/24",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1639476253490}, {"pathid": 3, "hopCount": 1, "namespace": "panos",
+    "hostname": "leaf01", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "10.0.0.32", "macLookup": "",
+    "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp": 1639476253487},
+    {"pathid": 3, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif":
+    "swp1", "oif": "swp6", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.32",
+    "vtepLookup": "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.32", "hopError":
+    "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount": 3, "namespace": "panos",
+    "hostname": "exit02", "iif": "swp2", "oif": "swp3.3", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.0.0.200", "hopError": "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount":
+    4, "namespace": "panos", "hostname": "firewall01", "iif": "ethernet1/2", "oif":
+    "loopback", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false,
+    "inMtu": 1500, "outMtu": 0, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254171}, {"pathid": 4, "hopCount": 0, "namespace": "panos", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "10.0.0.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid": 4, "hopCount":
+    1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10", "oif": "swp2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32", "vtepLookup":
+    "10.0.0.32", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU <
+    Src Mtu", "timestamp": 1639476253487}, {"pathid": 4, "hopCount": 2, "namespace":
+    "panos", "hostname": "spine02", "iif": "swp2", "oif": "swp6", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.32", "vtepLookup": "10.0.0.32", "macLookup":
+    "", "nexthopIp": "10.0.0.32", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    4, "hopCount": 3, "namespace": "panos", "hostname": "exit02", "iif": "swp2", "oif":
+    "swp3.3", "vrf": "evpn-vrf", "isL2": false, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "10.0.0.200/32",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.200", "hopError": "",
+    "timestamp": 1639476253487}, {"pathid": 4, "hopCount": 4, "namespace": "panos",
+    "hostname": "firewall01", "iif": "ethernet1/2", "oif": "loopback", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 1500, "outMtu": 0,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "Dst MTU != Src MTU", "timestamp": 1639476254171}]'
 - command: path show --namespace=panos --dest='172.16.2.254' --src='10.0.0.200' --format=json
   data-directory: tests/data/parquet/
   description: shows off recursive route handling in path

--- a/tests/integration/sqcmds/panos-samples/path.yml
+++ b/tests/integration/sqcmds/panos-samples/path.yml
@@ -6,189 +6,190 @@ tests:
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "spine01",
     "iif": "lo", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 65536, "outMtu": 65536, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1639476254852}]'
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1639476254852}]'
 - command: path show --dest=172.16.2.201 --src=172.16.2.201 --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: path show panos
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "server301",
     "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1639476253889}]'
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1639476253889}]'
 - command: path show --dest=10.0.0.11 --src=10.0.0.14 --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: path show panos
   output: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "leaf04",
     "iif": "lo", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false,
     "mtuMatch": true, "inMtu": 65536, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "timestamp":
-    1639476253487}, {"pathid": 1, "hopCount": 1, "namespace": "panos", "hostname":
-    "spine01", "iif": "swp4", "oif": "swp1", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp":
-    1639476253487}, {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname":
-    "leaf01", "iif": "swp1", "oif": "lo", "vrf": "default", "isL2": false, "overlay":
-    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
-    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "timestamp": 1639476254854},
-    {"pathid": 2, "hopCount": 0, "namespace": "panos", "hostname": "leaf04", "iif":
-    "lo", "oif": "swp2", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 65536, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.11/32",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.22", "timestamp": 1639476253487},
+    "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount": 1, "namespace": "panos",
+    "hostname": "spine01", "iif": "swp4", "oif": "swp1", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "10.0.0.11", "hopError": "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount":
+    2, "namespace": "panos", "hostname": "leaf01", "iif": "swp1", "oif": "lo", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    65536, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "", "timestamp": 1639476254854}, {"pathid": 2, "hopCount": 0,
+    "namespace": "panos", "hostname": "leaf04", "iif": "lo", "oif": "swp2", "vrf":
+    "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 65536,
+    "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.11/32", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1639476253487},
     {"pathid": 2, "hopCount": 1, "namespace": "panos", "hostname": "spine02", "iif":
     "swp4", "oif": "swp1", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
     true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.11/32",
-    "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "timestamp": 1639476253487},
-    {"pathid": 2, "hopCount": 2, "namespace": "panos", "hostname": "leaf01", "iif":
-    "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-    true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup": "", "vtepLookup":
-    "", "macLookup": "", "nexthopIp": "", "timestamp": 1639476254854}]'
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "10.0.0.11", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 2, "hopCount": 2, "namespace": "panos", "hostname":
+    "leaf01", "iif": "swp2", "oif": "lo", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 65536, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "", "timestamp":
+    1639476254854}]'
 - command: path show --src=172.16.1.101 --dest=172.16.2.254 --format=json --namespace=panos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "server101",
-      "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay":
-      false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup":
-      "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254",
-      "error": "", "timestamp": 1639476253490}, {"pathid": 1, "hopCount": 1, "namespace":
-      "panos", "hostname": "leaf01", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf",
-      "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu":
-      9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134",
-      "macLookup": "", "nexthopIp": "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp":
-      1639476253487}, {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname":
-      "spine01", "iif": "swp1", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error":
-      "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount": 3, "namespace": "panos",
-      "hostname": "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 2, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 2, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf02", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      2, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp2",
-      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 2, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 3, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 3, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf01", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      3, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp1",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 3, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 4, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 4, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf02", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.21", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      4, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp2",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 4, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 5, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 5, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf01", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      5, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp1",
-      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 5, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 6, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 6, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf02", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      6, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp2",
-      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 6, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 7, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 7, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf01", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      7, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp1",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 7, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 8, "hopCount":
-      0, "namespace": "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0",
-      "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
-      9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup":
-      "", "macLookup": "", "nexthopIp": "172.16.1.254", "error": "", "timestamp":
-      1639476253490}, {"pathid": 8, "hopCount": 1, "namespace": "panos", "hostname":
-      "leaf02", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
-      false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp",
-      "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp":
-      "10.0.0.22", "error": "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid":
-      8, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp2",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 8, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}]'
   marks: path show panos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "server101",
+    "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1639476253490}, {"pathid": 1, "hopCount": 1, "namespace": "panos",
+    "hostname": "leaf01", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1639476253487},
+    {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif":
+    "swp1", "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 1, "hopCount": 3, "namespace": "panos", "hostname":
+    "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1639476254844}, {"pathid": 2, "hopCount": 0, "namespace":
+    "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid":
+    2, "hopCount": 1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10",
+    "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError":
+    "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid": 2, "hopCount": 2,
+    "namespace": "panos", "hostname": "spine01", "iif": "swp2", "oif": "swp3", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup":
+    null, "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    2, "hopCount": 3, "namespace": "panos", "hostname": "leaf03", "iif": "swp1", "oif":
+    "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254844}, {"pathid": 3, "hopCount": 0, "namespace": "panos", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid": 3, "hopCount":
+    1, "namespace": "panos", "hostname": "leaf01", "iif": "Vlan10", "oif": "swp1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1639476253487}, {"pathid": 3, "hopCount": 2, "namespace":
+    "panos", "hostname": "spine01", "iif": "swp1", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount":
+    3, "namespace": "panos", "hostname": "leaf04", "iif": "swp1", "oif": "Vlan20",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1639476254836},
+    {"pathid": 4, "hopCount": 0, "namespace": "panos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1639476253490}, {"pathid": 4, "hopCount": 1, "namespace": "panos",
+    "hostname": "leaf02", "iif": "Vlan10", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.21", "hopError": "Hop MTU < Src Mtu", "timestamp": 1639476253487},
+    {"pathid": 4, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif":
+    "swp2", "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 4, "hopCount": 3, "namespace": "panos", "hostname":
+    "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1639476254836}, {"pathid": 5, "hopCount": 0, "namespace":
+    "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid":
+    5, "hopCount": 1, "namespace": "panos", "hostname": "leaf01", "iif": "Vlan10",
+    "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid": 5, "hopCount": 2,
+    "namespace": "panos", "hostname": "spine02", "iif": "swp1", "oif": "swp3", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup":
+    null, "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    5, "hopCount": 3, "namespace": "panos", "hostname": "leaf03", "iif": "swp2", "oif":
+    "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254844}, {"pathid": 6, "hopCount": 0, "namespace": "panos", "hostname":
+    "server101", "iif": "bond0", "oif": "bond0", "vrf": "default", "isL2": false,
+    "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid": 6, "hopCount":
+    1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10", "oif": "swp2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "Hop MTU
+    < Src Mtu", "timestamp": 1639476253487}, {"pathid": 6, "hopCount": 2, "namespace":
+    "panos", "hostname": "spine02", "iif": "swp2", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid": 6, "hopCount":
+    3, "namespace": "panos", "hostname": "leaf03", "iif": "swp2", "oif": "Vlan20",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1639476254844},
+    {"pathid": 7, "hopCount": 0, "namespace": "panos", "hostname": "server101", "iif":
+    "bond0", "oif": "bond0", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "", "ipLookup": "172.16.0.0/16",
+    "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.1.254", "hopError": "",
+    "timestamp": 1639476253490}, {"pathid": 7, "hopCount": 1, "namespace": "panos",
+    "hostname": "leaf01", "iif": "Vlan10", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
+    true, "overlay": false, "mtuMatch": false, "inMtu": 9000, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "",
+    "nexthopIp": "10.0.0.22", "hopError": "Hop MTU < Src Mtu", "timestamp": 1639476253487},
+    {"pathid": 7, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif":
+    "swp1", "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
+    "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 7, "hopCount": 3, "namespace": "panos", "hostname":
+    "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup":
+    "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU !=
+    Src MTU", "timestamp": 1639476254836}, {"pathid": 8, "hopCount": 0, "namespace":
+    "panos", "hostname": "server101", "iif": "bond0", "oif": "bond0", "vrf": "default",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "172.16.0.0/16", "vtepLookup": "", "macLookup": "",
+    "nexthopIp": "172.16.1.254", "hopError": "", "timestamp": 1639476253490}, {"pathid":
+    8, "hopCount": 1, "namespace": "panos", "hostname": "leaf02", "iif": "Vlan10",
+    "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch":
+    false, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError":
+    "Hop MTU < Src Mtu", "timestamp": 1639476253487}, {"pathid": 8, "hopCount": 2,
+    "namespace": "panos", "hostname": "spine02", "iif": "swp2", "oif": "swp4", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup":
+    null, "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    8, "hopCount": 3, "namespace": "panos", "hostname": "leaf04", "iif": "swp2", "oif":
+    "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "",
+    "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254836}]'
 - command: path summarize --dest=172.16.2.254 --src=172.16.1.101 --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: path summarize panos
@@ -290,149 +291,143 @@ tests:
 - command: path show --namespace=panos --dest='172.16.2.254' --src='10.0.0.200' --format=json
   data-directory: tests/data/parquet/
   description: shows off recursive route handling in path
-  error:
-    error: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "firewall01",
-      "iif": "loopback", "oif": "ethernet1/1.3", "vrf": "default", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
-      "169.254.254.5", "error": "", "timestamp": 1639476253357}, {"pathid": 1, "hopCount":
-      1, "namespace": "panos", "hostname": "exit01", "iif": "swp3.3", "oif": "swp1",
-      "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
-      9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
-      "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "error": "", "timestamp":
-      1639476253487}, {"pathid": 1, "hopCount": 2, "namespace": "panos", "hostname":
-      "spine01", "iif": "swp5", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
-      true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
-      "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error":
-      "", "timestamp": 1639476253487}, {"pathid": 1, "hopCount": 3, "namespace": "panos",
-      "hostname": "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2":
-      false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 2, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 2, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit02", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.21", "error": "", "timestamp": 1639476253487}, {"pathid":
-      2, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp6",
-      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 2, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 3, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 3, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit01", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.21", "error": "", "timestamp": 1639476253487}, {"pathid":
-      3, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp5",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 3, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 4, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 4, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit02", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.21", "error": "", "timestamp": 1639476253487}, {"pathid":
-      4, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp6",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 4, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 5, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 5, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit01", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
-      5, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp5",
-      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 5, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 6, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 6, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit02", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
-      6, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp6",
-      "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 6, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 7, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 7, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit01", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
-      7, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp5",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 7, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}, {"pathid": 8, "hopCount":
-      0, "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif":
-      "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay": false, "mtuMatch":
-      true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24",
-      "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5", "error": "",
-      "timestamp": 1639476253357}, {"pathid": 8, "hopCount": 1, "namespace": "panos",
-      "hostname": "exit02", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2":
-      true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol":
-      "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
-      "", "nexthopIp": "10.0.0.22", "error": "", "timestamp": 1639476253487}, {"pathid":
-      8, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp6",
-      "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch":
-      true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134",
-      "vtepLookup": "", "macLookup": null, "nexthopIp": "", "error": "", "timestamp":
-      1639476253487}, {"pathid": 8, "hopCount": 3, "namespace": "panos", "hostname":
-      "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false,
-      "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
-      "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "error":
-      "Dst MTU != Src MTU", "timestamp": 1639476254836}]'
   marks: path show panos recursive
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "panos", "hostname": "firewall01",
+    "iif": "loopback", "oif": "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5",
+    "hopError": "", "timestamp": 1639476253357}, {"pathid": 1, "hopCount": 1, "namespace":
+    "panos", "hostname": "exit01", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    1, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp5",
+    "oif": "swp3", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp": 1639476253487},
+    {"pathid": 1, "hopCount": 3, "namespace": "panos", "hostname": "leaf03", "iif":
+    "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254844}, {"pathid": 2, "hopCount": 0, "namespace": "panos", "hostname":
+    "firewall01", "iif": "loopback", "oif": "ethernet1/2.3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.253.5", "hopError": "", "timestamp": 1639476253357}, {"pathid": 2, "hopCount":
+    1, "namespace": "panos", "hostname": "exit02", "iif": "swp3.3", "oif": "swp1",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 2, "hopCount": 2, "namespace": "panos", "hostname":
+    "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1639476253487}, {"pathid": 2, "hopCount": 3, "namespace": "panos",
+    "hostname": "leaf03", "iif": "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 3, "hopCount": 0,
+    "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif": "ethernet1/1.3",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.254.5", "hopError": "", "timestamp":
+    1639476253357}, {"pathid": 3, "hopCount": 1, "namespace": "panos", "hostname":
+    "exit01", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount": 2, "namespace":
+    "panos", "hostname": "spine01", "iif": "swp5", "oif": "swp4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid": 3, "hopCount":
+    3, "namespace": "panos", "hostname": "leaf04", "iif": "swp1", "oif": "Vlan20",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1639476254836},
+    {"pathid": 4, "hopCount": 0, "namespace": "panos", "hostname": "firewall01", "iif":
+    "loopback", "oif": "ethernet1/2.3", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.253.5",
+    "hopError": "", "timestamp": 1639476253357}, {"pathid": 4, "hopCount": 1, "namespace":
+    "panos", "hostname": "exit02", "iif": "swp3.3", "oif": "swp1", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.21", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    4, "hopCount": 2, "namespace": "panos", "hostname": "spine01", "iif": "swp6",
+    "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp": 1639476253487},
+    {"pathid": 4, "hopCount": 3, "namespace": "panos", "hostname": "leaf04", "iif":
+    "swp1", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254836}, {"pathid": 5, "hopCount": 0, "namespace": "panos", "hostname":
+    "firewall01", "iif": "loopback", "oif": "ethernet1/1.3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.254.5", "hopError": "", "timestamp": 1639476253357}, {"pathid": 5, "hopCount":
+    1, "namespace": "panos", "hostname": "exit01", "iif": "swp3.3", "oif": "swp2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 5, "hopCount": 2, "namespace": "panos", "hostname":
+    "spine02", "iif": "swp5", "oif": "swp3", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1639476253487}, {"pathid": 5, "hopCount": 3, "namespace": "panos",
+    "hostname": "leaf03", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "Dst MTU != Src MTU", "timestamp": 1639476254844}, {"pathid": 6, "hopCount": 0,
+    "namespace": "panos", "hostname": "firewall01", "iif": "loopback", "oif": "ethernet1/2.3",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    0, "outMtu": 1500, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "169.254.253.5", "hopError": "", "timestamp":
+    1639476253357}, {"pathid": 6, "hopCount": 1, "namespace": "panos", "hostname":
+    "exit02", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf", "isL2": true, "overlay":
+    false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1639476253487}, {"pathid": 6, "hopCount": 2, "namespace":
+    "panos", "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1639476253487}, {"pathid": 6, "hopCount":
+    3, "namespace": "panos", "hostname": "leaf03", "iif": "swp2", "oif": "Vlan20",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": true, "inMtu":
+    9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1639476254844},
+    {"pathid": 7, "hopCount": 0, "namespace": "panos", "hostname": "firewall01", "iif":
+    "loopback", "oif": "ethernet1/1.3", "vrf": "default", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol": "bgp", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "169.254.254.5",
+    "hopError": "", "timestamp": 1639476253357}, {"pathid": 7, "hopCount": 1, "namespace":
+    "panos", "hostname": "exit01", "iif": "swp3.3", "oif": "swp2", "vrf": "evpn-vrf",
+    "isL2": true, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp": 1639476253487}, {"pathid":
+    7, "hopCount": 2, "namespace": "panos", "hostname": "spine02", "iif": "swp5",
+    "oif": "swp4", "vrf": "default", "isL2": true, "overlay": true, "mtuMatch": true,
+    "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup":
+    "", "macLookup": null, "nexthopIp": "", "hopError": "", "timestamp": 1639476253487},
+    {"pathid": 7, "hopCount": 3, "namespace": "panos", "hostname": "leaf04", "iif":
+    "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9216, "outMtu": 9000, "protocol": "", "ipLookup": "", "vtepLookup":
+    "", "macLookup": "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp":
+    1639476254836}, {"pathid": 8, "hopCount": 0, "namespace": "panos", "hostname":
+    "firewall01", "iif": "loopback", "oif": "ethernet1/2.3", "vrf": "default", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 0, "outMtu": 1500, "protocol":
+    "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "169.254.253.5", "hopError": "", "timestamp": 1639476253357}, {"pathid": 8, "hopCount":
+    1, "namespace": "panos", "hostname": "exit02", "iif": "swp3.3", "oif": "swp2",
+    "vrf": "evpn-vrf", "isL2": true, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "bgp", "ipLookup": "172.16.2.0/24", "vtepLookup":
+    "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22", "hopError": "", "timestamp":
+    1639476253487}, {"pathid": 8, "hopCount": 2, "namespace": "panos", "hostname":
+    "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2": true, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "ospf", "ipLookup":
+    "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp": "", "hopError":
+    "", "timestamp": 1639476253487}, {"pathid": 8, "hopCount": 3, "namespace": "panos",
+    "hostname": "leaf04", "iif": "swp2", "oif": "Vlan20", "vrf": "evpn-vrf", "isL2":
+    false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9000, "protocol":
+    "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp": "", "hopError":
+    "Dst MTU != Src MTU", "timestamp": 1639476254836}]'

--- a/tests/unit/poller/controller/manager/test_static_manager.py
+++ b/tests/unit/poller/controller/manager/test_static_manager.py
@@ -137,10 +137,7 @@ def test_static_manager_init(monkeypatch, manager_cfg, max_outstanding_cmds):
     manager_args['exclude-services'] = ['arpn']
     manager_args['service-only'] = ['interfaces', 'ospf']
     manager_args['ssh-config-file'] = 'ssh_config_file'
-
-    # Set the poller settings
-    poller_cfg = manager_cfg['config-dict']['poller']
-    poller_cfg['max-cmd-pipeline'] = max_outstanding_cmds
+    manager_args['max-cmd-pipeline'] = max_outstanding_cmds
 
     # Init manager
     static_manager = init_static_manager(manager_cfg, manager_args)
@@ -577,7 +574,8 @@ async def test_worker_replace(monkeypatch, manager_cfg):
 
     with patch.multiple(static_manager_module,
                         monitor_process=dummy_monitor_process), \
-            patch.object(manager, '_coalescer_launcher', coalescer_monitor_mock):
+            patch.object(manager, '_coalescer_launcher',
+                         coalescer_monitor_mock):
         execute_task = asyncio.create_task(manager._execute())
         try:
             injected_workers = {
@@ -646,7 +644,8 @@ async def test_unexpected_worker_death(monkeypatch, manager_cfg):
 
     with patch.multiple(static_manager_module,
                         monitor_process=dummy_monitor_process), \
-            patch.object(manager, '_coalescer_launcher', coalescer_monitor_mock):
+            patch.object(manager, '_coalescer_launcher',
+                         coalescer_monitor_mock):
         execute_task = asyncio.create_task(manager._execute())
 
         try:

--- a/tests/unit/poller/worker/test_inventory.py
+++ b/tests/unit/poller/worker/test_inventory.py
@@ -106,13 +106,8 @@ async def test_inventory_build(max_outstanding_cmds):
         nodes = await inv.build_inventory()
 
     # Check if a semaphore with the proper initial value have been created
-    if max_outstanding_cmds:
-        assert inv._cmd_semaphore, 'Command semaphore should be initialized'
-        assert inv._cmd_semaphore._value == max_outstanding_cmds, \
-            'Command semaphore has not the expected initial value'
-    else:
-        assert inv._cmd_semaphore is None, \
-            'Command semaphore created but max_outstanding_commands not set'
+    assert inv._cmd_pacer, 'Command semaphore should be initialized'
+    assert inv._cmd_pacer.max_cmds == max_outstanding_cmds
 
     # Check if nodes are registered in the inventory
     assert set(nodes) == set(inv.nodes)
@@ -126,9 +121,8 @@ async def test_inventory_build(max_outstanding_cmds):
         assert inv.connect_timeout == invnode.connect_timeout
         assert node['jump_host'].split("@")[1] == invnode.jump_host
         assert invnode.jump_host_key
-        if max_outstanding_cmds:
-            assert invnode._cmd_sem == inv._cmd_semaphore, \
-                'Semaphore not provided to nodes'
+        assert invnode._cmd_pacer == inv._cmd_pacer, \
+            'Pacer not provided to nodes'
 
         for arg, arg_value in node.items():
             if arg in ['namespace', 'ssh_keyfile', 'jump_host',

--- a/tests/unit/poller/worker/test_pacer.py
+++ b/tests/unit/poller/worker/test_pacer.py
@@ -1,0 +1,28 @@
+import pytest
+
+from suzieq.poller.worker.inventory.inventory import CommandPacer
+
+
+@pytest.mark.poller
+@pytest.mark.poller_unit_tests
+@pytest.mark.poller_worker
+@pytest.mark.poller_inventory
+def test_pacer_init():
+    """Test the initialization of the command pacer object
+    """
+    cp = CommandPacer(0)
+    assert cp.max_cmds == 0, 'Not expected command pacer max cmds value'
+    assert cp._cmd_mutex is None, 'Mutex should\'ve been None'
+    assert cp._cmd_semaphore is None, 'Semaphore should\'ve been None'
+
+    ##
+    # 2. Test with a value of maximum number of commands
+    ##
+    max_value = 2
+    cp = CommandPacer(max_value)
+    assert cp.max_cmds == max_value, 'Not expected max cmds value'
+    assert cp._cmd_mutex is not None, 'Mutex shouldn\'t be None'
+    assert cp._cmd_semaphore is not None, 'Semaphore shouldn\'t been None'
+    assert cp._cmd_semaphore._value == max_value, 'Unexpected semaphore value'
+    assert cp._cmd_pacer_sleep == float(1 / max_value), \
+        'Unexpected pacer sleep value'


### PR DESCRIPTION
## Description

This PR takes fixes from the enterprise repository.

The fixes are:
- add a class to centralize the pacer
- avoid to drop `0` and `False` args on the rest server *
- path rename `error` column as `hopError` *
- redo evpnVni assertion *
- change negated regex from `~!` to `!~` *
- fix the ospf assertReason to list instead of string

*: this commit wasn't cherry-picked because it was squashed with other fixes. I picked the changes by hand. Please review these commits carefully.

The PR is in draft because evpnVni tests are failing.

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
