### PR TITLE
Poller fixes 19

### DIFF
--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -274,6 +274,7 @@ class SqCommand(SqPlugin):
         else:
             print(df)
 
+    # pylint: disable=too-many-statements
     def _gen_output(self, df: pd.DataFrame, json_orient: str = "records",
                     dont_strip_cols: bool = False, sort: bool = True):
 
@@ -332,8 +333,13 @@ class SqCommand(SqPlugin):
                     if is_error:
                         print(df[cols])
                     else:
-                        sort_fields = [x for x in self.sqobj.sort_fields
-                                       if x in df.columns and x in cols]
+                        if (((self.start_time and self.end_time) or
+                             self.view == "all") and
+                                'timestamp' in df.columns):
+                            sort_fields = ['timestamp']
+                        else:
+                            sort_fields = [x for x in self.sqobj.sort_fields
+                                           if x in df.columns and x in cols]
                         if sort_fields:
                             self._pager_print(
                                 df[cols].sort_values(by=sort_fields,

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -470,7 +470,8 @@ class SqPandasEngine(SqEngineObj):
         if df.empty or ('error' in df.columns):
             return df
 
-        columns_by = [what] + self.schema.key_fields()
+        columns_by = [x for x in [what] + self.schema.key_fields()
+                      if x in df.columns]
 
         return df.sort_values(by=columns_by, ascending=reverse) \
                  .head(sqTopCount)

--- a/suzieq/engines/pandas/macs.py
+++ b/suzieq/engines/pandas/macs.py
@@ -61,6 +61,11 @@ class MacsObj(SqPandasEngine):
             df['moveCount'] = df.groupby(level=[0, 1, 2, 3])[
                 'moved'].cumsum()
             df = df.reset_index()
+            if not ((view == "all") or
+                    (self.iobj.start_time and self.iobj.end_time)):
+                df = df.drop_duplicates(subset=self.schema.key_fields(),
+                                        keep='last') \
+                    .reset_index(drop=True)
 
             if moveCount:
                 try:

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -255,6 +255,10 @@ class InterfaceService(Service):
                 # This is because textfsm adds peer LLA as well
                 entry['ip6AddressList'] = entry['ip6AddressList-_2nd']
 
+            # Remove loopbacks
+            entry['ip6AddressList'] = [x for x in entry['ip6AddressList']
+                                       if x != "::1/128"]
+
             if 'type-_2nd' in entry:
                 entry['type'] = entry['type-_2nd']
 
@@ -381,7 +385,7 @@ class InterfaceService(Service):
                 lifname = lentry.get('name', [{}])[0].get('data', '')
                 if not lifname:
                     continue
-                if '.' in lifname:
+                if '.' in lifname and not lifname.endswith('.0'):
                     _, vlan = lifname.split('.')
                     # This order is important, don't change; irb is an internal
                     # interface

--- a/suzieq/poller/worker/services/service_manager.py
+++ b/suzieq/poller/worker/services/service_manager.py
@@ -19,6 +19,7 @@ from suzieq.shared.exceptions import SqPollerConfError
 from suzieq.shared.schema import Schema, SchemaForTable
 
 logger = logging.getLogger(__name__)
+BLACKLIST_SERVICES = ['ifCounters', 'topmem', 'topcpu']
 
 
 class ServiceManager:
@@ -138,8 +139,6 @@ class ServiceManager:
             List[str]: the list of services to executed in the poller
         """
 
-        BLACKLIST_SERVICES = ['ifCounters', 'topmem', 'topcpu']
-
         if not os.path.isdir(service_directory):
             raise SqPollerConfError(
                 'The service directory provided is not a directory'
@@ -207,7 +206,11 @@ class ServiceManager:
                 logger.warning(f'Skip empty service file: {filename}')
                 continue
 
-            if svc_def.get('service') not in self.svcs_list:
+            service = svc_def.get('service')
+            if service in BLACKLIST_SERVICES:
+                continue
+
+            if all(service not in x for x in [self.svcs_list]):
                 logger.warning(
                     f"Ignoring unspecified service {svc_def.get('service')}"
                 )

--- a/tests/integration/sqcmds/cumulus-samples/top.yml
+++ b/tests/integration/sqcmds/cumulus-samples/top.yml
@@ -577,9 +577,20 @@ tests:
 - command: mac top --what=moveCount --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top
+  output: '[{"namespace": "ospf-single", "hostname": "leaf04", "vlan": 0, "macaddr":
+    "44:38:39:00:00:2c", "oif": "swp5", "remoteVtepIp": "", "bd": "", "flags": "permanent",
+    "moveCount": 0, "timestamp": 1616352403984}, {"namespace": "ospf-single", "hostname":
+    "leaf04", "vlan": 10, "macaddr": "44:38:39:00:00:2c", "oif": "bridge", "remoteVtepIp":
+    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1616352403984},
+    {"namespace": "ospf-single", "hostname": "leaf04", "vlan": 10, "macaddr": "00:03:00:44:44:02",
+    "oif": "swp5", "remoteVtepIp": "", "bd": "", "flags": "", "moveCount": 0, "timestamp":
+    1616352403984}, {"namespace": "ospf-single", "hostname": "leaf03", "vlan": 0,
+    "macaddr": "44:38:39:00:00:1f", "oif": "swp5", "remoteVtepIp": "", "bd": "", "flags":
+    "permanent", "moveCount": 0, "timestamp": 1616352404671}, {"namespace": "ospf-single",
+    "hostname": "leaf03", "vlan": 10, "macaddr": "44:38:39:00:00:1f", "oif": "bridge",
+    "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp":
+    1616352404671}]'
 - command: route top --what=prefixlen --format=json --namespace='ospf-single dual-evpn
     ospf-ibgp'
   data-directory: tests/data/parquet/

--- a/tests/integration/sqcmds/eos-samples/top.yml
+++ b/tests/integration/sqcmds/eos-samples/top.yml
@@ -126,9 +126,19 @@ tests:
     4, "action": "forward", "numNexthops": 3, "timestamp": 1623025174530}]'
 - command: mac top --what=moveCount --format=json --namespace='eos'
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top eos
+  output: '[{"namespace": "eos", "hostname": "server302", "vlan": 0, "macaddr": "33:33:ff:95:20:c5",
+    "oif": "eth0", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
+    0, "timestamp": 1623025175379}, {"namespace": "eos", "hostname": "server302",
+    "vlan": 0, "macaddr": "33:33:ff:66:e7:e2", "oif": "bond0", "remoteVtepIp": "",
+    "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025175379}, {"namespace":
+    "eos", "hostname": "server302", "vlan": 0, "macaddr": "33:33:ff:66:e7:e2", "oif":
+    "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp":
+    1623025175379}, {"namespace": "eos", "hostname": "server302", "vlan": 0, "macaddr":
+    "33:33:ff:66:e7:e2", "oif": "eth2", "remoteVtepIp": "", "bd": "", "flags": "permanent",
+    "moveCount": 0, "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
+    "server302", "vlan": 0, "macaddr": "33:33:00:00:00:01", "oif": "eth1", "remoteVtepIp":
+    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025175379}]'
 - command: route top --what=prefixlen --format=json --namespace='eos'
   data-directory: tests/data/parquet/
   marks: route top eos

--- a/tests/integration/sqcmds/junos-samples/top.yml
+++ b/tests/integration/sqcmds/junos-samples/top.yml
@@ -125,9 +125,20 @@ tests:
     "numNexthops": 2, "timestamp": 1623025802263}]'
 - command: mac top --what=moveCount --format=json --namespace='junos'
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top junos
+  output: '[{"namespace": "junos", "hostname": "server202", "vlan": 0, "macaddr":
+    "33:33:ff:88:ae:71", "oif": "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent",
+    "moveCount": 0, "timestamp": 1623025795510}, {"namespace": "junos", "hostname":
+    "server202", "vlan": 0, "macaddr": "33:33:ff:1f:79:0c", "oif": "eth0", "remoteVtepIp":
+    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025795510},
+    {"namespace": "junos", "hostname": "server202", "vlan": 0, "macaddr": "33:33:00:00:00:01",
+    "oif": "eth0", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount":
+    0, "timestamp": 1623025795510}, {"namespace": "junos", "hostname": "server202",
+    "vlan": 0, "macaddr": "33:33:00:00:00:01", "oif": "eth1", "remoteVtepIp": "",
+    "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1623025795510}, {"namespace":
+    "junos", "hostname": "server202", "vlan": 0, "macaddr": "01:80:c2:00:00:0e", "oif":
+    "eth1", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp":
+    1623025795510}]'
 - command: route top --what=prefixlen --format=json --namespace='junos'
   data-directory: tests/data/parquet/
   marks: route top junos

--- a/tests/integration/sqcmds/nxos-samples/top.yml
+++ b/tests/integration/sqcmds/nxos-samples/top.yml
@@ -130,9 +130,19 @@ tests:
     1619275257123}]'
 - command: mac top --what=moveCount --format=json --namespace='nxos'
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: ''mackey''"}]'
   marks: mac top nxos
+  output: '[{"namespace": "nxos", "hostname": "spine02", "vlan": 0, "macaddr": "44:01:01:02:1b:08",
+    "oif": "sup-eth1", "remoteVtepIp": "", "bd": "", "flags": "router", "moveCount":
+    0, "timestamp": 1619275258116}, {"namespace": "nxos", "hostname": "spine01", "vlan":
+    0, "macaddr": "44:01:01:01:1b:08", "oif": "sup-eth1", "remoteVtepIp": "", "bd":
+    "", "flags": "router", "moveCount": 0, "timestamp": 1619275257253}, {"namespace":
+    "nxos", "hostname": "server302", "vlan": 0, "macaddr": "33:33:ff:de:d8:99", "oif":
+    "eth0", "remoteVtepIp": "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp":
+    1619275256204}, {"namespace": "nxos", "hostname": "server302", "vlan": 0, "macaddr":
+    "33:33:ff:22:53:72", "oif": "bond0", "remoteVtepIp": "", "bd": "", "flags": "permanent",
+    "moveCount": 0, "timestamp": 1619275256204}, {"namespace": "nxos", "hostname":
+    "server302", "vlan": 0, "macaddr": "33:33:ff:22:53:72", "oif": "eth1", "remoteVtepIp":
+    "", "bd": "", "flags": "permanent", "moveCount": 0, "timestamp": 1619275256204}]'
 - command: route top --what=prefixlen --format=json --namespace='nxos'
   data-directory: tests/data/parquet/
   marks: route top nxos


### PR DESCRIPTION
This patch addresses several fixes:

* Removes the IPv6 loopback address from being saved for Linux-y NOS (Cumulus, SONiC)
* Treats the .0 interface in Junos to be of the same type as the parent interface (lo0.0 is the same type as lo0, but not lo0.1)
* Not printing "Ignoring service" for blacklisted services
* mac show displaying the correct information when user requests viewing moveCount logical column
* More improvements to network find
* Display data sorted by timestamp when user specifies view=all or provides both start and end times

I'll update the tests (moveCount tests are failing right now) and add new tests for network find once the review is done.