### PR TITLE
Nwfind fix

### DIFF
--- a/suzieq/config/schema/network.avsc
+++ b/suzieq/config/schema/network.avsc
@@ -54,7 +54,7 @@
             "name": "type",
             "type": "string",
             "display": 8,
-            "description": "Type of interface"
+            "description": "How is this address connected to network"
         },
         {
             "name": "vlan",

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -601,7 +601,7 @@ tests:
     between the last 5 mins and the polling period"}]'
 - command: table describe --table=network --format=json
   data-directory: tests/data/parquet-out/
-  marks: table network describe
+  marks: table describe
   output: '[{"name": "bondMembers", "type": "string", "key": "", "display": 7, "description":
     "Member ports of a bond interface"}, {"name": "hostname", "type": "string", "key":
     "", "display": 1, "description": "Hostname associated with this record"}, {"name":
@@ -612,6 +612,7 @@ tests:
     "string", "key": "", "display": 5, "description": "Interface mac address"}, {"name":
     "namespace", "type": "string", "key": "", "display": 0, "description": "Namespace
     associated with this record"}, {"name": "type", "type": "string", "key": "", "display":
-    8, "description": "Type of interface"}, {"name": "vlan", "type": "float", "key":
-    "", "display": 4, "description": "Interface vlan"}, {"name": "vrf", "type": "string",
-    "key": "", "display": 2, "description": "VRF associated with session"}]'
+    8, "description": "How is this address connected to network"}, {"name": "vlan",
+    "type": "float", "key": "", "display": 4, "description": "Interface vlan"}, {"name":
+    "vrf", "type": "string", "key": "", "display": 2, "description": "VRF associated
+    with session"}]'

--- a/tests/integration/sqcmds/cumulus-samples/network.yml
+++ b/tests/integration/sqcmds/cumulus-samples/network.yml
@@ -6,147 +6,131 @@ tests:
   marks: network find cumulus
   output: '[{"namespace": "ospf-single", "hostname": "leaf01", "vrf": "default", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "00:03:00:11:11:01", "ifname": "swp5",
-    "bondMembers": "", "type": "bridged", "l2miss": false, "timestamp": 1616352402479},
-    {"namespace": "dual-evpn", "hostname": "server103", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "0", "macaddr": "52:54:00:a0:c3:0b", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616644821711},
-    {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821712},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616644821712},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821713},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616644821714},
-    {"namespace": "ospf-ibgp", "hostname": "server103", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "0", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616681581179},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616681581182}]'
+    "bondMembers": "", "type": "bridged", "l2miss": false}, {"namespace": "dual-evpn",
+    "hostname": "exit02", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13", "bondMembers": "", "type":
+    "bridged", "l2miss": true}, {"namespace": "dual-evpn", "hostname": "leaf01", "vrf":
+    "default", "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b",
+    "ifname": "vlan13", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace":
+    "dual-evpn", "hostname": "exit01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
+    "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13", "bondMembers":
+    "", "type": "bridged", "l2miss": true}, {"namespace": "dual-evpn", "hostname":
+    "leaf02", "vrf": "default", "ipAddress": "172.16.1.101", "vlan": "13", "macaddr":
+    "52:54:00:a0:c3:0b", "ifname": "vlan13", "bondMembers": "", "type": "routed",
+    "l2miss": false}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname":
+    "bond01", "bondMembers": "swp5", "type": "bridged", "l2miss": false}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
+    "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01", "bondMembers":
+    "swp5", "type": "bridged", "l2miss": false}]'
 - command: network find --namespace=dual-evpn --address="172.16.1.101" --format=json
   data-directory: tests/data/parquet
   marks: network find cumulus
-  output: '[{"namespace": "dual-evpn", "hostname": "server103", "vrf": "default",
-    "ipAddress": "172.16.1.101", "vlan": "0", "macaddr": "52:54:00:a0:c3:0b", "ifname":
-    "bond0", "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp":
-    1616644821711}, {"namespace": "dual-evpn", "hostname": "exit02", "vrf": "evpn-vrf",
-    "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821712},
-    {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616644821712},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "ipAddress":
+  output: '[{"namespace": "dual-evpn", "hostname": "exit02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821713},
-    {"namespace": "dual-evpn", "hostname": "exit01", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714}]'
+    "bondMembers": "", "type": "bridged", "l2miss": true}, {"namespace": "dual-evpn",
+    "hostname": "leaf01", "vrf": "default", "ipAddress": "172.16.1.101", "vlan": "13",
+    "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13", "bondMembers": "", "type":
+    "routed", "l2miss": false}, {"namespace": "dual-evpn", "hostname": "exit01", "vrf":
+    "evpn-vrf", "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:a0:c3:0b",
+    "ifname": "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true}, {"namespace":
+    "dual-evpn", "hostname": "leaf02", "vrf": "default", "ipAddress": "172.16.1.101",
+    "vlan": "13", "macaddr": "52:54:00:a0:c3:0b", "ifname": "vlan13", "bondMembers":
+    "", "type": "routed", "l2miss": false}]'
 - command: network find --address="52:54:00:c5:1d:06" --namespace=ospf-ibgp --format=json
   data-directory: tests/data/parquet
   marks: network find cumulus
-  output: '[{"namespace": "ospf-ibgp", "hostname": "server103", "vrf": "default",
-    "ipAddress": "172.16.1.101", "vlan": "0", "macaddr": "52:54:00:c5:1d:06", "ifname":
-    "bond0", "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp":
-    1616681581179}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "evpn-vrf",
-    "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname":
-    "bond01", "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp":
-    1616681581180}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "evpn-vrf",
-    "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
+  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616681581182}]'
+    "bondMembers": "swp5", "type": "bridged", "l2miss": false}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01", "bondMembers": "swp5",
+    "type": "bridged", "l2miss": false}]'
 - command: network find --address="72:f0:17:6d:80:3f" --namespace=ospf-ibgp --format=json
   data-directory: tests/data/parquet
   marks: network find  cumulus
