### PR TITLE
sq-poller: fix Cumulus never set as dead

### DIFF
--- a/suzieq/poller/worker/services/device.py
+++ b/suzieq/poller/worker/services/device.py
@@ -111,7 +111,8 @@ class DeviceService(Service):
         for entry in processed_data:
             new_entries.update(entry)
 
-        processed_data = [new_entries]
+        if new_entries:
+            processed_data = [new_entries]
         return self._common_data_cleaner(processed_data, raw_data)
 
     def _clean_sonic_data(self, processed_data, raw_data):


### PR DESCRIPTION
## Description

Cumulus node was never been flagged as dead due to a parsing error. This PR fixes this bug.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)