### PR TITLE
gui: prevent crash when namespace does not exist

### DIFF
--- a/suzieq/gui/stlit/path.py
+++ b/suzieq/gui/stlit/path.py
@@ -79,10 +79,10 @@ class PathPage(SqGuiPage):
             st.stop()
 
         namespaces = [''] + sorted(devdf.namespace.unique().tolist())
-        if self._state.namespace:
-            nsidx = namespaces.index(self._state.namespace)
-        else:
-            nsidx = 0
+
+        nsidx = 0
+        if state.namespace and state.namespace in namespaces:
+            nsidx = namespaces.index(state.namespace)
 
         url = '&amp;'.join([
             f'{get_base_url()}?page=Help&session={get_session_id()}',

--- a/suzieq/gui/stlit/search.py
+++ b/suzieq/gui/stlit/search.py
@@ -53,10 +53,10 @@ class SearchPage(SqGuiPage):
             st.stop()
 
         namespaces = [''] + sorted(devdf.namespace.unique().tolist())
-        if not state.namespace:
-            nsidx = 0
-        else:
+        nsidx = 0
+        if state.namespace and state.namespace in namespaces:
             nsidx = namespaces.index(state.namespace)
+
         namespace = st.sidebar.selectbox('Namespace',
                                          namespaces, key='search_ns',
                                          index=nsidx,

--- a/suzieq/gui/stlit/status.py
+++ b/suzieq/gui/stlit/status.py
@@ -44,10 +44,10 @@ class StatusPage(SqGuiPage):
             st.stop()
 
         namespaces = [''] + sorted(devdf.namespace.unique().tolist())
-        if self._state.namespace:
+
+        nsidx = 0
+        if self._state.namespace and self._state.namespace in namespaces:
             nsidx = namespaces.index(self._state.namespace)
-        else:
-            nsidx = 0
         namespace = st.sidebar.selectbox('Namespace', namespaces, index=nsidx,
                                          key='status_ns',
                                          on_change=self._sync_state)

--- a/suzieq/gui/stlit/xplore.py
+++ b/suzieq/gui/stlit/xplore.py
@@ -90,10 +90,11 @@ class XplorePage(SqGuiPage):
 
         namespaces = [""]
         namespaces.extend(sorted(devdf.namespace.unique().tolist()))
-        if state.namespace:
+
+        nsidx = 0
+        if state.namespace and state.namespace in namespaces:
             nsidx = namespaces.index(state.namespace)
-        else:
-            nsidx = 0
+
         with st.sidebar:
             with st.form('Xplore'):
                 namespace = st.selectbox('Namespace',


### PR DESCRIPTION
## Description

When the cached query has a not-existing namespace, the gui page crashes making the page unusable. This PR fixes this problem by ignoring the namespace if it does not exist.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