-  output: '[]'
+  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "", "ipAddress":
+    "", "vlan": 24, "macaddr": "72:f0:17:6d:80:3f", "ifname": "vni24", "bondMembers":
+    "", "type": "interface", "l2miss": false}]'
 - command: network find --address="5254.00c5.1d06" --format=json
   data-directory: tests/data/parquet
   marks: network find cumulus
-  output: '[{"namespace": "ospf-ibgp", "hostname": "server103", "vrf": "default",
-    "ipAddress": "172.16.1.101", "vlan": "0", "macaddr": "52:54:00:c5:1d:06", "ifname":
-    "bond0", "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp":
-    1616681581179}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "evpn-vrf",
-    "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname":
-    "bond01", "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp":
-    1616681581180}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "vrf": "evpn-vrf",
-    "ipAddress": "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress":
-    "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616681581180},
-    {"namespace": "ospf-ibgp", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
+  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01",
-    "bondMembers": "swp5", "type": "bridged", "l2miss": false, "timestamp": 1616681581182}]'
+    "bondMembers": "swp5", "type": "bridged", "l2miss": false}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "13", "macaddr": "52:54:00:c5:1d:06", "ifname": "bond01", "bondMembers": "swp5",
+    "type": "bridged", "l2miss": false}]'
 - command: network find --address="10.0.0.11" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
   marks: network find cumulus
   output: '[{"namespace": "ospf-single", "hostname": "leaf01", "vrf": "default", "ipAddress":
     "10.0.0.11", "vlan": "0", "macaddr": "44:38:39:00:00:53", "ifname": "swp1", "bondMembers":
-    "", "type": "routed", "l2miss": false, "timestamp": 1616352402449}, {"namespace":
-    "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "ipAddress": "10.0.0.11",
-    "vlan": "0", "macaddr": "52:54:00:e6:0f:5c", "ifname": "swp1", "bondMembers":
-    "", "type": "routed", "l2miss": false, "timestamp": 1616681581180}]'
+    "", "type": "routed", "l2miss": false}, {"namespace": "ospf-single", "hostname":
+    "leaf01", "vrf": "default", "ipAddress": "10.0.0.11", "vlan": "0", "macaddr":
+    "44:38:39:00:00:24", "ifname": "swp2", "bondMembers": "", "type": "routed", "l2miss":
+    false}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "vrf": "default", "ipAddress":
+    "10.0.0.11", "vlan": "0", "macaddr": "52:54:00:e6:0f:5c", "ifname": "swp1", "bondMembers":
+    "", "type": "routed", "l2miss": false}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf01", "vrf": "default", "ipAddress": "10.0.0.11", "vlan": "0", "macaddr":
+    "52:54:00:e6:50:37", "ifname": "swp2", "bondMembers": "", "type": "routed", "l2miss":
+    false}]'
 - command: network find --address="169.254.127.0" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
   marks: network find cumulus
   output: '[{"namespace": "dual-evpn", "hostname": "internet", "vrf": "default", "ipAddress":
-    "169.254.127.0", "vlan": "0", "macaddr": "52:54:00:71:0c:94", "ifname": "swp1",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616644821714},
-    {"namespace": "ospf-ibgp", "hostname": "internet", "vrf": "default", "ipAddress":
-    "169.254.127.0", "vlan": "0", "macaddr": "52:54:00:88:3d:81", "ifname": "swp1",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616681581180}]'
+    "169.254.127.0, fe80::5054:ff:fe71:c94", "vlan": 0, "macaddr": "52:54:00:71:0c:94",
+    "ifname": "swp1", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "ospf-ibgp", "hostname": "internet", "vrf": "default", "ipAddress": "169.254.127.0,
+    fe80::5054:ff:fe88:3d81", "vlan": 0, "macaddr": "52:54:00:88:3d:81", "ifname":
+    "swp1", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.1" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
   marks: network find cumulus
   output: '[{"namespace": "dual-evpn", "hostname": "exit01", "vrf": "internet-vrf",
-    "ipAddress": "169.254.127.1", "vlan": "0", "macaddr": "52:54:00:c7:58:66", "ifname":
-    "swp6", "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616644821714},
-    {"namespace": "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf", "ipAddress":
-    "169.254.127.1", "vlan": "0", "macaddr": "52:54:00:cf:70:e0", "ifname": "swp6",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616681581503}]'
+    "ipAddress": "169.254.127.1, fe80::5054:ff:fec7:5866", "vlan": 0, "macaddr": "52:54:00:c7:58:66",
+    "ifname": "swp6", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "vrf": "internet-vrf", "ipAddress": "169.254.127.1,
+    fe80::5054:ff:fecf:70e0", "vlan": 0, "macaddr": "52:54:00:cf:70:e0", "ifname":
+    "swp6", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.21" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
   marks: network find cumulus
   output: '[{"namespace": "ospf-single", "hostname": "spine01", "vrf": "default",
     "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:00:00:54", "ifname":
