### PR TITLE
Change order of service commands to use prev input-dir data

### DIFF
--- a/suzieq/config/device.yml
+++ b/suzieq/config/device.yml
@@ -27,15 +27,7 @@ apply:
     version: all
     merge: False
     command:
-      - command: cat /proc/uptime; hostname
-        textfsm: textfsm_templates/cls_uptime_hostname.tfsm
-        _entryType: uptime
-
-      - command: /usr/cumulus/bin/decode-syseeprom; cat /etc/os-release; cat /proc/meminfo
-        textfsm: textfsm_templates/cls_model_rel.tfsm
-        _entryType: model
-
-      - command: net show foo json
+      - command: net show system json
         normalize: '[
         "os-version: version",
         "vendor: vendor?|Cumulus",
@@ -48,6 +40,14 @@ apply:
         "platform/info/cpu/summary: architecture?|x86_64",
         "_entryType: _entryType?|json"
         ]'
+
+      - command: cat /proc/uptime; hostname
+        textfsm: textfsm_templates/cls_uptime_hostname.tfsm
+        _entryType: uptime
+
+      - command: /usr/cumulus/bin/decode-syseeprom; cat /etc/os-release; cat /proc/meminfo
+        textfsm: textfsm_templates/cls_model_rel.tfsm
+        _entryType: model
 
   iosxe:
     version: all

--- a/suzieq/config/ospfIf.yml
+++ b/suzieq/config/ospfIf.yml
@@ -37,7 +37,7 @@ apply:
         "isUnnumbered: False",
         "interfaceMask: maskLen?|32",
         ]'
-        
+
   cumulus:
     version: all
     command: sudo vtysh -c 'show ip ospf vrf all interface'
@@ -53,11 +53,11 @@ apply:
     version: all
     merge: False
     command:
+      - command: show ip ospf interface
+        textfsm: textfsm_templates/iosxe_show_ip_ospfif.tfsm
       - command: show ip ospf
         textfsm: textfsm_templates/iosxe_show_ip_ospf.tfsm
         _entryType: process
-      - command: show ip ospf interface
-        textfsm: textfsm_templates/iosxe_show_ip_ospfif.tfsm
 
   ios:
     copy: iosxe
@@ -110,7 +110,7 @@ apply:
         - command: show ip ospf vrf all
           textfsm: textfsm_templates/nxos_show_ip_ospf.tfsm
           _entryType: "areas"
-          
+
     - version: all
       command:
         - command: show ip ospf interface vrf all | json native


### PR DESCRIPTION
## Description

In some previous PR improving the command parsing (PRs #740 #742 ), we changed the order of some commands, this caused the previous data gathered with `run-once=gather` no to be collected when used as input directory.
This PR restore the order of the commands to be able to use old outputs as input.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
