### PR TITLE
Fix coalesced file selection with start-time and timestamp column visualization

### DIFF
--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -317,7 +317,8 @@ class SqCommand(SqPlugin):
             if 'active' in df.columns:
                 df['active'] = np.where(df.active, '+', '-')
             if (not (self.view == "all" or self.columns == ['*'] or
-                     (self.start_time and self.end_time) or dont_strip_cols)):
+                     (self.start_time and self.end_time) or dont_strip_cols
+                     or 'timestamp' in self.columns)):
                 if 'timestamp' in cols:
                     cols.remove('timestamp')
             with pd.option_context(

--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -573,12 +573,14 @@ class SqParquetDB(SqDB):
                         thistime = os.path.basename(file).split('.')[0] \
                             .split('-')[-2:]
                         thistime = [int(x)*1000 for x in thistime]  # to msec
+                        file_start_time, file_end_time = thistime
+
                         if (not start_time) or start_selected or (
-                                thistime[0] <= start_time <= thistime[1]):
+                                file_end_time >= start_time):
                             if not end_time:
                                 selected_in_dir.extend(files_per_ns[ele][i:])
                                 break
-                            if thistime[0] <= end_time:
+                            if file_start_time <= end_time:
                                 if (start_time or start_selected or
                                         view == "all"):
                                     selected_in_dir.append(file)


### PR DESCRIPTION
## Description

This PR fixes two problems related to time:

- The start-time did not always work since some of the coalesced file were not selected
- The cli did not show the timestamp column when selected among the columns

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)