-    "swp1", "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1616352402479},
-    {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default", "ipAddress":
-    "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:e5:e3:d4", "ifname": "swp5", "bondMembers":
-    "", "type": "routed", "l2miss": false, "timestamp": 1616681581179}]'
+    "swp1", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace": "ospf-single",
+    "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "44:38:39:00:00:29", "ifname": "swp2", "bondMembers": "", "type": "routed",
+    "l2miss": false}, {"namespace": "ospf-single", "hostname": "spine01", "vrf": "default",
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:00:00:50", "ifname":
+    "swp3", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace": "ospf-single",
+    "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "44:38:39:00:00:0a", "ifname": "swp6", "bondMembers": "", "type": "routed",
+    "l2miss": false}, {"namespace": "ospf-single", "hostname": "spine01", "vrf": "default",
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:00:00:22", "ifname":
+    "swp5", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace": "ospf-single",
+    "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "44:38:39:00:00:3c", "ifname": "swp4", "bondMembers": "", "type": "routed",
+    "l2miss": false}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:e5:e3:d4", "ifname":
+    "swp5", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "52:54:00:5d:da:ac", "ifname": "swp6", "bondMembers": "", "type": "routed",
+    "l2miss": false}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:54:3d:39", "ifname":
+    "swp1", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "52:54:00:25:b0:5b", "ifname": "swp3", "bondMembers": "", "type": "routed",
+    "l2miss": false}, {"namespace": "ospf-ibgp", "hostname": "spine02", "vrf": "default",
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:a7:ba:2d", "ifname":
+    "swp4", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "52:54:00:d1:00:da", "ifname": "swp2", "bondMembers": "", "type": "routed",
+    "l2miss": false}]'
 - command: network find --address="10.0.0.32" --format=json --namespace='ospf-single
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
@@ -179,27 +163,14 @@ tests:
     dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet
   marks: network find cumulus
-  output: '[{"namespace": "dual-evpn", "hostname": "server103", "vrf": "default",
-    "ipAddress": "172.16.1.1", "vlan": "0", "macaddr": "44:39:39:ff:00:13", "ifname":
-    "bond0", "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp":
-    1616644821711}, {"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default",
-    "ipAddress": "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname":
-    "vlan13", "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821712},
-    {"namespace": "dual-evpn", "hostname": "leaf03", "vrf": "default", "ipAddress":
-    "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821713},
-    {"namespace": "dual-evpn", "hostname": "leaf02", "vrf": "default", "ipAddress":
-    "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "leaf04", "vrf": "default", "ipAddress":
-    "172.16.1.1", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13",
-    "bondMembers": "", "type": "bridged", "l2miss": true, "timestamp": 1616644821714},
-    {"namespace": "dual-evpn", "hostname": "server101", "vrf": "default", "ipAddress":
-    "172.16.1.1", "vlan": "0", "macaddr": "44:39:39:ff:00:13", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616644821714},
-    {"namespace": "ospf-ibgp", "hostname": "server103", "vrf": "default", "ipAddress":
-    "172.16.1.1", "vlan": "0", "macaddr": "44:39:39:ff:00:13", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616681581179},
-    {"namespace": "ospf-ibgp", "hostname": "server101", "vrf": "default", "ipAddress":
-    "172.16.1.1", "vlan": "0", "macaddr": "44:39:39:ff:00:13", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1616681581180}]'
+  output: '[{"namespace": "dual-evpn", "hostname": "leaf01", "vrf": "default", "ipAddress":
+    "fe80::4639:39ff:feff:13", "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname":
+    "vlan13", "bondMembers": "", "type": "routed", "l2miss": false}, {"namespace":
+    "dual-evpn", "hostname": "leaf03", "vrf": "default", "ipAddress": "fe80::4639:39ff:feff:13",
+    "vlan": "13", "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13", "bondMembers":
+    "", "type": "routed", "l2miss": false}, {"namespace": "dual-evpn", "hostname":
+    "leaf02", "vrf": "default", "ipAddress": "fe80::4639:39ff:feff:13", "vlan": "13",
+    "macaddr": "44:39:39:ff:00:13", "ifname": "vlan13", "bondMembers": "", "type":
+    "routed", "l2miss": false}, {"namespace": "dual-evpn", "hostname": "leaf04", "vrf":
+    "default", "ipAddress": "fe80::4639:39ff:feff:13", "vlan": "13", "macaddr": "44:39:39:ff:00:13",
+    "ifname": "vlan13", "bondMembers": "", "type": "routed", "l2miss": false}]'

--- a/tests/integration/sqcmds/eos-samples/network.yml
+++ b/tests/integration/sqcmds/eos-samples/network.yml
@@ -5,67 +5,92 @@ tests:
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3",
-    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177307},
-    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
-    "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
-    "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177688}]'
+    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
+    "Ethernet3", "type": "bridged", "l2miss": false}]'
 - command: network find --address="66:49:0d:d4:d8:63" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3",
-    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177307},
-    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
-    "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
-    "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177688}]'
+    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
+    "Ethernet3", "type": "bridged", "l2miss": false}]'
 - command: network find --address="6649.0dd4.d863" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find  eos
   output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3",
-    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177307},
-    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
-    "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
-    "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177688}]'
+    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
+    "Ethernet3", "type": "bridged", "l2miss": false}]'
 - command: network find --address="66:49:0d:D4:D8:63" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3",
-    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177307},
-    {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
-    "vlan": "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
-    "Ethernet3", "type": "bridged", "l2miss": false, "timestamp": 1623025177688}]'
+    "bondMembers": "Ethernet3", "type": "bridged", "l2miss": false}, {"namespace":
+    "eos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101", "vlan":
+    "10", "macaddr": "66:49:0d:d4:d8:63", "ifname": "Port-Channel3", "bondMembers":
+    "Ethernet3", "type": "bridged", "l2miss": false}]'
 - command: network find --address="10.0.0.11" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "leaf01", "vrf": "default", "ipAddress":
     "10.0.0.11", "vlan": "0", "macaddr": "44:38:39:e3:19:2e", "ifname": "Ethernet1",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025177202}]'
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "eos",
+    "hostname": "leaf01", "vrf": "default", "ipAddress": "10.0.0.11", "vlan": "0",
+    "macaddr": "44:38:39:e3:19:2e", "ifname": "Ethernet2", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "eos", "hostname": "leaf01", "vrf":
+    "default", "ipAddress": "10.0.0.11", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "Loopback0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.0" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "dcedge01", "vrf": "default", "ipAddress":
-    "169.254.127.0", "vlan": "0", "macaddr": "02:05:86:71:f0:03", "ifname": "xe-0/0/0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025177530}]'
+    "169.254.127.0", "vlan": 0, "macaddr": "02:05:86:71:f0:03", "ifname": "xe-0/0/0.0",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.1" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "exit01", "vrf": "internet-vrf", "ipAddress":
-    "169.254.127.1", "vlan": "0", "macaddr": "44:38:39:33:d8:43", "ifname": "Ethernet4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025181909}]'
+    "169.254.127.1", "vlan": 0, "macaddr": "44:38:39:33:d8:43", "ifname": "Ethernet4",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.21" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "spine01", "vrf": "default", "ipAddress":
     "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:ba:d2:34", "ifname": "Ethernet3",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025177304}]'
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "eos",
+    "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0",
+    "macaddr": "44:38:39:ba:d2:34", "ifname": "Ethernet2", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "eos", "hostname": "spine01", "vrf":
+    "default", "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:ba:d2:34",
+    "ifname": "Ethernet5", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21",
+    "vlan": "0", "macaddr": "44:38:39:ba:d2:34", "ifname": "Ethernet6", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "eos", "hostname": "spine01",
+    "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "44:38:39:ba:d2:34",
+    "ifname": "Ethernet1", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "eos", "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21",
+    "vlan": "0", "macaddr": "44:38:39:ba:d2:34", "ifname": "Ethernet4", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "eos", "hostname": "spine01",
+    "vrf": "default", "ipAddress": "10.0.0.21", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "Loopback0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.32" --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
   output: '[{"namespace": "eos", "hostname": "exit02", "vrf": "default", "ipAddress":
     "10.0.0.32", "vlan": "0", "macaddr": "44:38:39:c3:55:cb", "ifname": "Ethernet1",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025177202}]'
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "eos",
+    "hostname": "exit02", "vrf": "default", "ipAddress": "10.0.0.32", "vlan": "0",
+    "macaddr": "44:38:39:c3:55:cb", "ifname": "Ethernet2", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "eos", "hostname": "exit02", "vrf":
+    "default", "ipAddress": "10.0.0.32", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "Loopback0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address='foobar' --format=json --namespace=eos
   data-directory: tests/data/parquet
   error:
@@ -79,18 +104,28 @@ tests:
 - command: network find --address='00:00:00:11:12:10' --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
-  output: '[{"namespace": "eos", "hostname": "server301", "vrf": "default", "ipAddress":
-    "172.16.2.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176216},
-    {"namespace": "eos", "hostname": "server302", "vrf": "default", "ipAddress": "172.16.3.254",
-    "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0", "bondMembers":
-    "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176216},
-    {"namespace": "eos", "hostname": "server101", "vrf": "default", "ipAddress": "172.16.1.254",
-    "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0", "bondMembers":
-    "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176435},
-    {"namespace": "eos", "hostname": "server102", "vrf": "default", "ipAddress": "172.16.3.254",
-    "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0", "bondMembers":
-    "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176627}]'
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
+    "0.0.0.0, 172.16.1.254", "vlan": 10, "macaddr": "00:00:00:11:12:10", "ifname":
+    "Vlan10", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.3.254",
+    "vlan": 30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.3.254", "vlan": 30, "macaddr":
+    "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "ipAddress": "0.0.0.0, 172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "0.0.0.0,
+    172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan20",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "eos",
+    "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.3.254",
+    "vlan": 30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.1.254", "vlan": 10, "macaddr":
+    "00:00:00:11:12:10", "ifname": "Vlan10", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "ipAddress": "0.0.0.0, 172.16.3.254", "vlan": 30, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan30", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address='00:00:00:11:12' --format=json --namespace=eos
   data-directory: tests/data/parquet
   error:
@@ -99,15 +134,25 @@ tests:
 - command: network find --address='0000.0011.1210' --format=json --namespace=eos
   data-directory: tests/data/parquet
   marks: network find eos
-  output: '[{"namespace": "eos", "hostname": "server301", "vrf": "default", "ipAddress":
-    "172.16.2.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176216},
-    {"namespace": "eos", "hostname": "server302", "vrf": "default", "ipAddress": "172.16.3.254",
-    "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0", "bondMembers":
-    "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176216},
-    {"namespace": "eos", "hostname": "server101", "vrf": "default", "ipAddress": "172.16.1.254",
-    "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0", "bondMembers":
-    "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176435},
-    {"namespace": "eos", "hostname": "server102", "vrf": "default", "ipAddress": "172.16.3.254",
-    "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0", "bondMembers":
-    "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1623025176627}]'
+  output: '[{"namespace": "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
+    "0.0.0.0, 172.16.1.254", "vlan": 10, "macaddr": "00:00:00:11:12:10", "ifname":
+    "Vlan10", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "eos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.3.254",
+    "vlan": 30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "eos", "hostname": "leaf04",
+    "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.3.254", "vlan": 30, "macaddr":
+    "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "eos", "hostname": "leaf04", "vrf": "evpn-vrf",
+    "ipAddress": "0.0.0.0, 172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "eos", "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "0.0.0.0,
+    172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan20",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "eos",
+    "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.3.254",
+    "vlan": 30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "eos", "hostname": "leaf01",
+    "vrf": "evpn-vrf", "ipAddress": "0.0.0.0, 172.16.1.254", "vlan": 10, "macaddr":
+    "00:00:00:11:12:10", "ifname": "Vlan10", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "eos", "hostname": "leaf01", "vrf": "evpn-vrf",
+    "ipAddress": "0.0.0.0, 172.16.3.254", "vlan": 30, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan30", "bondMembers": "", "type": "interface", "l2miss": false}]'

--- a/tests/integration/sqcmds/junos-samples/network.yml
+++ b/tests/integration/sqcmds/junos-samples/network.yml
@@ -5,31 +5,41 @@ tests:
   marks: network find junos
   output: '[{"namespace": "junos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "28:b7:ad:3c:81:d0", "ifname": "xe-0/0/2",
-    "bondMembers": "", "type": "bridged", "l2miss": false, "timestamp": 1623025797193}]'
+    "bondMembers": "", "type": "bridged", "l2miss": false}]'
 - command: network find --address="10.0.0.11" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos
   output: '[{"namespace": "junos", "hostname": "leaf01", "vrf": "default", "ipAddress":
     "10.0.0.11", "vlan": "0", "macaddr": "02:05:86:71:ad:03", "ifname": "xe-0/0/0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025796956}]'
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "junos",
+    "hostname": "leaf01", "vrf": "default", "ipAddress": "10.0.0.11", "vlan": "0",
+    "macaddr": "02:05:86:71:ad:07", "ifname": "xe-0/0/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "junos", "hostname": "leaf01", "vrf":
+    "default", "ipAddress": "10.0.0.11", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "lo0.0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.0" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos
   output: '[{"namespace": "junos", "hostname": "dcedge01", "vrf": "default", "ipAddress":
-    "169.254.127.0", "vlan": "0", "macaddr": "02:05:86:71:c2:03", "ifname": "xe-0/0/0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025796956}]'
+    "169.254.127.0", "vlan": 0, "macaddr": "02:05:86:71:c2:03", "ifname": "xe-0/0/0.0",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.1" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos
-  output: '[{"namespace": "junos", "hostname": "exit01", "vrf": "default", "ipAddress":
-    "169.254.127.1", "vlan": "0", "macaddr": "02:05:86:71:74:0f", "ifname": "xe-0/0/3",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025797193}]'
+  output: '[{"namespace": "junos", "hostname": "exit01", "vrf": "internet-vrf", "ipAddress":
+    "169.254.127.1", "vlan": 0, "macaddr": "02:05:86:71:74:0f", "ifname": "xe-0/0/3.0",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.31" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos
   output: '[{"namespace": "junos", "hostname": "exit01", "vrf": "default", "ipAddress":
     "10.0.0.31", "vlan": "0", "macaddr": "02:05:86:71:74:03", "ifname": "xe-0/0/0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1623025796956}]'
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "junos",
+    "hostname": "exit01", "vrf": "default", "ipAddress": "10.0.0.31", "vlan": "0",
+    "macaddr": "02:05:86:71:74:07", "ifname": "xe-0/0/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "junos", "hostname": "exit01", "vrf":
+    "default", "ipAddress": "10.0.0.31", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "lo0.0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.112" --format=json --namespace=junos
   data-directory: tests/data/parquet
   marks: network find junos

--- a/tests/integration/sqcmds/nxos-samples/network.yml
+++ b/tests/integration/sqcmds/nxos-samples/network.yml
@@ -5,41 +5,53 @@ tests:
   marks: network find nxos
   output: '[{"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress":
     "172.16.1.101", "vlan": "10", "macaddr": "32:bb:c5:b5:3a:20", "ifname": "port-channel3",
-    "bondMembers": "Ethernet1/3", "type": "bridged", "l2miss": false, "timestamp":
-    1619275264428}, {"namespace": "nxos", "hostname": "leaf01", "vrf": "evpn-vrf",
-    "ipAddress": "172.16.1.101", "vlan": "10", "macaddr": "32:bb:c5:b5:3a:20", "ifname":
-    "port-channel3", "bondMembers": "Ethernet1/3", "type": "bridged", "l2miss": false,
-    "timestamp": 1619275264429}]'
+    "bondMembers": "Ethernet1/3", "type": "bridged", "l2miss": false}, {"namespace":
+    "nxos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.101",
+    "vlan": "10", "macaddr": "32:bb:c5:b5:3a:20", "ifname": "port-channel3", "bondMembers":
+    "Ethernet1/3", "type": "bridged", "l2miss": false}]'
 - command: network find --address="10.0.0.11" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
   output: '[{"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "ipAddress":
-    "10.0.0.11", "vlan": "0", "macaddr": "44:01:02:01:1b:08", "ifname": "loopback0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1619275262853,
-    "bondMbrs": ""}]'
+    "10.0.0.11", "vlan": "0", "macaddr": "44:01:02:01:1b:08", "ifname": "Ethernet1/2",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf01", "vrf": "default", "ipAddress": "10.0.0.11", "vlan": "0",
+    "macaddr": "44:01:02:01:1b:08", "ifname": "Ethernet1/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "default", "ipAddress": "10.0.0.11", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "loopback0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.0" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
   output: '[{"namespace": "nxos", "hostname": "dcedge01", "vrf": "default", "ipAddress":
-    "169.254.127.0", "vlan": "0", "macaddr": "02:05:86:71:3c:03", "ifname": "xe-0/0/0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1619275264358}]'
+    "169.254.127.0", "vlan": 0, "macaddr": "02:05:86:71:3c:03", "ifname": "xe-0/0/0.0",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.1" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
   output: '[{"namespace": "nxos", "hostname": "exit01", "vrf": "internet-vrf", "ipAddress":
-    "169.254.127.1", "vlan": "0", "macaddr": "44:01:03:01:1b:08", "ifname": "Ethernet1/4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1619275261428}]'
+    "169.254.127.1", "vlan": 0, "macaddr": "44:01:03:01:1b:08", "ifname": "Ethernet1/4",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.31" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
   output: '[{"namespace": "nxos", "hostname": "exit01", "vrf": "default", "ipAddress":
-    "10.0.0.31", "vlan": "0", "macaddr": "44:01:03:01:1b:08", "ifname": "loopback0",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1619275262853,
-    "bondMbrs": ""}]'
+    "10.0.0.31", "vlan": "0", "macaddr": "44:01:03:01:1b:08", "ifname": "Ethernet1/2",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "exit01", "vrf": "default", "ipAddress": "10.0.0.31", "vlan": "0",
+    "macaddr": "44:01:03:01:1b:08", "ifname": "Ethernet1/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "default", "ipAddress": "10.0.0.31", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "loopback0", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.112" --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
-  output: '[]'
+  output: '[{"namespace": "nxos", "hostname": "leaf01", "vrf": "default", "ipAddress":
+    "10.0.0.201, 10.0.0.112", "vlan": 0, "macaddr": "00:00:00:00:00:00", "ifname":
+    "loopback1", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "nxos", "hostname": "leaf02", "vrf": "default", "ipAddress": "10.0.0.202, 10.0.0.112",
+    "vlan": 0, "macaddr": "00:00:00:00:00:00", "ifname": "loopback1", "bondMembers":
+    "", "type": "interface", "l2miss": false}]'
 - command: network find --address='foobar' --format=json --namespace=nxos
   data-directory: tests/data/parquet
   error:
@@ -53,18 +65,41 @@ tests:
 - command: network find --address='00:00:00:11:12:10' --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
-  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "ipAddress":
-    "172.16.1.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256310},
-    {"namespace": "nxos", "hostname": "server102", "vrf": "default", "ipAddress":
-    "172.16.3.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256394},
-    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "ipAddress":
-    "172.16.2.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256403},
-    {"namespace": "nxos", "hostname": "server302", "vrf": "default", "ipAddress":
-    "172.16.3.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256425}]'
+  output: '[{"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress":
+    "172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan20",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "172.16.3.254", "vlan":
+    30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.254", "vlan":
+    10, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan10", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "ipAddress": "172.16.3.254", "vlan": 30, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan30", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "", "ipAddress": "", "vlan":
+    999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress": "172.16.3.254", "vlan":
+    30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "ipAddress": "172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "172.16.1.254",
+    "vlan": 10, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan10", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "ipAddress": "172.16.3.254", "vlan": 30, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan30", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "", "ipAddress": "", "vlan":
+    999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan999", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address='00:00:00:11:12' --format=json --namespace=nxos
   data-directory: tests/data/parquet
   error:
@@ -73,15 +108,38 @@ tests:
 - command: network find --address='0000.0011.1210' --format=json --namespace=nxos
   data-directory: tests/data/parquet
   marks: network find nxos
-  output: '[{"namespace": "nxos", "hostname": "server101", "vrf": "default", "ipAddress":
-    "172.16.1.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256310},
-    {"namespace": "nxos", "hostname": "server102", "vrf": "default", "ipAddress":
-    "172.16.3.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256394},
-    {"namespace": "nxos", "hostname": "server301", "vrf": "default", "ipAddress":
-    "172.16.2.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256403},
-    {"namespace": "nxos", "hostname": "server302", "vrf": "default", "ipAddress":
-    "172.16.3.254", "vlan": "0", "macaddr": "00:00:00:11:12:10", "ifname": "bond0",
-    "bondMembers": "eth1, eth2", "type": "routed", "l2miss": false, "timestamp": 1619275256425}]'
+  output: '[{"namespace": "nxos", "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress":
+    "172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan20",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "172.16.3.254", "vlan":
+    30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf03", "vrf":
+    "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "172.16.1.254", "vlan":
+    10, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan10", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf01", "vrf":
+    "evpn-vrf", "ipAddress": "172.16.3.254", "vlan": 30, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan30", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "nxos", "hostname": "leaf01", "vrf": "", "ipAddress": "", "vlan":
+    999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress": "172.16.3.254", "vlan":
+    30, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan30", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf04", "vrf":
+    "evpn-vrf", "ipAddress": "172.16.2.254", "vlan": 20, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "172.16.1.254",
+    "vlan": 10, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan10", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "leaf02",
+    "vrf": "evpn-vrf", "ipAddress": "172.16.3.254", "vlan": 30, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan30", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "nxos", "hostname": "leaf02", "vrf": "", "ipAddress": "", "vlan":
+    999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "nxos", "hostname": "exit01", "vrf":
+    "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10", "ifname": "Vlan999",
+    "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace": "nxos",
+    "hostname": "exit02", "vrf": "", "ipAddress": "", "vlan": 999, "macaddr": "00:00:00:11:12:10",
+    "ifname": "Vlan999", "bondMembers": "", "type": "interface", "l2miss": false}]'

--- a/tests/integration/sqcmds/panos-samples/network.yml
+++ b/tests/integration/sqcmds/panos-samples/network.yml
@@ -3,16 +3,22 @@ tests:
 - command: network find --address="172.16.1.101" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
-  output: '[]'
+  output: '[{"namespace": "panos", "hostname": "server101", "vrf": "default", "ipAddress":
+    "172.16.1.101", "vlan": 0, "macaddr": "26:76:20:42:e2:c6", "ifname": "bond0",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --namespace=panos --address="172.16.1.101" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
-  output: '[]'
-- command: network find --address="52:54:00:c5:1d:06" --namespace=panos --format=json --namespace=panos
+  output: '[{"namespace": "panos", "hostname": "server101", "vrf": "default", "ipAddress":
+    "172.16.1.101", "vlan": 0, "macaddr": "26:76:20:42:e2:c6", "ifname": "bond0",
+    "bondMembers": "", "type": "interface", "l2miss": false}]'
+- command: network find --address="52:54:00:c5:1d:06" --namespace=panos --format=json
+    --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
   output: '[]'
-- command: network find --address="72:f0:17:6d:80:3f" --namespace=panos --format=json --namespace=panos
+- command: network find --address="72:f0:17:6d:80:3f" --namespace=panos --format=json
+    --namespace=panos
   data-directory: tests/data/parquet
   marks: network find  panos
   output: '[]'
@@ -25,40 +31,53 @@ tests:
   marks: network find panos
   output: '[{"namespace": "panos", "hostname": "leaf01", "vrf": "default", "ipAddress":
     "10.0.0.11", "vlan": "0", "macaddr": "52:54:00:89:13:56", "ifname": "swp2", "bondMembers":
-    "", "type": "routed", "l2miss": false, "timestamp": 1639476254326}]'
+    "", "type": "interface", "l2miss": false}, {"namespace": "panos", "hostname":
+    "leaf01", "vrf": "default", "ipAddress": "10.0.0.11", "vlan": "0", "macaddr":
+    "52:54:00:c4:19:83", "ifname": "swp1", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "panos", "hostname": "leaf01", "vrf": "default",
+    "ipAddress": "10.0.0.11", "vlan": 0, "macaddr": "00:00:00:00:00:00", "ifname":
+    "lo", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.0" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
   output: '[{"namespace": "panos", "hostname": "dcedge01", "vrf": "default", "ipAddress":
-    "169.254.127.0", "vlan": "0", "macaddr": "52:54:00:89:e4:e1", "ifname": "swp1",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1639476254367}]'
+    "169.254.127.0, fe80::5054:ff:fe89:e4e1", "vlan": 0, "macaddr": "52:54:00:89:e4:e1",
+    "ifname": "swp1", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="169.254.127.1" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
   output: '[{"namespace": "panos", "hostname": "exit01", "vrf": "internet-vrf", "ipAddress":
-    "169.254.127.1", "vlan": "0", "macaddr": "52:54:00:de:df:7d", "ifname": "swp4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1639476254136}]'
+    "169.254.127.1, fe80::5054:ff:fede:df7d", "vlan": 0, "macaddr": "52:54:00:de:df:7d",
+    "ifname": "swp4", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.21" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
   output: '[{"namespace": "panos", "hostname": "spine01", "vrf": "default", "ipAddress":
     "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:c4:54:00", "ifname": "swp6", "bondMembers":
-    "", "type": "routed", "l2miss": false, "timestamp": 1639476254350}]'
+    "", "type": "interface", "l2miss": false}, {"namespace": "panos", "hostname":
+    "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan": "0", "macaddr":
+    "52:54:00:f5:f0:96", "ifname": "swp5", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "panos", "hostname": "spine01", "vrf": "default",
+    "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:41:6f:13", "ifname":
+    "swp2", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan":
+    "0", "macaddr": "52:54:00:d3:be:93", "ifname": "swp3", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "panos", "hostname": "spine01", "vrf":
+    "default", "ipAddress": "10.0.0.21", "vlan": "0", "macaddr": "52:54:00:83:d9:77",
+    "ifname": "swp1", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "panos", "hostname": "spine01", "vrf": "default", "ipAddress": "10.0.0.21", "vlan":
+    "0", "macaddr": "52:54:00:a0:82:3d", "ifname": "swp4", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "panos", "hostname": "spine01", "vrf":
+    "default", "ipAddress": "10.0.0.21", "vlan": 0, "macaddr": "00:00:00:00:00:00",
+    "ifname": "lo", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="10.0.0.32" --format=json --namespace=panos
   data-directory: tests/data/parquet
   marks: network find panos
   output: '[{"namespace": "panos", "hostname": "exit02", "vrf": "default", "ipAddress":
     "10.0.0.32", "vlan": "0", "macaddr": "52:54:00:3c:63:f0", "ifname": "swp2", "bondMembers":
-    "", "type": "routed", "l2miss": false, "timestamp": 1639476254326}, {"namespace":
-    "panos", "hostname": "leaf02", "vrf": "evpn-vrf", "ipAddress": "10.0.0.32", "vlan":
-    "999", "macaddr": "44:39:39:ff:41:96", "ifname": "vlan999", "bondMembers": "",
-    "type": "bridged", "l2miss": true, "timestamp": 1639476254402}, {"namespace":
-    "panos", "hostname": "leaf03", "vrf": "evpn-vrf", "ipAddress": "10.0.0.32", "vlan":
-    "999", "macaddr": "44:39:39:ff:41:96", "ifname": "vlan999", "bondMembers": "",
-    "type": "bridged", "l2miss": true, "timestamp": 1639476254419}, {"namespace":
-    "panos", "hostname": "leaf01", "vrf": "evpn-vrf", "ipAddress": "10.0.0.32", "vlan":
-    "999", "macaddr": "44:39:39:ff:41:96", "ifname": "vlan999", "bondMembers": "",
-    "type": "bridged", "l2miss": true, "timestamp": 1639476254425}, {"namespace":
-    "panos", "hostname": "leaf04", "vrf": "evpn-vrf", "ipAddress": "10.0.0.32", "vlan":
-    "999", "macaddr": "44:39:39:ff:41:96", "ifname": "vlan999", "bondMembers": "",
-    "type": "bridged", "l2miss": true, "timestamp": 1639476254425}]'
+    "", "type": "interface", "l2miss": false}, {"namespace": "panos", "hostname":
+    "exit02", "vrf": "default", "ipAddress": "10.0.0.32", "vlan": "0", "macaddr":
+    "52:54:00:d2:4a:6a", "ifname": "swp1", "bondMembers": "", "type": "interface",
+    "l2miss": false}, {"namespace": "panos", "hostname": "exit02", "vrf": "default",
+    "ipAddress": "10.0.0.32", "vlan": 0, "macaddr": "00:00:00:00:00:00", "ifname":
+    "lo", "bondMembers": "", "type": "interface", "l2miss": false}]'

--- a/tests/integration/sqcmds/vmx-samples/network.yml
+++ b/tests/integration/sqcmds/vmx-samples/network.yml
@@ -5,34 +5,64 @@ tests:
   marks: network find junos vmx
   output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "ipAddress":
     "172.16.11.11", "vlan": "101", "macaddr": "00:50:79:66:68:08", "ifname": "ge-0/0/8",
-    "bondMembers": "", "type": "bridged", "l2miss": false, "timestamp": 1631009089424}]'
+    "bondMembers": "", "type": "bridged", "l2miss": false}]'
 - command: network find --address="00:50:79:66:68:08" --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: network find junos vmx
   output: '[{"namespace": "vmx", "hostname": "CRP-ACC-SW01", "vrf": "default", "ipAddress":
     "172.16.11.11", "vlan": "101", "macaddr": "00:50:79:66:68:08", "ifname": "ge-0/0/8",
-    "bondMembers": "", "type": "bridged", "l2miss": false, "timestamp": 1631009089424}]'
+    "bondMembers": "", "type": "bridged", "l2miss": false}]'
 - command: network find --address="10.0.20.2" --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: network find junos vmx
-  output: '[{"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "ae2", "ipAddress":
-    "10.0.20.2", "vlan": "20", "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1631009089424}]'
+  output: '[{"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default",
+    "ipAddress": "10.0.20.2", "vlan": 20, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname":
+    "ae1.20", "bondMembers": "", "type": "interface", "l2miss": false}]'
 - command: network find --address="2c:6b:f5:b6:ce:c1" --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: network find junos vmx
-  output: '[{"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "ae2", "ipAddress":
-    "10.0.10.2", "vlan": "10", "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1631009089424}]'
+  output: '[{"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "", "ipAddress":
+    "", "vlan": 0, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ae1", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "", "ipAddress": "", "vlan": 0, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname":
+    "ge-0/0/0", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "", "ipAddress": "", "vlan": 0,
+    "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "default", "ipAddress": "10.0.20.2", "vlan": 20, "macaddr": "2c:6b:f5:b6:ce:c1",
+    "ifname": "ae1.20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "ipAddress":
+    "10.0.10.2", "vlan": 10, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ae1.10", "bondMembers":
+    "", "type": "interface", "l2miss": false}]'
 - command: network find --address="2c6b.f5b6.cec1" --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: network find junos vmx
-  output: '[{"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "ae2", "ipAddress":
-    "10.0.10.2", "vlan": "10", "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1631009089424}]'
+  output: '[{"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "", "ipAddress":
+    "", "vlan": 0, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ae1", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "", "ipAddress": "", "vlan": 0, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname":
+    "ge-0/0/0", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "", "ipAddress": "", "vlan": 0,
+    "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "default", "ipAddress": "10.0.20.2", "vlan": 20, "macaddr": "2c:6b:f5:b6:ce:c1",
+    "ifname": "ae1.20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "ipAddress":
+    "10.0.10.2", "vlan": 10, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ae1.10", "bondMembers":
+    "", "type": "interface", "l2miss": false}]'
 - command: network find --address="2C6b.F5B6.CEC1" --format=json --namespace=vmx
   data-directory: tests/data/parquet
   marks: network find junos vmx
-  output: '[{"namespace": "vmx", "hostname": "CRP-DIS-SW01", "vrf": "ae2", "ipAddress":
-    "10.0.10.2", "vlan": "10", "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/4",
-    "bondMembers": "", "type": "routed", "l2miss": false, "timestamp": 1631009089424}]'
+  output: '[{"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "", "ipAddress":
+    "", "vlan": 0, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ae1", "bondMembers":
+    "", "type": "interface", "l2miss": false}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "", "ipAddress": "", "vlan": 0, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname":
+    "ge-0/0/0", "bondMembers": "", "type": "interface", "l2miss": false}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "", "ipAddress": "", "vlan": 0,
+    "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ge-0/0/1", "bondMembers": "", "type":
+    "interface", "l2miss": false}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "vrf": "default", "ipAddress": "10.0.20.2", "vlan": 20, "macaddr": "2c:6b:f5:b6:ce:c1",
+    "ifname": "ae1.20", "bondMembers": "", "type": "interface", "l2miss": false},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "vrf": "default", "ipAddress":
+    "10.0.10.2", "vlan": 10, "macaddr": "2c:6b:f5:b6:ce:c1", "ifname": "ae1.10", "bondMembers":
+    "", "type": "interface", "l2miss": false}]'


### PR DESCRIPTION
Network find had a bunch of fixes:

* Correct handling when both start and end times are provided or view=all
* Correct tagging of an address as bridged/routed
* Correct handling of an address that is an interface address on a device we're polling.