### PR TITLE
More misc fixes 19

### DIFF
--- a/suzieq/config/routes.yml
+++ b/suzieq/config/routes.yml
@@ -93,7 +93,24 @@ apply:
     copy: junos-qfx
 
   junos-mx:
-    copy: junos-qfx
+      - command: show route protocol direct | display json | no-more
+        normalize: 'route-information/[0]/route-table/*:table-name:vrf/rt/*/[
+        "rt-destination/[0]/data: prefix",
+        "rt-prefix-length/[0]/data: _rtlen?|0",
+        "rt-entry/[0]/protocol-name/[0]/data: protocol",
+        "rt-entry/[0]/preference/[0]/data: preference?|0",
+        "rt-entry/[0]/age/[0]/attributes: statusChangeTimestamp?|",
+        "rt-entry/[0]/metric/[0]/data: metric?|0",
+        "rt-entry/[0]/active-tag/[0]/data: _activeTag",
+        "rt-entry/[0]/as-path/[0]/data: asPathList?|[]",
+        "rt-entry/[0]/validation-state/[0]/data: validState?|",
+        "rt-entry/[0]/nh/[*]/to/[0]/data: nexthopIps",
+        "rt-entry/[0]/nh/[*]/via/[0]/data: oifs",
+        "rt-entry/[0]/nh/[0]/nh-local-interface/[0]/data: _localif?|",
+        "rt-entry/[0]/nh-type/[0]/data: action?|forward",
+        "rt-entry/[0]/rt-tag/[0]/data: routeTag?|",
+        "hardwareProgrammed: hardwareProgrammed?|unknown",
+        ]'
 
   junos-es:
     copy: junos-qfx

--- a/suzieq/config/schema/topology.avsc
+++ b/suzieq/config/schema/topology.avsc
@@ -57,13 +57,13 @@
         },
         {
             "name": "asn",
-            "type": "string",
+            "type": "long",
             "display": 7,
             "description": "BGP ASN for BGP peering"
         },
         {
             "name": "peerAsn",
-            "type": "string",
+            "type": "long",
             "display": 8,
             "description": "BGP peerASN in BGP peering"
         },

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -10,7 +10,7 @@ from ciscoconfparse import CiscoConfParse
 from suzieq.engines.pandas.engineobj import SqPandasEngine
 from suzieq.shared.confutils import (get_access_port_interfaces,
                                      get_trunk_port_interfaces)
-from suzieq.shared.utils import build_query_str, reduce_filter_list
+from suzieq.shared.utils import build_query_str
 
 
 class InterfacesObj(SqPandasEngine):
@@ -132,9 +132,9 @@ class InterfacesObj(SqPandasEngine):
             vlan = int(vlan)
             if op == "!":
                 tmpdf = df[df.apply(
-                    lambda x, vlan: all(opdict[op](y, vlan)
-                                        for y in x.vlanList) and
-                    opdict[op](x.vlan, vlan), args=(vlan,), axis=1)]
+                    lambda row, vlan: all(opdict[op](v, vlan)
+                                          for v in row.vlanList) and
+                    opdict[op](row.vlan, vlan), args=(vlan,), axis=1)]
             else:
                 tmpdf = df[df.apply(
                     lambda x, vlan: any(opdict[op](y, vlan)

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -1,5 +1,7 @@
+from typing import List
 from ipaddress import ip_network
 import re
+import operator
 
 import numpy as np
 import pandas as pd
@@ -8,7 +10,7 @@ from ciscoconfparse import CiscoConfParse
 from suzieq.engines.pandas.engineobj import SqPandasEngine
 from suzieq.shared.confutils import (get_access_port_interfaces,
                                      get_trunk_port_interfaces)
-from suzieq.shared.utils import build_query_str
+from suzieq.shared.utils import build_query_str, reduce_filter_list
 
 
 class InterfacesObj(SqPandasEngine):
@@ -71,14 +73,10 @@ class InterfacesObj(SqPandasEngine):
             query_str = build_query_str([], self.schema, state=state,
                                         portmode=portmode)
 
-            df = df.query(query_str)
+            df = df.query(query_str).reset_index(drop=True)
 
         if vlan:
-            # vlan needs to be looked at even in vlanList
-            vlan = [int(x) for x in vlan]
-            query_str = f' (vlan.isin({vlan}) or ' \
-                f'@self._is_any_in_list(vlanList, {vlan}))'
-            df = df.query(query_str)
+            df = self._check_vlan_match(vlan, df).reset_index(drop=True)
 
         if user_query:
             df = self._handle_user_query_str(df, user_query)
@@ -88,6 +86,69 @@ class InterfacesObj(SqPandasEngine):
                      .reset_index(drop=True)[fields]
         else:
             return df.reset_index(drop=True)[fields]
+
+    def _check_vlan_match(self, vlan_list: List[str],
+                          df: pd.DataFrame) -> pd.DataFrame:
+        '''Return a dataframe with rows in VLANs requested
+
+        VLAN is treated specially because its the only field that is a list
+        of integers, and can be filtered on multiple fields: vlan and vlanList
+        A user filter on VLAN is a list that can contain numeric comparisons
+        as well as simple integers.
+
+        Its not made into a generic filter match because this match on VLAN
+        applies only to interface table.
+        '''
+
+        # If there are any VLANs with ! mixed without !, remove the
+        # ! ones. vlanList is an OR list, not an AND list, except
+        # if all are !
+        if any(x.startswith('!') for x in vlan_list):
+            cond = 'and'
+        else:
+            cond = 'or'
+
+        resdf_list = []
+        if (any(x.startswith('>') for x in vlan_list) and
+                any(x.startswith('<') for x in vlan_list)):
+            # if the user specifies both >/>= and </<=, then we
+            # treat this as an and
+            cond = 'and'
+
+        opdict = {'<': operator.lt, '>': operator.gt,
+                  '<=': operator.le, '>=': operator.ge,
+                  '!': operator.ne, '==': operator.eq}
+
+        for vlan in vlan_list:
+            if vlan.startswith(('<=', '>=')):
+                op = vlan[0:2]
+                vlan = vlan[2:].strip()
+            elif vlan.startswith(('<', '>', '!')):
+                op = vlan[0]
+                vlan = vlan[1:].strip()
+            else:
+                op = '=='
+
+            vlan = int(vlan)
+            if op == "!":
+                tmpdf = df[df.apply(
+                    lambda x, vlan: all(opdict[op](y, vlan)
+                                        for y in x.vlanList) and
+                    opdict[op](x.vlan, vlan), args=(vlan,), axis=1)]
+            else:
+                tmpdf = df[df.apply(
+                    lambda x, vlan: any(opdict[op](y, vlan)
+                                        for y in x.vlanList) or
+                    opdict[op](x.vlan, vlan), args=(vlan,), axis=1)]
+            if cond == "or":
+                resdf_list.append(tmpdf.reset_index(drop=True))
+            else:
+                df = tmpdf
+
+        if resdf_list:
+            df = pd.concat(resdf_list)
+
+        return df.query('vlanList.str.len() > 0 or vlan != 0')
 
     def aver(self, what="", **kwargs) -> pd.DataFrame:
         """Assert that interfaces are in good state"""

--- a/suzieq/engines/pandas/lldp.py
+++ b/suzieq/engines/pandas/lldp.py
@@ -67,8 +67,11 @@ class LldpObj(SqPandasEngine):
                                  errors='ignore')
 
         ifidx_df = df.query('subtype.str.startswith("locally")')
-        ifindices = ifidx_df.query('peerIfindex != 0').peerIfindex \
-            .unique().tolist()
+        # stringify the numbers because sqobj expects pretty much all input
+        # to be strings
+        ifindices = [str(x)
+                     for x in ifidx_df.query('peerIfindex != 0').peerIfindex
+                     .unique().tolist()]
         if not ifidx_df.empty and ifindices:
             ifdf = self._get_table_sqobj('interfaces').get(
                 namespace=namespace, ifindex=ifindices,

--- a/suzieq/engines/pandas/macs.py
+++ b/suzieq/engines/pandas/macs.py
@@ -9,6 +9,7 @@ class MacsObj(SqPandasEngine):
         '''Table name'''
         return 'macs'
 
+    # pylint: disable=too-many-statements
     def get(self, **kwargs):
         if not self.iobj.table:
             raise NotImplementedError
@@ -75,6 +76,8 @@ class MacsObj(SqPandasEngine):
                 except ValueError:
                     df = df.query(
                         f'moveCount {moveCount}').reset_index(drop=True)
+        elif df.empty and compute_moves:
+            df['moveCount'] = []
 
         df = self._handle_user_query_str(df, user_query)
         if remoteOnly:

--- a/suzieq/gui/stlit/guiutils.py
+++ b/suzieq/gui/stlit/guiutils.py
@@ -57,8 +57,7 @@ def display_help_icon(url: str):
         unsafe_allow_html=True)
 
 
-@st.cache(ttl=90, allow_output_mutation=True, show_spinner=False,
-          max_entries=20)
+@st.experimental_memo
 def gui_get_df(table: str,
                config_file: str,
                verb: str = 'get', **kwargs) -> pd.DataFrame:

--- a/suzieq/gui/stlit/xplore.py
+++ b/suzieq/gui/stlit/xplore.py
@@ -639,7 +639,6 @@ class XplorePage(SqGuiPage):
                 else:
                     st.info('Assert not run')
 
-    @st.cache(ttl=90)
     def _run_summarize(self, **kwargs):
         '''Get summarize dataframe for the object in question'''
         df = gui_get_df(self._state.table, self._config_file, verb='summarize',

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -887,7 +887,7 @@ class Node:
             if isinstance(use, list):
                 # There's more than one version here, we have to pick ours
                 for item in use:
-                    if item['version'] != "all":
+                    if item.get('version', '') != "all":
                         os_version = item['version']
                         opdict = {'>': operator.gt, '<': operator.lt,
                                   '>=': operator.ge, '<=': operator.le,

--- a/suzieq/sqobjects/address.py
+++ b/suzieq/sqobjects/address.py
@@ -31,4 +31,4 @@ class AddressObj(SqObject):
                     if not validate_macaddr(a):
                         raise ValueError("Invalid address specified")
 
-        super().validate_get_input(**kwargs)
+        return super().validate_get_input(**kwargs)

--- a/suzieq/sqobjects/arpnd.py
+++ b/suzieq/sqobjects/arpnd.py
@@ -38,5 +38,5 @@ class ArpndObj(SqObject):
                 if not validate_macaddr(m):
                     raise ValueError("Invalid mac address specified")
 
-        super().validate_get_input(**kwargs)
         self._unique_def_column = ['ipAddress']
+        return super().validate_get_input(**kwargs)

--- a/suzieq/sqobjects/macs.py
+++ b/suzieq/sqobjects/macs.py
@@ -32,4 +32,4 @@ class MacsObj(SqObject):
                         int(words[-1])
                     except Exception:
                         raise ValueError(f'Invalid VLAN value: {val}')
-        super().validate_get_input(**kwargs)
+        return super().validate_get_input(**kwargs)

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -528,24 +528,24 @@ tests:
     "OSPF area in OSPF peering"}, {"name": "arpnd", "type": "bool", "key": "", "display":
     10, "description": "Is the peer connected via ARP"}, {"name": "arpndBidir", "type":
     "bool", "key": "", "display": 11, "description": "Is the ARP peering bidirecttonal"},
-    {"name": "asn", "type": "string", "key": "", "display": 7, "description": "BGP
-    ASN for BGP peering"}, {"name": "bgp", "type": "bool", "key": "", "display": 12,
-    "description": "Is the peer connected via BGP"}, {"name": "hostname", "type":
-    "string", "key": "", "display": 2, "description": "Hostname associated with this
-    record"}, {"name": "ifname", "type": "string", "key": "", "display": 3, "description":
-    "Interface that the host is connected on, discovered through lldp"}, {"name":
-    "lldp", "type": "bool", "key": "", "display": 13, "description": "Is the peer
-    connected via LLDP"}, {"name": "namespace", "type": "string", "key": "", "display":
-    1, "description": "Namespace associated with this record"}, {"name": "ospf", "type":
-    "bool", "key": "", "display": 14, "description": "Is the perr connected via OSPF"},
-    {"name": "peerAsn", "type": "string", "key": "", "display": 8, "description":
-    "BGP peerASN in BGP peering"}, {"name": "peerHostname", "type": "string", "key":
-    "", "display": 4, "description": "Name of the other side of the connection"},
-    {"name": "polled", "type": "bool", "key": "", "display": 15, "description": "is
-    this peerHostname polled by Suzieq"}, {"name": "sqvers", "type": "string", "key":
-    "", "display": "", "description": "Schema version, not selectable"}, {"name":
-    "vrf", "type": "string", "key": "", "display": 6, "description": "VRF that the
-    connection is in"}]'
+    {"name": "asn", "type": "long", "key": "", "display": 7, "description": "BGP ASN
+    for BGP peering"}, {"name": "bgp", "type": "bool", "key": "", "display": 12, "description":
+    "Is the peer connected via BGP"}, {"name": "hostname", "type": "string", "key":
+    "", "display": 2, "description": "Hostname associated with this record"}, {"name":
+    "ifname", "type": "string", "key": "", "display": 3, "description": "Interface
+    that the host is connected on, discovered through lldp"}, {"name": "lldp", "type":
+    "bool", "key": "", "display": 13, "description": "Is the peer connected via LLDP"},
+    {"name": "namespace", "type": "string", "key": "", "display": 1, "description":
+    "Namespace associated with this record"}, {"name": "ospf", "type": "bool", "key":
+    "", "display": 14, "description": "Is the perr connected via OSPF"}, {"name":
+    "peerAsn", "type": "long", "key": "", "display": 8, "description": "BGP peerASN
+    in BGP peering"}, {"name": "peerHostname", "type": "string", "key": "", "display":
+    4, "description": "Name of the other side of the connection"}, {"name": "polled",
+    "type": "bool", "key": "", "display": 15, "description": "is this peerHostname
+    polled by Suzieq"}, {"name": "sqvers", "type": "string", "key": "", "display":
+    "", "description": "Schema version, not selectable"}, {"name": "vrf", "type":
+    "string", "key": "", "display": 6, "description": "VRF that the connection is
+    in"}]'
 - command: vlan describe --format=json
   data-directory: tests/data/parquet
   marks: vlan describe

--- a/tests/integration/sqcmds/cumulus-samples/interface.yml
+++ b/tests/integration/sqcmds/cumulus-samples/interface.yml
@@ -3683,3 +3683,1161 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique cumulus
   output: '[]'
+- command: interface show --mtu='>1514 <9216' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth1",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.101/24"], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.103/24"], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.2.104/24"], "ip6AddressList": [], "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.2.102/24"], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24-v0",
+    "state": "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0,
+    "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.12/24"], "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.2/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d543/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 24, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.13/24"], "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan24-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:24/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.13/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "vni13", "state": "up", "adminState":
+    "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "peerlink.4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList":
+    ["169.254.1.1/30"], "ip6AddressList": ["fe80::4a47:ff:fee9:d545/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan24-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan24",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 24, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.14/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan13-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.1.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:13/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.14/24"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vni13", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vni24", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.2/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "bond01", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.1/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp3", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp4", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vni24", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.11/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan24-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan24",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 24, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.11/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan13-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.1.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:13/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp6", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond01", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}]'
+- command: interface show --vlan='> 10 < 100' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.1.12/24"], "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vni24", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.13/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.13/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vni13", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.14/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.14/24"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "vni13", "state": "up", "adminState":
+    "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.11/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.11/24"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}]'
+- command: interface show --mtu='>= 1514' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth1",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.101/24"], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581492},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "bond0", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "",
+    "ipAddressList": ["172.16.1.103/24"], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth2", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master":
+    "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth1", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master":
+    "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581509}, {"namespace":
+    "ospf-ibgp", "hostname": "server104", "ifname": "bond0", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "", "ipAddressList": ["172.16.2.104/24"],
+    "ip6AddressList": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+    "hostname": "server104", "ifname": "eth2", "state": "up", "adminState": "up",
+    "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond0", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+    "hostname": "server104", "ifname": "eth1", "state": "up", "adminState": "up",
+    "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond0", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+    "hostname": "server104", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.100/32"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server102",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.2.102/24"], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "internet-vrf", "ipAddressList": ["169.254.127.1/31"], "ip6AddressList":
+    ["fe80::5054:ff:fecf:70e0/64"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "bridge", "state": "up", "adminState": "up", "type":
+    "bridge", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    ["fe80::900d:55ff:fe8d:b541/64"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"],
+    "ip6AddressList": ["fe80::5054:ff:feff:73be/64"], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp2", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.101/32"], "ip6AddressList": ["fe80::5054:ff:fe28:db32/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp5.2", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 2, "master": "", "ipAddressList": ["169.254.254.1/30"], "ip6AddressList":
+    ["fe80::5054:ff:fe81:c154/64"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "evpn-vrf", "state": "up", "adminState": "up",
+    "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"],
+    "ip6AddressList": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "swp5.4", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9216, "vlan": 4, "master": "internet-vrf", "ipAddressList": ["169.254.254.9/30"],
+    "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.3", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 3, "master": "evpn-vrf",
+    "ipAddressList": ["169.254.254.5/30"], "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "vlan4001", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 4001, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    ["fe80::900d:55ff:fe8d:b541/64"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "internet-vrf", "state": "up", "adminState": "up",
+    "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"],
+    "ip6AddressList": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "mgmt", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"],
+    "ip6AddressList": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "vxlan4001", "state": "up", "adminState": "up",
+    "type": "vxlan", "mtu": 9216, "vlan": 4001, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe51:eb3d/64"], "timestamp": 1616681582129},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": ["::1/128"], "timestamp":
+    1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp2",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": ["fe80::5054:ff:feeb:d477/64"],
+    "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    ["fe80::5054:ff:fecf:3b50/64"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe7a:b002/64"], "timestamp": 1616681582129},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp6", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": ["fe80::5054:ff:fe83:94bc/64"],
+    "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "ifname": "mgmt", "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [],
+    "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    ["fe80::5054:ff:feb0:3559/64"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "bridge", "state": "up", "adminState": "up", "type":
+    "bridge", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    ["fe80::e8c9:a5ff:fe5f:c7ca/64"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe93:9e21/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"], "timestamp":
+    1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.2",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 2, "master":
+    "", "ipAddressList": ["169.254.253.1/30"], "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "swp2", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"], "ip6AddressList":
+    ["fe80::5054:ff:fe5f:a0b6/64"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "swp5.3", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9216, "vlan": 3, "master": "evpn-vrf", "ipAddressList": ["169.254.253.5/30"],
+    "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "vlan4001", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4001, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": ["fe80::e8c9:a5ff:fe5f:c7ca/64"],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "internet-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"], "ip6AddressList":
+    [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "swp5.4", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 4, "master": "internet-vrf", "ipAddressList": ["169.254.253.9/30"],
+    "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp6", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "internet-vrf",
+    "ipAddressList": ["169.254.127.3/31"], "ip6AddressList": ["fe80::5054:ff:fe54:b41d/64"],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "mgmt", "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"], "ip6AddressList":
+    [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24-v0",
+    "state": "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0,
+    "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan13-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.1.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:13/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vlan24", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.12/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan4001", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4001, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": ["fe80::4639:39ff:feff:4094/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "mgmt", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "bond01", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bridge", "state": "up", "adminState": "up", "type": "bridge", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.12/32", "10.0.0.112/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "peerlink.4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList":
+    ["169.254.1.2/30"], "ip6AddressList": ["fe80::4a47:ff:fee9:d543/64"], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": ["fe80::5054:ff:fed5:33ac/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp2", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList":
+    ["fe80::5054:ff:fec7:a486/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "internet", "ifname": "swp2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["169.254.127.2/31"],
+    "ip6AddressList": ["fe80::5054:ff:fecd:78c7/64"], "timestamp": 1616681582344},
+    {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.253/32", "172.16.253.1/32"], "ip6AddressList": ["::1/128"],
+    "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname": "internet",
+    "ifname": "swp1", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["169.254.127.0/31"], "ip6AddressList":
+    ["fe80::5054:ff:fe88:3d81/64"], "timestamp": 1616681582344}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vni13", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "mgmt", "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan4001", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 4001, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    ["fe80::4639:39ff:feff:4095/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan24", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.13/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan13-v0", "state":
+    "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.13/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "evpn-vrf", "state": "up", "adminState": "up",
+    "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan24-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:24/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.13/32"],
+    "ip6AddressList": ["fe80::5054:ff:fea1:a5be/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.13/32"], "ip6AddressList": ["fe80::5054:ff:fedb:8ed/64"],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.1/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d545/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "lo", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.13/32", "10.0.0.134/32"], "ip6AddressList": ["::1/128"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bridge",
+    "state": "up", "adminState": "up", "type": "bridge", "mtu": 9216, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond02",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vni24", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan13",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.14/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "mgmt", "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.14/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan24-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan4001",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4001,
+    "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": ["fe80::4639:39ff:feff:4095/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan13-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.1.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:13/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vni13", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "bridge", "state": "up", "adminState": "up", "type": "bridge", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.14/32", "10.0.0.134/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp1", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList":
+    ["fe80::5054:ff:fe13:2a2c/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "swp2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.14/32"],
+    "ip6AddressList": ["fe80::5054:ff:feb5:4a7b/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp3", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink.4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList":
+    ["169.254.1.2/30"], "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp5",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": ["fe80::5054:ff:fee5:e3d4/64"],
+    "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList":
+    ["fe80::5054:ff:fea7:ba2d/64"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe25:b05b/64"], "timestamp": 1616681582843},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp2", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": ["fe80::5054:ff:fed1:da/64"],
+    "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "ifname": "swp1", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList":
+    ["fe80::5054:ff:fe54:3d39/64"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "swp6", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe5d:daac/64"], "timestamp": 1616681582843},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "mgmt", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582843}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "swp5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan4001", "state": "up", "adminState": "up",
+    "type": "vlan", "mtu": 9216, "vlan": 4001, "master": "evpn-vrf", "ipAddressList":
+    [], "ip6AddressList": ["fe80::4639:39ff:feff:4094/64"], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan24-v0", "state":
+    "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.11/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan13",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.11/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "mgmt",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vxlan4001", "state":
+    "up", "adminState": "up", "type": "vxlan", "mtu": 9216, "vlan": 4001, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "bridge", "state": "up", "adminState": "up", "type": "bridge", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.11/32", "10.0.0.112/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList":
+    ["169.254.1.1/30"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList": ["fe80::5054:ff:fee6:f5c/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp2", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList":
+    ["fe80::5054:ff:fee6:5037/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vni13", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}]'
+- command: interface show --mtu='! 1514 !9216' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth0",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["192.168.123.184/24"], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.101/24"], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581492},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth1", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master":
+    "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth2", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master":
+    "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "bond0", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 0, "master": "",
+    "ipAddressList": ["172.16.1.103/24"], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "server103", "ifname": "eth0", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": ["192.168.123.150/24"], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581509},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.100/32"], "ip6AddressList": [], "timestamp": 1616681581517},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth0", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": ["192.168.123.180/24"], "ip6AddressList": [], "timestamp": 1616681581517},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "ifname": "eth1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681581517}, {"namespace":
+    "ospf-ibgp", "hostname": "edge01", "ifname": "eth2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp",
+    "hostname": "server104", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104",
+    "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": ["192.168.123.197/24"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104",
+    "ifname": "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "eth1.4", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 4, "master": "", "ipAddressList": ["169.254.254.10/30"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "eth1.3", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 3, "master": "", "ipAddressList": ["169.254.254.6/30"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "eth2.3", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 3, "master": "", "ipAddressList": ["169.254.253.6/30"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "eth2.2", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 2, "master": "", "ipAddressList": ["169.254.253.2/30"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "eth1.2", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 2, "master": "", "ipAddressList": ["169.254.254.2/30"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104",
+    "ifname": "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "ifname": "eth2.4", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 4, "master": "", "ipAddressList": ["169.254.253.10/30"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104",
+    "ifname": "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000,
+    "vlan": 0, "master": "", "ipAddressList": ["172.16.2.104/24"], "ip6AddressList":
+    [], "timestamp": 1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server102",
+    "ifname": "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000,
+    "vlan": 0, "master": "", "ipAddressList": ["172.16.2.102/24"], "ip6AddressList":
+    [], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102",
+    "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": ["192.168.123.134/24"], "ip6AddressList":
+    [], "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102",
+    "ifname": "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "mgmt",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "eth0", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt",
+    "ipAddressList": ["192.168.123.188/24"], "ip6AddressList": ["fe80::5054:ff:fea5:b81e/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "internet-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"], "ip6AddressList":
+    [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"], "ip6AddressList":
+    [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp4", "state": "down", "adminState": "down", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp3",
+    "state": "down", "adminState": "down", "type": "ethernet", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.101/32"], "ip6AddressList": ["::1/128"], "timestamp":
+    1616681582085}, {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "lo",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": ["::1/128"],
+    "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "mgmt", "ipAddressList": ["192.168.123.135/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe27:7be2/64"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "ifname": "mgmt", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"],
+    "ip6AddressList": [], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "mgmt", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/8"],
+    "ip6AddressList": [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "eth0", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt", "ipAddressList": ["192.168.123.136/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe83:b0c4/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "internet-vrf", "state":
+    "up", "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.102/32"], "ip6AddressList": [], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "evpn-vrf", "state":
+    "up", "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.102/32"], "ip6AddressList": [], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp4", "state": "down",
+    "adminState": "down", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582248}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "ifname": "swp3", "state": "down", "adminState":
+    "down", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "eth0", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt", "ipAddressList": ["192.168.123.239/24"],
+    "ip6AddressList": ["fe80::5054:ff:fef5:60b5/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24-v0", "state":
+    "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.12/24"], "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vni24",
+    "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "mgmt", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "swp6", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "bond01", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.12/32", "10.0.0.112/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.2/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d543/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vni13", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "internet", "ifname": "eth0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["192.168.123.237/24"], "ip6AddressList": ["fe80::5054:ff:fe98:9fd5/64"], "timestamp":
+    1616681582344}, {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "lo",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.253/32", "172.16.253.1/32"], "ip6AddressList":
+    ["::1/128"], "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf03", "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.13/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "mgmt", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "eth0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt", "ipAddressList":
+    ["192.168.123.248/24"], "ip6AddressList": ["fe80::5054:ff:fe3c:a62d/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24-v0",
+    "state": "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0,
+    "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.13/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vni24",
+    "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vni13", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "evpn-vrf", "state": "up", "adminState": "up",
+    "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.13/32", "10.0.0.134/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.1/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d545/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "mgmt", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "eth0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt", "ipAddressList":
+    ["192.168.123.202/24"], "ip6AddressList": ["fe80::5054:ff:fe18:6851/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan24-v0",
+    "state": "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0,
+    "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.14/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan13",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.14/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "peerlink", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.2/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "lo", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.14/32", "10.0.0.134/32"], "ip6AddressList": ["::1/128"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond01", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "evpn-vrf", "state": "up", "adminState":
+    "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "lo", "state": "up", "adminState": "up", "type":
+    "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "eth0", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt", "ipAddressList": ["192.168.123.16/24"],
+    "ip6AddressList": ["fe80::5054:ff:fead:db52/64"], "timestamp": 1616681582843},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "mgmt", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582843}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan13", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.11/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "mgmt",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["127.0.0.1/8"], "ip6AddressList": [], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "eth0", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "mgmt",
+    "ipAddressList": ["192.168.123.30/24"], "ip6AddressList": ["fe80::5054:ff:fe93:6d43/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan24-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:24/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond01", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.11/32", "10.0.0.112/32"],
+    "ip6AddressList": ["::1/128"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "peerlink", "state": "up", "adminState": "up",
+    "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "peerlink.4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList":
+    ["169.254.1.1/30"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "peerlink", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "peerlink", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vni13",
+    "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan24", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.2.11/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan13-v0",
+    "state": "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0,
+    "master": "evpn-vrf", "ipAddressList": ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582844}]'

--- a/tests/integration/sqcmds/cumulus-samples/swport.yml
+++ b/tests/integration/sqcmds/cumulus-samples/swport.yml
@@ -1674,3 +1674,46 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique cumulus switchport
   output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=ospf-ibgp
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=ospf-ibgp
+    --columns='hostname ifname state adminState type vlan vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=ospf-ibgp
+    --columns='hostname ifname state adminState type vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='!10 !20' --state=up --namespace=ospf-ibgp
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus switchport
+  output: '[{"vlan": 2}, {"vlan": 2}, {"vlan": 3}, {"vlan": 3}, {"vlan": 4}, {"vlan":
+    4}, {"vlan": 2}, {"vlan": 3}, {"vlan": 4001}, {"vlan": 4001}, {"vlan": 4}, {"vlan":
+    4001}, {"vlan": 3}, {"vlan": 4001}, {"vlan": 4}, {"vlan": 2}, {"vlan": 4001},
+    {"vlan": 13}, {"vlan": 24}, {"vlan": 4001}, {"vlan": 24}, {"vlan": 13}, {"vlan":
+    24}, {"vlan": 13}, {"vlan": 1}, {"vlan": 4094}, {"vlan": 24}, {"vlan": 4001},
+    {"vlan": 4001}, {"vlan": 13}, {"vlan": 13}, {"vlan": 13}, {"vlan": 24}, {"vlan":
+    1}, {"vlan": 4094}, {"vlan": 24}, {"vlan": 4001}, {"vlan": 24}, {"vlan": 13},
+    {"vlan": 24}, {"vlan": 13}, {"vlan": 24}, {"vlan": 13}, {"vlan": 1}, {"vlan":
+    4094}, {"vlan": 4001}, {"vlan": 4001}, {"vlan": 24}, {"vlan": 13}, {"vlan": 4001},
+    {"vlan": 24}, {"vlan": 13}, {"vlan": 24}, {"vlan": 1}, {"vlan": 4094}, {"vlan":
+    13}]'
+- command: interface show --columns=vlan --vlan='20' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='10 20' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus switchport
+  output: '[]'
+- command: interface unique --columns=vlanList --vlan='!10 !20' --namespace=ospf-ibgp
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique cumulus switchport
+  output: '[{"vlanList": 1}, {"vlanList": 13}, {"vlanList": 24}]'

--- a/tests/integration/sqcmds/cumulus-samples/topology.yml
+++ b/tests/integration/sqcmds/cumulus-samples/topology.yml
@@ -1125,22 +1125,76 @@ tests:
   data-directory: tests/data/parquet/
   marks: topology unique cumulus
   output: '[]'
-- command: topology show --asn=64520 --format=json --namespace=ospf-ibgp
+- command: topology show --asn=65000 --format=json --namespace=ospf-ibgp
   data-directory: tests/data/parquet/
   marks: topology show cumulus
-  output: '[]'
-- command: topology summarize --asn=64520 --format=json --namespace=ospf-ibgp
+  output: '[{"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "peerHostname": "spine02", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "exit01", "peerHostname": "edge01", "vrf": "default",
+    "asn": 65000, "peerAsn": 65530, "bgp": true, "polled": false}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "peerHostname": "edge01", "vrf": "evpn-vrf", "asn": 65000,
+    "peerAsn": 65530, "bgp": true, "polled": false}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf03", "peerHostname": "spine01", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "peerHostname": "edge01", "vrf":
+    "default", "asn": 65000, "peerAsn": 65530, "bgp": true, "polled": false}, {"namespace":
+    "ospf-ibgp", "hostname": "exit02", "peerHostname": "spine01", "vrf": "default",
+    "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "peerHostname": "edge01", "vrf": "evpn-vrf", "asn": 65000,
+    "peerAsn": 65530, "bgp": true, "polled": false}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf01", "peerHostname": "spine01", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "peerHostname": "exit01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname":
+    "exit02", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf04",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf03", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "spine01", "peerHostname": "leaf01", "vrf": "default",
+    "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "peerHostname": "spine02", "vrf": "default", "asn": 65000,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "peerHostname": "leaf02", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "peerHostname": "spine02", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp":
+    true, "polled": true}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "peerHostname":
+    "spine01", "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled":
+    true}, {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "exit01",
+    "vrf": "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "peerHostname": "leaf01", "vrf":
+    "default", "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace":
+    "ospf-ibgp", "hostname": "spine02", "peerHostname": "leaf02", "vrf": "default",
+    "asn": 65000, "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "peerHostname": "leaf03", "vrf": "default", "asn": 65000,
+    "peerAsn": 65000, "bgp": true, "polled": true}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "peerHostname": "leaf04", "vrf": "default", "asn": 65000, "peerAsn":
+    65000, "bgp": true, "polled": true}]'
+- command: topology summarize --asn=65000 --format=json --namespace=ospf-ibgp
   data-directory: tests/data/parquet/
   marks: topology summarize cumulus
-  output: '{"bgp": {}}'
-- command: topology unique --asn=64520 --format=json --namespace=ospf-ibgp --columns=hostname
+  output: '{"ospf-ibgp": {"bgp_center": ["spine01"], "bgp_degree_histogram": "...",
+    "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
+    13, "bgp_number_of_nodes": 9, "bgp_self_loops": []}}'
+- command: topology unique --asn=65000 --format=json --namespace=ospf-ibgp --columns=hostname
   data-directory: tests/data/parquet/
   marks: topology unique cumulus
-  output: '[]'
-- command: topology summarize --vrf=default --asn=64520 --format=json --namespace=ospf-ibgp
+  output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
+    {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
+    "spine01"}, {"hostname": "spine02"}]'
+- command: topology summarize --vrf=default --asn=65000 --format=json --namespace=ospf-ibgp
   data-directory: tests/data/parquet/
   marks: topology summarize cumulus
-  output: '{"bgp": {}}'
+  output: '{"ospf-ibgp": {"bgp_center": ["spine01"], "bgp_degree_histogram": "...",
+    "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
+    13, "bgp_number_of_nodes": 9, "bgp_self_loops": []}}'
 - command: topology summarize --vrf=default --via=lldp --format=json --namespace=ospf-ibgp
   data-directory: tests/data/parquet/
   marks: topology summarize cumulus

--- a/tests/integration/sqcmds/eos-samples/interface.yml
+++ b/tests/integration/sqcmds/eos-samples/interface.yml
@@ -1029,3 +1029,945 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique eos
   output: '[]'
+- command: interface show --mtu='>1514 <9216' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan1006",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 10, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan10", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet5", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Vlan1006", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 1006, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel1", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Vlan20", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9164, "vlan": 20, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0",
+    "172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1623025176018},
+    {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet4", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel4",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Ethernet5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9214, "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "exit01", "ifname": "Vlan4094",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 4094,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Vlan4094",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 4094,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet6", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "leaf03", "ifname": "Ethernet5", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9214, "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vlan20", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    20, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Ethernet4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel3", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 10, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan10",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}]'
+- command: interface show --vlan='> 10 < 100' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Vxlan1", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798}, {"namespace":
+    "eos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel1", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1623025176018},
+    {"namespace": "eos", "hostname": "leaf04", "ifname": "Vxlan1", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Port-Channel1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9214, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan20",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Vxlan1",
+    "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176020},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Vxlan1", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel4", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "leaf01", "ifname": "Port-Channel4", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9214, "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}]'
+- command: interface show --mtu='>= 1514' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos
+  output: '[{"namespace": "eos", "hostname": "server302", "ifname": "bond0", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["172.16.3.202/24"], "ip6AddressList": [], "timestamp": 1623025175379},
+    {"namespace": "eos", "hostname": "server302", "ifname": "eth2", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 0, "master": "bond0",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175379}, {"namespace":
+    "eos", "hostname": "server302", "ifname": "eth1", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
+    "server302", "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025175379}, {"namespace": "eos", "hostname": "server301",
+    "ifname": "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 0, "master": "", "ipAddressList": ["172.16.2.201/24"], "ip6AddressList":
+    [], "timestamp": 1623025175379}, {"namespace": "eos", "hostname": "server301",
+    "ifname": "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175379}, {"namespace": "eos", "hostname": "server301", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175379}, {"namespace": "eos", "hostname": "server301", "ifname": "lo",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175379},
+    {"namespace": "eos", "hostname": "server101", "ifname": "lo", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025175566}, {"namespace": "eos", "hostname":
+    "server101", "ifname": "eth1", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025175566}, {"namespace": "eos", "hostname": "server101",
+    "ifname": "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175566}, {"namespace": "eos", "hostname": "server101", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.101/24"], "ip6AddressList": [], "timestamp":
+    1623025175566}, {"namespace": "eos", "hostname": "server102", "ifname": "lo",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175575},
+    {"namespace": "eos", "hostname": "server102", "ifname": "bond0", "state": "up",
+    "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList":
+    ["172.16.3.102/24"], "ip6AddressList": [], "timestamp": 1623025175575}, {"namespace":
+    "eos", "hostname": "server102", "ifname": "eth1", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025175575}, {"namespace": "eos", "hostname":
+    "server102", "ifname": "eth2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025175575}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.200/32"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Loopback0", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Loopback1", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.112/32"], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Ethernet5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Ethernet4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Vlan30", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    30, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan10",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Port-Channel3", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 10, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Port-Channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 20, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018},
+    {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan20", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan1006",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Port-Channel1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018},
+    {"namespace": "eos", "hostname": "leaf04", "ifname": "Port-Channel4", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Loopback1", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.134/32"], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "exit01", "ifname": "Loopback0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.31/32"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit02", "ifname": "Loopback0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.32/32"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit02", "ifname": "Vlan4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 4094, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit01", "ifname": "Vlan4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 4094, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "spine01", "ifname": "Loopback0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.21/32"], "ip6AddressList": [], "timestamp": 1623025176022}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet5", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "leaf03", "ifname": "Loopback0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65535, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.13/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Loopback1", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.134/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet4", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel4",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "spine02", "ifname": "Loopback0", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet3", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel3",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Vlan1006", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 1006, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf01", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 10, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname":
+    "leaf01", "ifname": "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9214, "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vlan30", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    30, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Ethernet4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vlan10", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    10, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Loopback0", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Loopback1", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.112/32"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176024},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/9", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "xe-0/0/8", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/7", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/6", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/3",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/4", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "xe-0/0/2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/1", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/0", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/10",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/5", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "xe-0/0/11", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "em0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "em1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "em2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "em3", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
+    "em4", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "fti0", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
+    "vtep", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "lo0.0", "state": "up",
+    "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList": ["fe80::205:860f:fc71:f000/128"],
+    "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
+    "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "dsc",
+    "state": "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "gr-0/0/0", "state": "up", "adminState":
+    "up", "type": "gre", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1623025179345}]'
+- command: interface show --mtu='! 1514 !9216' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos
+  output: '[{"namespace": "eos", "hostname": "server302", "ifname": "lo", "state":
+    "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175379}, {"namespace":
+    "eos", "hostname": "server301", "ifname": "eth0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.255.2.151/24"], "ip6AddressList": [], "timestamp": 1623025175379}, {"namespace":
+    "eos", "hostname": "server301", "ifname": "lo", "state": "up", "adminState": "up",
+    "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1623025175379}, {"namespace": "eos", "hostname":
+    "server302", "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.137/24"], "ip6AddressList":
+    [], "timestamp": 1623025175379}, {"namespace": "eos", "hostname": "server101",
+    "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.57/24"], "ip6AddressList":
+    [], "timestamp": 1623025175566}, {"namespace": "eos", "hostname": "server101",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175566}, {"namespace": "eos", "hostname": "server102", "ifname": "eth0",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.255.2.230/24"], "ip6AddressList": [], "timestamp":
+    1623025175575}, {"namespace": "eos", "hostname": "server102", "ifname": "lo",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175575},
+    {"namespace": "eos", "hostname": "firewall01", "ifname": "eth1.4", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 4, "master": "", "ipAddressList":
+    ["169.254.254.10/30"], "ip6AddressList": [], "timestamp": 1623025175583}, {"namespace":
+    "eos", "hostname": "firewall01", "ifname": "eth2.3", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 1500, "vlan": 3, "master": "", "ipAddressList": ["169.254.253.6/30"],
+    "ip6AddressList": [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname":
+    "firewall01", "ifname": "eth2.2", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 1500, "vlan": 2, "master": "", "ipAddressList": ["169.254.253.2/30"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "eth1.3", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 3, "master": "", "ipAddressList": ["169.254.254.6/30"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "eth1.2", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 2, "master": "", "ipAddressList": ["169.254.254.2/30"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.200/32"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.189/24"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "eth2.4", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    1500, "vlan": 4, "master": "", "ipAddressList": ["169.254.253.10/30"], "ip6AddressList":
+    [], "timestamp": 1623025175583}, {"namespace": "eos", "hostname": "firewall01",
+    "ifname": "eth1", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175583}, {"namespace": "eos", "hostname": "firewall01", "ifname": "eth2",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175583},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet2", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "evpn-vrf", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname":
+    "leaf02", "ifname": "Port-Channel4", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9214, "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Loopback1",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.112/32"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Vxlan1",
+    "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan10", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan1006",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Vlan4094", "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan":
+    4094, "master": "", "ipAddressList": ["169.254.1.1/31"], "ip6AddressList": [],
+    "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Ethernet4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname":
+    "Port-Channel3", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 10, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Management1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.255.2.185/24"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Management1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.255.2.187/24"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "evpn-vrf",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel4", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 30, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Port-Channel1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9214, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Loopback0", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Port-Channel3", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 20, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Ethernet2", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan4094",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 4094,
+    "master": "", "ipAddressList": ["169.254.1.1/31"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Loopback1",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.134/32"], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan20",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "exit02", "ifname":
+    "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176020},
+    {"namespace": "eos", "hostname": "exit02", "ifname": "internet-vrf", "state":
+    "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit01", "ifname": "Management1", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.255.2.251/24"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit01", "ifname": "Vlan4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 4094, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit01", "ifname": "Vxlan1", "state": "up", "adminState":
+    "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit01", "ifname": "Ethernet2", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.31/32"], "ip6AddressList":
+    [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname": "Ethernet1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.31/32"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "internet-vrf", "ipAddressList": ["169.254.127.1/31"], "ip6AddressList":
+    [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    "Ethernet3.2", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": ["169.254.254.1/30"], "ip6AddressList":
+    [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    "Loopback0", "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.31/32"], "ip6AddressList":
+    [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    "Ethernet3.4", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "internet-vrf", "ipAddressList": ["169.254.254.9/30"],
+    "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit01", "ifname": "internet-vrf", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176020},
+    {"namespace": "eos", "hostname": "exit01", "ifname": "Ethernet3.3", "state": "up",
+    "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master":
+    "evpn-vrf", "ipAddressList": ["169.254.254.5/30"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Vlan4094",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 4094,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Management1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.255.2.253/24"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.32/32"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Ethernet3.2",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": ["169.254.253.1/30"], "ip6AddressList": [],
+    "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname":
+    "Ethernet3.3", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["169.254.253.5/30"],
+    "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit02", "ifname": "Ethernet4", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "internet-vrf", "ipAddressList": ["169.254.127.3/31"],
+    "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit02", "ifname": "Ethernet3.4", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 1500, "vlan": 0, "master": "internet-vrf", "ipAddressList":
+    ["169.254.253.9/30"], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace":
+    "eos", "hostname": "exit02", "ifname": "Ethernet3", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname":
+    "exit02", "ifname": "Ethernet2", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.32/32"], "ip6AddressList":
+    [], "timestamp": 1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Ethernet1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.32/32"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet2",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Management1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.255.2.117/24"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet3",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet6",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "spine01", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp":
+    1623025176022}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet6", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan1006", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Loopback1", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.134/32"], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 20, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet5", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Ethernet3", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel3",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Ethernet4", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel4",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Loopback0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65535, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.13/32"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Ethernet2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.13/32"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "spine02", "ifname": "Ethernet5", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.22/32"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Vlan4094", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 1500, "vlan": 4094, "master": "", "ipAddressList":
+    ["169.254.1.0/31"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Ethernet1", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.13/32"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Management1", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.255.2.186/24"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "spine02", "ifname": "Ethernet4", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.22/32"], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Port-Channel4", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 30, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "spine02", "ifname": "Management1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.118/24"],
+    "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "spine02", "ifname": "Loopback0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65535, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname":
+    "Ethernet2", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname":
+    "Ethernet1", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "spine02", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "evpn-vrf",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf01", "ifname": "evpn-vrf", "state": "up", "adminState":
+    "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname":
+    "leaf01", "ifname": "Port-Channel1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9214, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Management1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.255.2.184/24"], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan10",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vlan4094", "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan":
+    4094, "master": "", "ipAddressList": ["169.254.1.0/31"], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet2",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Port-Channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 10, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176024},
+    {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.11/32"], "ip6AddressList": [], "timestamp": 1623025176024},
+    {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Loopback1",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65535, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.112/32"], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan1006",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/3.0",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/2.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "xe-0/0/1.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["169.254.127.2/31"], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "xe-0/0/0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["169.254.127.0/31"], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "fti0", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState": "up",
+    "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/4.0",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "vtep", "state": "up",
+    "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/5.0", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "em1.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["169.254.0.2/24"], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "xe-0/0/7.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/8.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}, {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/9.0",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345},
+    {"namespace": "eos", "hostname": "dcedge01", "ifname": "xe-0/0/10.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace":
+    "eos", "hostname": "dcedge01", "ifname": "xe-0/0/11.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "em0.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.250/24"], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "em2.32768", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["192.168.1.2/24"], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "em4.32768", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["192.0.2.2/24"], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "lo0.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList":
+    ["fe80::205:860f:fc71:f000/128"], "timestamp": 1623025179345}, {"namespace": "eos",
+    "hostname": "dcedge01", "ifname": "lo0.16385", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/6.0", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025179345}, {"namespace": "eos", "hostname": "dcedge01",
+    "ifname": "gr-0/0/0", "state": "up", "adminState": "up", "type": "gre", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025179345}]'

--- a/tests/integration/sqcmds/eos-samples/swport.yml
+++ b/tests/integration/sqcmds/eos-samples/swport.yml
@@ -1067,3 +1067,43 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique eos switchport
   output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=eos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=eos
+    --columns='hostname ifname state adminState type vlan vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=eos
+    --columns='hostname ifname state adminState type vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos switchport
+  output: '[]'
+- command: interface show --columns=vlan --vlan='!10 !20' --state=up --namespace=eos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos switchport
+  output: '[{"vlan": 3}, {"vlan": 4}, {"vlan": 2}, {"vlan": 3}, {"vlan": 4}, {"vlan":
+    2}, {"vlan": 30}, {"vlan": 4094}, {"vlan": 1006}, {"vlan": 30}, {"vlan": 30},
+    {"vlan": 1006}, {"vlan": 4094}, {"vlan": 30}, {"vlan": 4094}, {"vlan": 0}, {"vlan":
+    0}, {"vlan": 4094}, {"vlan": 4094}, {"vlan": 1006}, {"vlan": 30}, {"vlan": 30},
+    {"vlan": 30}, {"vlan": 4094}, {"vlan": 30}, {"vlan": 1006}]'
+- command: interface show --columns=vlan --vlan='20' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos switchport
+  output: '[{"vlan": 0}, {"vlan": 20}, {"vlan": 1}, {"vlan": 20}, {"vlan": 0}, {"vlan":
+    20}, {"vlan": 1}, {"vlan": 20}]'
+- command: interface show --columns=vlan --vlan='10 20' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos switchport
+  output: '[{"vlan": 10}, {"vlan": 0}, {"vlan": 10}, {"vlan": 1}, {"vlan": 10}, {"vlan":
+    10}, {"vlan": 0}, {"vlan": 1}, {"vlan": 0}, {"vlan": 20}, {"vlan": 1}, {"vlan":
+    20}, {"vlan": 0}, {"vlan": 20}, {"vlan": 1}, {"vlan": 20}]'
+- command: interface unique --columns=vlanList --vlan='!10 999' --state=up --namespace=eos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique eos switchport
+  output: '[]'

--- a/tests/integration/sqcmds/eos-samples/topology.yml
+++ b/tests/integration/sqcmds/eos-samples/topology.yml
@@ -862,21 +862,68 @@ tests:
 - command: topology show --asn=64520 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: topology show eos
-  output: '[]'
+  output: '[{"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "eos", "hostname": "leaf03", "peerHostname": "spine01", "vrf": "default",
+    "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos",
+    "hostname": "spine01", "peerHostname": "leaf02", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine01", "peerHostname": "exit02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine01", "peerHostname":
+    "leaf04", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine01", "peerHostname": "exit01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine01", "peerHostname": "leaf01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "leaf02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "leaf04", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "exit02", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "exit01",
+    "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "exit01", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "spine02", "peerHostname": "exit02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "spine02", "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname": "spine02",
+    "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "eos", "hostname": "spine02", "peerHostname":
+    "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "eos", "hostname": "spine02", "peerHostname": "leaf01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "eos", "hostname": "leaf01", "peerHostname": "spine01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "eos", "hostname":
+    "leaf01", "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}]'
 - command: topology summarize --asn=64520 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: topology summarize eos
-  output: '{"namespace": {}, "hostname": {}, "peerHostname": {}, "vrf": {}, "asn":
-    {}, "peerAsn": {}, "bgp": {}, "polled": {}}'
+  output: '{"eos": {"bgp_center": ["spine02", "spine01"], "bgp_degree_histogram":
+    "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
+    12, "bgp_number_of_nodes": 8, "bgp_self_loops": []}}'
 - command: topology unique --asn=64520 --format=json --namespace=eos --columns=hostname
   data-directory: tests/data/parquet/
   marks: topology unique eos
-  output: '[]'
+  output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
+    {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
+    "spine01"}, {"hostname": "spine02"}]'
 - command: topology summarize --vrf=default --asn=64520 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: topology summarize eos
-  output: '{"namespace": {}, "hostname": {}, "peerHostname": {}, "vrf": {}, "asn":
-    {}, "peerAsn": {}, "bgp": {}, "polled": {}}'
+  output: '{"eos": {"bgp_center": ["spine02", "spine01"], "bgp_degree_histogram":
+    "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
+    12, "bgp_number_of_nodes": 8, "bgp_self_loops": []}}'
 - command: topology summarize --vrf=default --via=lldp --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: topology summarize eos

--- a/tests/integration/sqcmds/junos-samples/swport.yml
+++ b/tests/integration/sqcmds/junos-samples/swport.yml
@@ -1765,3 +1765,51 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique junos switchport
   output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=junos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos switchport
+  output: '[{"vlan": 999}, {"vlan": 999}, {"vlan": 999}, {"vlan": 999}]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=junos
+    --columns='hostname ifname state adminState type vlan vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos switchport
+  output: '[{"hostname": "exit01", "ifname": "lo0.999", "state": "up", "adminState":
+    "up", "type": "subinterface", "vlan": 999, "vlanList": []}, {"hostname": "leaf02",
+    "ifname": "lo0.999", "state": "up", "adminState": "up", "type": "subinterface",
+    "vlan": 999, "vlanList": []}, {"hostname": "exit02", "ifname": "lo0.999", "state":
+    "up", "adminState": "up", "type": "subinterface", "vlan": 999, "vlanList": []},
+    {"hostname": "leaf01", "ifname": "lo0.999", "state": "up", "adminState": "up",
+    "type": "subinterface", "vlan": 999, "vlanList": []}]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=junos
+    --columns='hostname ifname state adminState type vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos switchport
+  output: '[{"hostname": "exit01", "ifname": "lo0.999", "state": "up", "adminState":
+    "up", "type": "subinterface", "vlanList": []}, {"hostname": "leaf02", "ifname":
+    "lo0.999", "state": "up", "adminState": "up", "type": "subinterface", "vlanList":
+    []}, {"hostname": "exit02", "ifname": "lo0.999", "state": "up", "adminState":
+    "up", "type": "subinterface", "vlanList": []}, {"hostname": "leaf01", "ifname":
+    "lo0.999", "state": "up", "adminState": "up", "type": "subinterface", "vlanList":
+    []}]'
+- command: interface show --columns=vlan --vlan='!10 !20' --state=up --namespace=junos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos switchport
+  output: '[{"vlan": 3}, {"vlan": 4}, {"vlan": 2}, {"vlan": 4}, {"vlan": 2}, {"vlan":
+    3}, {"vlan": 2}, {"vlan": 999}, {"vlan": 3}, {"vlan": 4}, {"vlan": 999}, {"vlan":
+    30}, {"vlan": 30}, {"vlan": 999}, {"vlan": 4}, {"vlan": 3}, {"vlan": 2}, {"vlan":
+    999}, {"vlan": 30}, {"vlan": 30}]'
+- command: interface show --columns=vlan --vlan='20' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos switchport
+  output: '[{"vlan": 20}, {"vlan": 20}]'
+- command: interface show --columns=vlan --vlan='10 20' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos
+  output: '[{"vlan": 10}, {"vlan": 10}, {"vlan": 20}, {"vlan": 20}]'
+- command: interface unique --columns=vlan --vlan='!10 999' --state=up --namespace=junos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique junos switchport
+  output: '[{"vlan": 999}]'

--- a/tests/integration/sqcmds/junos-samples/topology.yml
+++ b/tests/integration/sqcmds/junos-samples/topology.yml
@@ -686,21 +686,53 @@ tests:
 - command: topology show --asn=64520 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology show junos
-  output: '[]'
+  output: '[{"namespace": "junos", "hostname": "leaf01", "peerHostname": "spine01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "junos", "hostname": "leaf01", "peerHostname": "spine02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "junos", "hostname": "leaf02", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "junos",
+    "hostname": "leaf02", "peerHostname": "spine01", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "junos", "hostname":
+    "spine01", "peerHostname": "exit02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "junos", "hostname": "spine01",
+    "peerHostname": "exit01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "junos", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine01", "peerHostname": "leaf01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "junos", "hostname": "exit01", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "junos", "hostname": "exit01", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "junos",
+    "hostname": "exit02", "peerHostname": "spine02", "vrf": "default", "asn": 64520,
+    "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "junos", "hostname":
+    "exit02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "junos", "hostname": "spine02",
+    "peerHostname": "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "junos", "hostname": "spine02", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "junos", "hostname": "spine02", "peerHostname": "exit01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "junos", "hostname": "spine02", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}]'
 - command: topology summarize --asn=64520 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology summarize junos
-  output: '{"namespace": {}, "hostname": {}, "peerHostname": {}, "vrf": {}, "asn":
-    {}, "peerAsn": {}, "bgp": {}, "polled": {}}'
+  output: '{"junos": {"bgp_center": ["spine01", "spine02"], "bgp_degree_histogram":
+    [0, 0, 4, 0, 2], "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets":
+    1, "bgp_number_of_edges": 8, "bgp_number_of_nodes": 6, "bgp_self_loops": []}}'
 - command: topology unique --asn=64520 --format=json --namespace=junos --columns=hostname
   data-directory: tests/data/parquet/
   marks: topology unique junos
-  output: '[]'
+  output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
+    {"hostname": "leaf02"}, {"hostname": "spine01"}, {"hostname": "spine02"}]'
 - command: topology summarize --vrf=default --asn=64520 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology summarize junos
-  output: '{"namespace": {}, "hostname": {}, "peerHostname": {}, "vrf": {}, "asn":
-    {}, "peerAsn": {}, "bgp": {}, "polled": {}}'
+  output: '{"junos": {"bgp_center": ["spine01", "spine02"], "bgp_degree_histogram":
+    [0, 0, 4, 0, 2], "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets":
+    1, "bgp_number_of_edges": 8, "bgp_number_of_nodes": 6, "bgp_self_loops": []}}'
 - command: topology summarize --vrf=default --via=lldp --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: topology summarize junos

--- a/tests/integration/sqcmds/nxos-samples/interface.yml
+++ b/tests/integration/sqcmds/nxos-samples/interface.yml
@@ -2680,3 +2680,2237 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique nxos
   output: '[]'
+- command: interface show --mtu='>1514 <9216' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos
+  output: '[{"namespace": "nxos", "hostname": "leaf03", "ifname": "Vlan20", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 20, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "Vlan999", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master": "evpn-vrf",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Vlan10", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 10, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.254/24"], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Vlan30", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Vlan999", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master": "evpn-vrf", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Vlan20", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 20, "master": "evpn-vrf", "ipAddressList": ["172.16.2.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Vlan30", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Vlan999", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Vlan10", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    10, "master": "evpn-vrf", "ipAddressList": ["172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Vlan30", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "exit01", "ifname": "Vlan999",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259574},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Vlan999", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master": "evpn-vrf",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}]'
+- command: interface show --vlan='> 10 < 100' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos
+  output: '[{"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/4", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 30, "master":
+    "port-channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/6", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master":
+    "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/5", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master":
+    "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/3", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 20, "master":
+    "port-channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "port-channel1", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "port-channel4", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9216, "vlan": 30, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Vlan20", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 20, "master": "evpn-vrf", "ipAddressList": ["172.16.2.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Vlan30", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "port-channel3", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9216, "vlan": 20, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 30, "master": "port-channel4", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "port-channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname": "port-channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762},
+    {"namespace": "nxos", "hostname": "leaf01", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1619275258762},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/6", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master":
+    "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/5", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master":
+    "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/4", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 30, "master":
+    "port-channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/3", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 20, "master":
+    "port-channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan20", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 20, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "port-channel3", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 20, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "port-channel1", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9216, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "port-channel4", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9216, "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 30, "master": "port-channel4", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "port-channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "port-channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186},
+    {"namespace": "nxos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1619275259186}]'
+- command: interface show --mtu='>= 1514' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "ifname": "lo", "state":
+    "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275256203}, {"namespace":
+    "nxos", "hostname": "server101", "ifname": "eth1", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275256203}, {"namespace": "nxos", "hostname":
+    "server101", "ifname": "eth2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275256203}, {"namespace": "nxos", "hostname": "server101",
+    "ifname": "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 0, "master": "", "ipAddressList": ["172.16.1.101/24"], "ip6AddressList":
+    [], "timestamp": 1619275256203}, {"namespace": "nxos", "hostname": "server102",
+    "ifname": "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 0, "master": "", "ipAddressList": ["172.16.3.102/24"], "ip6AddressList":
+    [], "timestamp": 1619275256204}, {"namespace": "nxos", "hostname": "server102",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275256204}, {"namespace": "nxos", "hostname": "server102", "ifname": "eth2",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan":
+    0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275256204}, {"namespace": "nxos", "hostname": "server102", "ifname": "eth1",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan":
+    0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275256204}, {"namespace": "nxos", "hostname": "server301", "ifname": "bond0",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 0, "master":
+    "", "ipAddressList": ["172.16.2.201/24"], "ip6AddressList": [], "timestamp": 1619275256205},
+    {"namespace": "nxos", "hostname": "server301", "ifname": "eth2", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 0, "master": "bond0",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275256205}, {"namespace":
+    "nxos", "hostname": "server301", "ifname": "eth1", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 0, "master": "bond0", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275256205}, {"namespace": "nxos", "hostname":
+    "server301", "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275256205}, {"namespace": "nxos", "hostname": "firewall01",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.200/32"], "ip6AddressList":
+    [], "timestamp": 1619275256290}, {"namespace": "nxos", "hostname": "server302",
+    "ifname": "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 0, "master": "", "ipAddressList": ["172.16.3.202/24"], "ip6AddressList":
+    [], "timestamp": 1619275256321}, {"namespace": "nxos", "hostname": "server302",
+    "ifname": "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275256321}, {"namespace": "nxos", "hostname": "server302", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275256321}, {"namespace": "nxos", "hostname": "server302", "ifname": "lo",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275256321},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/6", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master":
+    "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "nve1", "state": "up", "adminState":
+    "up", "type": "vxlan", "mtu": 9216, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Vlan999", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "port-channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname": "Vlan20",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 20, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.254/24"], "ip6AddressList": [], "timestamp":
+    1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname": "port-channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539},
+    {"namespace": "nxos", "hostname": "leaf03", "ifname": "port-channel3", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 20, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "Ethernet1/1", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList":
+    ["10.0.0.13/32"], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "Ethernet1/3", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 20, "master": "port-channel3",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "Ethernet1/4", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 30, "master": "port-channel4",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "Ethernet1/5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master": "port-channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "Ethernet1/2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList":
+    ["10.0.0.13/32"], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Ethernet1/2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList":
+    ["10.0.0.11/32"], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Ethernet1/5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master": "port-channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Ethernet1/4", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 30, "master": "port-channel4",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Ethernet1/3", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 10, "master": "port-channel3",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Ethernet1/6", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9216, "vlan": 1, "master": "port-channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "port-channel1", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9216, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Vlan10", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 10, "master": "evpn-vrf", "ipAddressList": ["172.16.1.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Vlan30", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Vlan999", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "nve1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9216, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname": "port-channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762},
+    {"namespace": "nxos", "hostname": "leaf01", "ifname": "Ethernet1/1", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master":
+    "default", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList": [], "timestamp":
+    1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname": "port-channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 10, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "gr-0/0/0", "state": "up",
+    "adminState": "up", "type": "gre", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "em2", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/10", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/11",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "dsc", "state": "up",
+    "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "em0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "em1", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/7", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "em3", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "em4", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "fti0", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "lo0", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/9", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "vme", "state": "down", "adminState": "up", "type": "mgmt-vlan",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "lo0.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList":
+    ["fe80::205:860f:fc71:3c00/128"], "timestamp": 1619275258985}, {"namespace": "nxos",
+    "hostname": "dcedge01", "ifname": "lo0.16385", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/6", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/5", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/4",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/3", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/1", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/0", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "vtep",
+    "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/8", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "nve1", "state": "up", "adminState": "up", "type": "vxlan",
+    "mtu": 9216, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "spine01", "ifname": "Ethernet1/3",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "default", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [],
+    "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02", "ifname":
+    "Ethernet1/4", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/3", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/6", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/5", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/4", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Vlan30", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Vlan20", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 20, "master": "evpn-vrf", "ipAddressList": ["172.16.2.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/6", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "port-channel3", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9216, "vlan": 20, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "port-channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan":
+    1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan":
+    1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan":
+    30, "master": "port-channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9216, "vlan":
+    20, "master": "port-channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Ethernet1/2",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "default", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList": [],
+    "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/1", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/5", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 9216, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "port-channel4", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9216, "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/1", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/2", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 10, "master": "port-channel3", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 30, "master": "port-channel4", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/5", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9216, "vlan": 1, "master": "port-channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "port-channel3", "state": "up", "adminState": "up", "type": "bond", "mtu": 9216,
+    "vlan": 10, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "port-channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9216, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186},
+    {"namespace": "nxos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1619275259186},
+    {"namespace": "nxos", "hostname": "leaf02", "ifname": "Vlan999", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master": "evpn-vrf",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "nve1", "state": "up", "adminState": "up",
+    "type": "vxlan", "mtu": 9216, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "port-channel1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9216, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Vlan10", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    10, "master": "evpn-vrf", "ipAddressList": ["172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "nve1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9216, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname": "Vlan999",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259574},
+    {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/2", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master":
+    "default", "ipAddressList": ["10.0.0.31/32"], "ip6AddressList": [], "timestamp":
+    1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "default", "ipAddressList": ["10.0.0.31/32"], "ip6AddressList": [],
+    "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit02", "ifname":
+    "nve1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9216, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname": "Vlan999",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 999, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/2", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master":
+    "default", "ipAddressList": ["10.0.0.32/32"], "ip6AddressList": [], "timestamp":
+    1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "default", "ipAddressList": ["10.0.0.32/32"], "ip6AddressList": [],
+    "timestamp": 1619275260177}]'
+- command: interface show --mtu='! 1514 !9216' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos
+  output: '[{"namespace": "nxos", "hostname": "server101", "ifname": "eth0", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": ["10.255.2.204/24"], "ip6AddressList": [], "timestamp": 1619275256203},
+    {"namespace": "nxos", "hostname": "server101", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275256203}, {"namespace":
+    "nxos", "hostname": "server102", "ifname": "eth0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.255.2.39/24"], "ip6AddressList": [], "timestamp": 1619275256204}, {"namespace":
+    "nxos", "hostname": "server102", "ifname": "lo", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275256204}, {"namespace": "nxos", "hostname":
+    "server301", "ifname": "eth0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.140/24"], "ip6AddressList":
+    [], "timestamp": 1619275256205}, {"namespace": "nxos", "hostname": "server301",
+    "ifname": "lo", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275256205}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth2.4",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 4, "master":
+    "", "ipAddressList": ["169.254.253.10/30"], "ip6AddressList": [], "timestamp":
+    1619275256290}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth2.3",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 3, "master":
+    "", "ipAddressList": ["169.254.253.6/30"], "ip6AddressList": [], "timestamp":
+    1619275256290}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth1.4",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 4, "master":
+    "", "ipAddressList": ["169.254.254.10/30"], "ip6AddressList": [], "timestamp":
+    1619275256290}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth1.3",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 3, "master":
+    "", "ipAddressList": ["169.254.254.6/30"], "ip6AddressList": [], "timestamp":
+    1619275256290}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth1.2",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 2, "master":
+    "", "ipAddressList": ["169.254.254.2/30"], "ip6AddressList": [], "timestamp":
+    1619275256290}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth2.2",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 2, "master":
+    "", "ipAddressList": ["169.254.253.2/30"], "ip6AddressList": [], "timestamp":
+    1619275256290}, {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275256290},
+    {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth0", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": ["10.255.2.249/24"], "ip6AddressList": [], "timestamp": 1619275256290},
+    {"namespace": "nxos", "hostname": "firewall01", "ifname": "lo", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.200/32"], "ip6AddressList": [], "timestamp": 1619275256290},
+    {"namespace": "nxos", "hostname": "firewall01", "ifname": "eth2", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275256290}, {"namespace":
+    "nxos", "hostname": "server302", "ifname": "eth0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.255.2.114/24"], "ip6AddressList": [], "timestamp": 1619275256321}, {"namespace":
+    "nxos", "hostname": "server302", "ifname": "lo", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275256321}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/60", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "mgmt0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "management", "ipAddressList": ["10.255.2.190/24"],
+    "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/7", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/8", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/11", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/10", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/12", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/13", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/61", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/9", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/62", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "default", "state": "up", "adminState": "up", "type": "vrf",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "Ethernet1/64", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "loopback0", "state": "up", "adminState": "up", "type": "loopback", "mtu": 1500,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.13/32"], "ip6AddressList":
+    [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "loopback1", "state": "up", "adminState": "up", "type": "loopback", "mtu": 1500,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.203/32", "10.0.0.134/32"],
+    "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Vlan1", "state": "down", "adminState": "down", "type": "vlan",
+    "mtu": 1500, "vlan": 1, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "Vlan20", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    20, "master": "evpn-vrf", "ipAddressList": ["172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "Vlan30", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname": "Ethernet1/14",
+    "state": "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258539}, {"namespace": "nxos", "hostname": "leaf03", "ifname": "evpn-vrf",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace":
+    "nxos", "hostname": "leaf03", "ifname": "management", "state": "up", "adminState":
+    "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/58", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/63", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/15", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/59", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/17", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/57", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/56", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/55", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/54", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/53", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/52", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/51", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/50", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/39", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/49", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/47", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/46", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/45", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/44", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/43", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/42", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/41", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/16", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/48", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/38", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/40", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/36", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/18", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/37", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/20", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/21", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/22", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/23", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/24", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/25", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/26", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/19", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/27", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/28", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/29", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/30", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/31", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/32", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/33", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/35", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf03", "ifname": "Ethernet1/34", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258539}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/20", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/21", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/22", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/23", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/26", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/25", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/27", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/28", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/24", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/19", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/15", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/17", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/16", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/29", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/14", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/13", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/12", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/11", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/10", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/8", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/7", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "mgmt0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "management", "ipAddressList": ["10.255.2.189/24"],
+    "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/18", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/30", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/42", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/32", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/56", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/57", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/58", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/59", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/60", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/61", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/62", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Ethernet1/63", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "loopback0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 1500, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.11/32"],
+    "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "loopback1", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 1500, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.201/32",
+    "10.0.0.112/32"], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace":
+    "nxos", "hostname": "leaf01", "ifname": "Vlan1", "state": "down", "adminState":
+    "down", "type": "vlan", "mtu": 1500, "vlan": 1, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Vlan10", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 10, "master": "evpn-vrf", "ipAddressList": ["172.16.1.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Vlan30", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 30, "master": "evpn-vrf", "ipAddressList": ["172.16.3.254/24"],
+    "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "Vlan999", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "default", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258762},
+    {"namespace": "nxos", "hostname": "leaf01", "ifname": "evpn-vrf", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname":
+    "leaf01", "ifname": "management", "state": "up", "adminState": "up", "type": "vrf",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/55", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/54", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/53", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/52", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/33", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/34", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/35", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/36", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/37", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/38", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/39", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/40", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/31", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/41", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/44", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/45", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/46", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/47", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/48", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/49", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/50", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/51", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/43", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/64", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "leaf01", "ifname":
+    "Ethernet1/9", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258762}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "gr-0/0/0", "state": "up", "adminState": "up", "type": "gre", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "lo0.16385",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "lo0.0", "state": "up",
+    "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.41/32"], "ip6AddressList": ["fe80::205:860f:fc71:3c00/128"],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "em2.32768", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": ["192.168.1.2/24"], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "em1.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["169.254.0.2/24"], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "em0.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.255.2.250/24"], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "xe-0/0/11.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/10.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/9.0",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985},
+    {"namespace": "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/8.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "xe-0/0/7.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "xe-0/0/6.0", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "em4.32768", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["192.0.2.2/24"], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "xe-0/0/4.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/5.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "dsc",
+    "state": "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "fti0", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "dcedge01", "ifname": "lo0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname":
+    "dcedge01", "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "xe-0/0/0.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["169.254.127.0/31"], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "xe-0/0/1.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["169.254.127.2/31"], "ip6AddressList":
+    [], "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01",
+    "ifname": "xe-0/0/2.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname":
+    "xe-0/0/3.0", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275258985}, {"namespace": "nxos", "hostname": "dcedge01", "ifname": "vtep",
+    "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275258985}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/22", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/16", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/21", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/20", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/19", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/18", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/17", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/15", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/9", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/13", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/12", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/11", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/10", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/8", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/7", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "mgmt0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "management", "ipAddressList":
+    ["10.255.2.191/24"], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/23", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/14", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/24", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/36", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/26", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/44", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/43", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/42", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/41", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/40", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/39", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/38", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/37", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/25", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/25", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/34", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/33", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/32", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/31", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/30", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/29", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/28", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/27", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "leaf04", "ifname": "Ethernet1/35", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/26", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/38", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/28", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/51", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/52", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/53", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/54", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/55", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/56", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/57", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/58", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/59", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/60", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/61", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/62", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/63", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "Ethernet1/64", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "loopback0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 1500, "vlan": 0, "master": "default", "ipAddressList":
+    ["10.0.0.22/32"], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace":
+    "nxos", "hostname": "spine02", "ifname": "loopback1", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Vlan1", "state": "down", "adminState": "down", "type": "vlan",
+    "mtu": 1500, "vlan": 1, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02", "ifname":
+    "Ethernet1/50", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/49", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/48", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/47", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/29", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/30", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/31", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/32", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/33", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/34", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/35", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/36", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/27", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/37", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/39", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/40", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/41", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/42", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/43", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/44", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/45", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "Ethernet1/46", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/45", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/46", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/7", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/48", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/22", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/23", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/24", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/25", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/26", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/27", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/28", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/29", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/30", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/31", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/32", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/33", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/34", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/35", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/36", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/37", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/38", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/39", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/40", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/41", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/42", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/43", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/44", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/21", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/20", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/19", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/18", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/8", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/9", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/10", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "management", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "evpn-vrf", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "default", "state": "up", "adminState": "up", "type": "vrf",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan20",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 20, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.254/24"], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "Vlan1",
+    "state": "down", "adminState": "down", "type": "vlan", "mtu": 1500, "vlan": 1,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "leaf04", "ifname": "loopback1", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 1500, "vlan": 0, "master": "default",
+    "ipAddressList": ["10.0.0.204/32", "10.0.0.134/32"], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "spine01", "ifname": "Ethernet1/45",
+    "state": "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname": "loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 1500, "vlan": 0,
+    "master": "default", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList": [],
+    "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/63", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/62", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/61", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/60", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/11", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/12", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/13", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/14", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/15", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/16", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "Ethernet1/17", "state": "notConnected", "adminState": "up", "type":
+    "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "leaf04", "ifname":
+    "Ethernet1/64", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01",
+    "ifname": "mgmt0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "management", "ipAddressList": ["10.255.2.119/24"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/46", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/48", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/13", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/14", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/15", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/16", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/17", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/18", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/19", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/20", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/21", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/22", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/23", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/24", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/59", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/58", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/57", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/56", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/55", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/54", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/53", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/52", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/51", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/50", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/49", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/12", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/11", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/10", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/9", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/49", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/50", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/51", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/52", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/53", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/54", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/55", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/56", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/57", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/58", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/59", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/47", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/60", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/62", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/63", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/64", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "loopback0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 1500, "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "loopback1", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine01", "ifname":
+    "Vlan1", "state": "down", "adminState": "down", "type": "vlan", "mtu": 1500, "vlan":
+    1, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259180},
+    {"namespace": "nxos", "hostname": "spine01", "ifname": "default", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "management", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "mgmt0", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1500, "vlan": 0, "master": "management", "ipAddressList": ["10.255.2.120/24"],
+    "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/7", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "Ethernet1/8", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine01", "ifname": "Ethernet1/61", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "leaf04", "ifname": "Ethernet1/47", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname":
+    "spine02", "ifname": "management", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259180}, {"namespace": "nxos", "hostname": "spine02",
+    "ifname": "default", "state": "up", "adminState": "up", "type": "vrf", "mtu":
+    1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259180}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "evpn-vrf",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/23", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/24", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/25", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/26", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/27", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/22", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/28", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/30", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/31", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/32", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/33", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/34", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/35", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/29", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/36", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/21", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "Ethernet1/19", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace":
+    "nxos", "hostname": "leaf02", "ifname": "management", "state": "up", "adminState":
+    "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "mgmt0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "management", "ipAddressList": ["10.255.2.188/24"],
+    "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/7", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/8", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/9", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/10", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/20", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/11", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/13", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/14", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/15", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/16", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/17", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/18", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/12", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/37", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/50", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/39", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "Ethernet1/38", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname":
+    "leaf02", "ifname": "default", "state": "up", "adminState": "up", "type": "vrf",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "Vlan10",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 10, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.1.254/24"], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "Vlan1",
+    "state": "down", "adminState": "down", "type": "vlan", "mtu": 1500, "vlan": 1,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259186},
+    {"namespace": "nxos", "hostname": "leaf02", "ifname": "loopback1", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 1500, "vlan": 0, "master": "default",
+    "ipAddressList": ["10.0.0.202/32", "10.0.0.112/32"], "ip6AddressList": [], "timestamp":
+    1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname": "loopback0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 1500, "vlan": 0,
+    "master": "default", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": [],
+    "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/63", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/62", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/61", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/60", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/59", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/58", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/57", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/64", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/55", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/41", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/56", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/40", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/42", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/43", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/44", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/46", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/45", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/48", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/49", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/51", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/52", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/53", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/54", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "leaf02", "ifname":
+    "Ethernet1/47", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259186}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/51", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/47", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/50", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/49", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/48", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/46", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/39", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/44", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/43", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/42", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/41", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/40", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/38", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/52", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/45", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/53", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan":
+    999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname": "Ethernet1/55",
+    "state": "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname": "evpn-vrf",
+    "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace":
+    "nxos", "hostname": "exit01", "ifname": "default", "state": "up", "adminState":
+    "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/37", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Vlan1", "state": "down", "adminState": "down", "type": "vlan",
+    "mtu": 1500, "vlan": 1, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "loopback1", "state": "up", "adminState": "up", "type": "loopback", "mtu": 1500,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.221/32"], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "loopback0", "state": "up", "adminState": "up", "type": "loopback", "mtu": 1500,
+    "vlan": 0, "master": "default", "ipAddressList": ["10.0.0.31/32"], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/64", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/63", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/62", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/61", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/60", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/59", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/58", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/57", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/56", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/54", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/36", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/21", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/34", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/13", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/12", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/11", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/10", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/9", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/8", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/7", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/6", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/5", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/4", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 0, "master": "internet-vrf", "ipAddressList": ["169.254.127.1/31"], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/3.4", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 4, "master": "internet-vrf", "ipAddressList": ["169.254.254.9/30"],
+    "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/3.3", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 1500, "vlan": 3, "master": "evpn-vrf", "ipAddressList":
+    ["169.254.254.5/30"], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace":
+    "nxos", "hostname": "exit01", "ifname": "Ethernet1/3.2", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 1500, "vlan": 2, "master": "default", "ipAddressList":
+    ["169.254.254.1/30"], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace":
+    "nxos", "hostname": "exit01", "ifname": "Ethernet1/3", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "mgmt0", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 0, "master": "management", "ipAddressList": ["10.255.2.253/24"],
+    "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/14", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/15", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/16", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/17", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/33", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/32", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/31", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/30", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/29", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/28", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/27", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/35", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/26", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/24", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/23", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "Ethernet1/22", "state": "notConnected", "adminState": "up",
+    "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname":
+    "exit01", "ifname": "management", "state": "up", "adminState": "up", "type": "vrf",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/20", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/19", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/18", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "Ethernet1/25", "state": "notConnected", "adminState": "up", "type": "ethernet",
+    "mtu": 1500, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275259574}, {"namespace": "nxos", "hostname": "exit01", "ifname":
+    "internet-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275259574}, {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/13",
+    "state": "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/3",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/53", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/52", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/51", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/50", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/49", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/48", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/54", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/47", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/45", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/44", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/43", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/42", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/41", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/40", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/46", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/55", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/56", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/57", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "management", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname":
+    "exit02", "ifname": "internet-vrf", "state": "up", "adminState": "up", "type":
+    "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname":
+    "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "default", "state": "up",
+    "adminState": "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname":
+    "exit02", "ifname": "Vlan999", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 999, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname":
+    "Vlan1", "state": "down", "adminState": "down", "type": "vlan", "mtu": 1500, "vlan":
+    1, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "loopback1", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 1500, "vlan": 0, "master": "default",
+    "ipAddressList": ["10.0.0.222/32"], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "loopback0", "state": "up",
+    "adminState": "up", "type": "loopback", "mtu": 1500, "vlan": 0, "master": "default",
+    "ipAddressList": ["10.0.0.32/32"], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/64", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/63", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/62", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/61", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/60", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/59", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/58", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/39", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "mgmt0", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master": "management",
+    "ipAddressList": ["10.255.2.254/24"], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/38", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/36", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/15", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/14", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/12", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/11", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/10", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/9", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/16", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/8", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/6", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/5", "state":
+    "notConnected", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177},
+    {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/4", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 0, "master":
+    "internet-vrf", "ipAddressList": ["169.254.127.3/31"], "ip6AddressList": [], "timestamp":
+    1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname": "Ethernet1/3.4",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan":
+    4, "master": "internet-vrf", "ipAddressList": ["169.254.253.9/30"], "ip6AddressList":
+    [], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname": "exit02", "ifname":
+    "Ethernet1/3.3", "state": "up", "adminState": "up", "type": "subinterface", "mtu":
+    1500, "vlan": 3, "master": "evpn-vrf", "ipAddressList": ["169.254.253.5/30"],
+    "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace": "nxos", "hostname":
+    "exit02", "ifname": "Ethernet1/3.2", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 1500, "vlan": 2, "master": "default", "ipAddressList":
+    ["169.254.253.1/30"], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/7", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/17", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/18", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/19", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/35", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/34", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/33", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/32", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/30", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/29", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/28", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/27", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/26", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/25", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/24", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/23", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/22", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/21", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/20", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/37", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}, {"namespace":
+    "nxos", "hostname": "exit02", "ifname": "Ethernet1/31", "state": "notConnected",
+    "adminState": "up", "type": "ethernet", "mtu": 1500, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1619275260177}]'

--- a/tests/integration/sqcmds/nxos-samples/swport.yml
+++ b/tests/integration/sqcmds/nxos-samples/swport.yml
@@ -3839,3 +3839,87 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique nxos switchport
   output: '[]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=nxos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos switchport
+  output: '[{"vlan": 1}, {"vlan": 1}, {"vlan": 1}, {"vlan": 999}, {"vlan": 999}, {"vlan":
+    1}, {"vlan": 1}, {"vlan": 999}, {"vlan": 1}, {"vlan": 999}, {"vlan": 999}, {"vlan":
+    999}]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=nxos
+    --columns='hostname ifname state adminState type vlan vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos switchport
+  output: '[{"hostname": "leaf03", "ifname": "Ethernet1/6", "state": "up", "adminState":
+    "up", "type": "bond_slave", "vlan": 1, "vlanList": [1, 20, 30, 999]}, {"hostname":
+    "leaf03", "ifname": "Ethernet1/5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "vlan": 1, "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf03",
+    "ifname": "port-channel1", "state": "up", "adminState": "up", "type": "bond",
+    "vlan": 1, "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf03", "ifname": "Vlan999",
+    "state": "up", "adminState": "up", "type": "vlan", "vlan": 999, "vlanList": []},
+    {"hostname": "leaf01", "ifname": "Vlan999", "state": "up", "adminState": "up",
+    "type": "vlan", "vlan": 999, "vlanList": []}, {"hostname": "leaf04", "ifname":
+    "Ethernet1/6", "state": "up", "adminState": "up", "type": "bond_slave", "vlan":
+    1, "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf04", "ifname": "Ethernet1/5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "vlan": 1, "vlanList":
+    [1, 20, 30, 999]}, {"hostname": "leaf04", "ifname": "Vlan999", "state": "up",
+    "adminState": "up", "type": "vlan", "vlan": 999, "vlanList": []}, {"hostname":
+    "leaf04", "ifname": "port-channel1", "state": "up", "adminState": "up", "type":
+    "bond", "vlan": 1, "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf02", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "vlan": 999, "vlanList":
+    []}, {"hostname": "exit01", "ifname": "Vlan999", "state": "up", "adminState":
+    "up", "type": "vlan", "vlan": 999, "vlanList": []}, {"hostname": "exit02", "ifname":
+    "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "vlan": 999, "vlanList":
+    []}]'
+- command: interface show --columns=vlan --vlan='!10 999' --state=up --namespace=nxos
+    --columns='hostname ifname state adminState type vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos switchport
+  output: '[{"hostname": "leaf03", "ifname": "Ethernet1/6", "state": "up", "adminState":
+    "up", "type": "bond_slave", "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf03",
+    "ifname": "Ethernet1/5", "state": "up", "adminState": "up", "type": "bond_slave",
+    "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf03", "ifname": "port-channel1",
+    "state": "up", "adminState": "up", "type": "bond", "vlanList": [1, 20, 30, 999]},
+    {"hostname": "leaf03", "ifname": "Vlan999", "state": "up", "adminState": "up",
+    "type": "vlan", "vlanList": []}, {"hostname": "leaf01", "ifname": "Vlan999", "state":
+    "up", "adminState": "up", "type": "vlan", "vlanList": []}, {"hostname": "leaf04",
+    "ifname": "Ethernet1/6", "state": "up", "adminState": "up", "type": "bond_slave",
+    "vlanList": [1, 20, 30, 999]}, {"hostname": "leaf04", "ifname": "Ethernet1/5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "vlanList": [1, 20, 30,
+    999]}, {"hostname": "leaf04", "ifname": "Vlan999", "state": "up", "adminState":
+    "up", "type": "vlan", "vlanList": []}, {"hostname": "leaf04", "ifname": "port-channel1",
+    "state": "up", "adminState": "up", "type": "bond", "vlanList": [1, 20, 30, 999]},
+    {"hostname": "leaf02", "ifname": "Vlan999", "state": "up", "adminState": "up",
+    "type": "vlan", "vlanList": []}, {"hostname": "exit01", "ifname": "Vlan999", "state":
+    "up", "adminState": "up", "type": "vlan", "vlanList": []}, {"hostname": "exit02",
+    "ifname": "Vlan999", "state": "up", "adminState": "up", "type": "vlan", "vlanList":
+    []}]'
+- command: interface show --columns=vlan --vlan='!10 !20' --state=up --namespace=nxos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos switchport
+  output: '[{"vlan": 4}, {"vlan": 3}, {"vlan": 4}, {"vlan": 2}, {"vlan": 2}, {"vlan":
+    3}, {"vlan": 30}, {"vlan": 30}, {"vlan": 30}, {"vlan": 999}, {"vlan": 30}, {"vlan":
+    30}, {"vlan": 30}, {"vlan": 999}, {"vlan": 30}, {"vlan": 999}, {"vlan": 30}, {"vlan":
+    30}, {"vlan": 30}, {"vlan": 30}, {"vlan": 30}, {"vlan": 999}, {"vlan": 999}, {"vlan":
+    4}, {"vlan": 3}, {"vlan": 2}, {"vlan": 999}, {"vlan": 4}, {"vlan": 3}, {"vlan":
+    2}]'
+- command: interface show --columns=vlan --vlan='20' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos switchport
+  output: '[{"vlan": 1}, {"vlan": 1}, {"vlan": 20}, {"vlan": 1}, {"vlan": 20}, {"vlan":
+    20}, {"vlan": 1}, {"vlan": 1}, {"vlan": 20}, {"vlan": 20}, {"vlan": 20}, {"vlan":
+    1}]'
+- command: interface show --columns=vlan --vlan='10 20' --namespace=nxos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show nxos switchport
+  output: '[{"vlan": 1}, {"vlan": 1}, {"vlan": 10}, {"vlan": 1}, {"vlan": 10}, {"vlan":
+    10}, {"vlan": 10}, {"vlan": 1}, {"vlan": 1}, {"vlan": 1}, {"vlan": 10}, {"vlan":
+    10}, {"vlan": 1}, {"vlan": 1}, {"vlan": 20}, {"vlan": 1}, {"vlan": 20}, {"vlan":
+    20}, {"vlan": 1}, {"vlan": 1}, {"vlan": 20}, {"vlan": 20}, {"vlan": 20}, {"vlan":
+    1}]'
+- command: interface unique --columns=vlan --vlan='!10 999' --state=up --namespace=nxos
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique nxos switchport
+  output: '[{"vlan": 1}, {"vlan": 999}]'

--- a/tests/integration/sqcmds/nxos-samples/topology.yml
+++ b/tests/integration/sqcmds/nxos-samples/topology.yml
@@ -875,21 +875,69 @@ tests:
 - command: topology show --asn=64520 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: topology show nxos
-  output: '[]'
+  output: '[{"namespace": "nxos", "hostname": "spine02", "peerHostname": "exit02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "spine02", "peerHostname": "exit01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "spine02", "peerHostname": "leaf04", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "spine02", "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "spine02",
+    "peerHostname": "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "spine02", "peerHostname":
+    "leaf01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf03", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "leaf03", "peerHostname": "spine01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "leaf01", "peerHostname": "spine01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "leaf01", "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "exit01",
+    "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "exit01", "peerHostname":
+    "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf04", "peerHostname": "spine01",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "spine01", "peerHostname": "exit02", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "spine01", "peerHostname": "exit01", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "spine01", "peerHostname": "leaf04", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "spine01",
+    "peerHostname": "leaf03", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "spine01", "peerHostname":
+    "leaf02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}, {"namespace": "nxos", "hostname": "leaf04", "peerHostname": "spine02",
+    "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true},
+    {"namespace": "nxos", "hostname": "spine01", "peerHostname": "leaf01", "vrf":
+    "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace":
+    "nxos", "hostname": "leaf02", "peerHostname": "spine02", "vrf": "default", "asn":
+    64520, "peerAsn": 64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname":
+    "leaf02", "peerHostname": "spine01", "vrf": "default", "asn": 64520, "peerAsn":
+    64520, "bgp": true, "polled": true}, {"namespace": "nxos", "hostname": "exit02",
+    "peerHostname": "spine02", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp":
+    true, "polled": true}, {"namespace": "nxos", "hostname": "exit02", "peerHostname":
+    "spine01", "vrf": "default", "asn": 64520, "peerAsn": 64520, "bgp": true, "polled":
+    true}]'
 - command: topology summarize --asn=64520 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: topology summarize nxos
-  output: '{"namespace": {}, "hostname": {}, "peerHostname": {}, "vrf": {}, "asn":
-    {}, "peerAsn": {}, "bgp": {}, "polled": {}}'
+  output: '{"nxos": {"bgp_center": ["spine02", "spine01"], "bgp_degree_histogram":
+    "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
+    12, "bgp_number_of_nodes": 8, "bgp_self_loops": []}}'
 - command: topology unique --asn=64520 --format=json --namespace=nxos --columns=hostname
   data-directory: tests/data/parquet/
   marks: topology unique nxos
-  output: '[]'
+  output: '[{"hostname": "exit01"}, {"hostname": "exit02"}, {"hostname": "leaf01"},
+    {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname": "leaf04"}, {"hostname":
+    "spine01"}, {"hostname": "spine02"}]'
 - command: topology summarize --vrf=default --asn=64520 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: topology summarize nxos
-  output: '{"namespace": {}, "hostname": {}, "peerHostname": {}, "vrf": {}, "asn":
-    {}, "peerAsn": {}, "bgp": {}, "polled": {}}'
+  output: '{"nxos": {"bgp_center": ["spine02", "spine01"], "bgp_degree_histogram":
+    "...", "bgp_is_fully_connected": true, "bgp_number_of_disjoint_sets": 1, "bgp_number_of_edges":
+    12, "bgp_number_of_nodes": 8, "bgp_self_loops": []}}'
 - command: topology summarize --vrf=default --via=lldp --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: topology summarize nxos

--- a/tests/integration/sqcmds/nxos-samples/vlan.yml
+++ b/tests/integration/sqcmds/nxos-samples/vlan.yml
@@ -177,3 +177,41 @@ tests:
   output: '[{"hostname": "dcedge01"}, {"hostname": "exit01"}, {"hostname": "exit02"},
     {"hostname": "leaf01"}, {"hostname": "leaf02"}, {"hostname": "leaf03"}, {"hostname":
     "leaf04"}, {"hostname": "spine01"}, {"hostname": "spine02"}]'
+- command: vlan show --vlan='>10 <100' --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  marks: vlan show nxos
+  output: '[{"namespace": "nxos", "hostname": "leaf01", "vlanName": "vlan30", "state":
+    "active", "interfaces": ["port-channel1", "port-channel4", "Ethernet1/4", "Ethernet1/5",
+    "Ethernet1/6"], "vlan": 30, "timestamp": 1619275257018}, {"namespace": "nxos",
+    "hostname": "leaf02", "vlanName": "vlan30", "state": "active", "interfaces": ["port-channel1",
+    "port-channel4", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "vlan": 30, "timestamp":
+    1619275257018}, {"namespace": "nxos", "hostname": "leaf03", "vlanName": "vlan20",
+    "state": "active", "interfaces": ["port-channel1", "port-channel3", "Ethernet1/3",
+    "Ethernet1/5", "Ethernet1/6"], "vlan": 20, "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf03", "vlanName": "vlan30", "state": "active", "interfaces":
+    ["port-channel1", "port-channel4", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"],
+    "vlan": 30, "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf04",
+    "vlanName": "vlan20", "state": "active", "interfaces": ["port-channel1", "port-channel3",
+    "Ethernet1/3", "Ethernet1/5", "Ethernet1/6"], "vlan": 20, "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vlanName": "vlan30", "state": "active",
+    "interfaces": ["port-channel1", "port-channel4", "Ethernet1/4", "Ethernet1/5",
+    "Ethernet1/6"], "vlan": 30, "timestamp": 1619275257671}]'
+- command: vlan show --vlan='> 10 < 100' --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  marks: vlan show nxos
+  output: '[{"namespace": "nxos", "hostname": "leaf01", "vlanName": "vlan30", "state":
+    "active", "interfaces": ["port-channel1", "port-channel4", "Ethernet1/4", "Ethernet1/5",
+    "Ethernet1/6"], "vlan": 30, "timestamp": 1619275257018}, {"namespace": "nxos",
+    "hostname": "leaf02", "vlanName": "vlan30", "state": "active", "interfaces": ["port-channel1",
+    "port-channel4", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"], "vlan": 30, "timestamp":
+    1619275257018}, {"namespace": "nxos", "hostname": "leaf03", "vlanName": "vlan20",
+    "state": "active", "interfaces": ["port-channel1", "port-channel3", "Ethernet1/3",
+    "Ethernet1/5", "Ethernet1/6"], "vlan": 20, "timestamp": 1619275257446}, {"namespace":
+    "nxos", "hostname": "leaf03", "vlanName": "vlan30", "state": "active", "interfaces":
+    ["port-channel1", "port-channel4", "Ethernet1/4", "Ethernet1/5", "Ethernet1/6"],
+    "vlan": 30, "timestamp": 1619275257446}, {"namespace": "nxos", "hostname": "leaf04",
+    "vlanName": "vlan20", "state": "active", "interfaces": ["port-channel1", "port-channel3",
+    "Ethernet1/3", "Ethernet1/5", "Ethernet1/6"], "vlan": 20, "timestamp": 1619275257671},
+    {"namespace": "nxos", "hostname": "leaf04", "vlanName": "vlan30", "state": "active",
+    "interfaces": ["port-channel1", "port-channel4", "Ethernet1/4", "Ethernet1/5",
+    "Ethernet1/6"], "vlan": 30, "timestamp": 1619275257671}]'

--- a/tests/integration/sqcmds/vmx-samples/interfaces.yml
+++ b/tests/integration/sqcmds/vmx-samples/interfaces.yml
@@ -1183,3 +1183,949 @@ tests:
     8}, {"type": "vtep", "numRows": 10}, {"type": "bond_slave", "numRows": 16}, {"type":
     "subinterface", "numRows": 21}, {"type": "ethernet", "numRows": 38}, {"type":
     "flexible-tunnel-interface", "numRows": 40}]'
+- command: interface show --mtu='>1514 <9192' --namespace=vmx --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx junos
+  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "pp0",
+    "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae0", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/1", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ge-0/0/0", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "ae1", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae1", "state": "up",
+    "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master": "ae2", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "pp0", "state": "up", "adminState": "up", "type": "pppoe",
+    "mtu": 1532, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/0", "state": "up", "adminState": "up", "type": "flexible-ethernet",
+    "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/4", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae2", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/1", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ae1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/0", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "pp0", "state": "up",
+    "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "pp0", "state": "up", "adminState": "up", "type":
+    "pppoe", "mtu": 1532, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae1", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/2", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/1", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/0", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/3", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ae0", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864}]'
+- command: interface show --vlan='> 10 < 100' --namespace=vmx --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx junos
+  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae0",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 20, "master":
+    "", "ipAddressList": ["10.0.20.3/29"], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/0", "state":
+    "up", "adminState": "up", "type": "flexible-ethernet", "mtu": 1518, "vlan": 0,
+    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae1", "state": "up",
+    "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "ae1", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ae1.20", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
+    "vlan": 20, "master": "", "ipAddressList": ["10.0.20.2/29"], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}]'
+- command: interface show --mtu='>= 1514' --namespace=vmx --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx junos
+  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lo0.16385",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/0", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/1", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/2", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/3", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/4", "state":
+    "down", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/5", "state": "down",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/6", "state": "down",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/7", "state": "down",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/8", "state": "down",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/9", "state": "down",
+    "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae0", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "ifname": "ae1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 1518, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "demux0", "state": "up", "adminState": "up", "type": "software-pseudo",
+    "mtu": 9192, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "em1", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lo0.16384", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["127.0.0.1/32"], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti0", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 20, "master":
+    "", "ipAddressList": ["10.0.20.3/29"], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.10", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 10, "master":
+    "", "ipAddressList": ["10.0.10.3/29"], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "vtep", "state":
+    "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "rbeb", "state": "up", "adminState":
+    "up", "type": "remote-beb", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "ifname": "esi", "state": "up", "adminState": "up", "type":
+    "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti6", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti5", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti4", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti3", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti2", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti1", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti7", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti2", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti3", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti4", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti5", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti6", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lo0.16385", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lo0", "state": "up", "adminState":
+    "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "pp0", "state": "up", "adminState": "up", "type": "pppoe",
+    "mtu": 1532, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "rbeb", "state": "up", "adminState": "up", "type": "remote-beb", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "vtep",
+    "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "lo0.16384", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/32"], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti1", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti7", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "fti0", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/9", "state": "down", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "em1", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "demux0",
+    "state": "up", "adminState": "up", "type": "software-pseudo", "mtu": 9192, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2", "state": "up",
+    "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae1", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "ge-0/0/8", "state": "down", "adminState": "up", "type":
+    "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/7", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/6", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/5", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae2", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/4", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae2", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/1", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/0",
+    "state": "up", "adminState": "up", "type": "flexible-ethernet", "mtu": 1518, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/0",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan":
+    0, "master": "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "esi", "state": "up",
+    "adminState": "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "rbeb", "state": "up", "adminState": "up", "type": "remote-beb",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "lo0",
+    "state": "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti7", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti6", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti5", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti4", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti3", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti2", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti1", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "fti0", "state": "up",
+    "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "lo0.16385", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "vtep", "state": "up", "adminState":
+    "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "em1", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "demux0", "state": "up", "adminState": "up", "type": "software-pseudo",
+    "mtu": 9192, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ae1", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ae0",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/9", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 100, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/8", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 101, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/7", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 200, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/6", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 201, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/5", "state":
+    "down", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ge-0/0/4", "state": "down", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/1", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "lo0.16384",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": ["127.0.0.1/32"], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ge-0/0/3", "state": "down", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ge-0/0/0", "state": "down", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "ge-0/0/2", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 1514,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti2", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/1", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/2.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.100.0/31"], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "vtep", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "rbeb", "state": "up", "adminState": "up", "type": "remote-beb", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "lo0", "state":
+    "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti7", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti6", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti5", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti4", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "fti3", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "lo0.16385", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "fti1", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "fti0", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "esi", "state": "up", "adminState": "up", "type":
+    "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "em1", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "demux0", "state":
+    "up", "adminState": "up", "type": "software-pseudo", "mtu": 9192, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "ge-0/0/9", "state": "down", "adminState":
+    "up", "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/8", "state": "down", "adminState": "up",
+    "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/7", "state": "down", "adminState": "up",
+    "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/6", "state": "down", "adminState": "up",
+    "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/5", "state": "down", "adminState": "up",
+    "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/4", "state": "down", "adminState": "up",
+    "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/3.0", "state": "down", "adminState": "up",
+    "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "lo0.16384", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/32"],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/6", "state": "down", "adminState": "up",
+    "type": "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/0", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/1", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/7", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/8", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/9", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ae1", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "demux0", "state":
+    "up", "adminState": "up", "type": "software-pseudo", "mtu": 9192, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "dsc", "state": "up", "adminState":
+    "up", "type": "null", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "em1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "fti0", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti1", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/4", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ge-0/0/5", "state": "down", "adminState": "up", "type": "ethernet",
+    "mtu": 1514, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti3", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti5", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti6", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti7", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "rbeb", "state":
+    "up", "adminState": "up", "type": "remote-beb", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "vtep", "state": "up", "adminState":
+    "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "ae1.10", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 10, "master": "", "ipAddressList": ["10.0.10.2/29"],
+    "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "ae1.20", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 20, "master": "", "ipAddressList": ["10.0.20.2/29"],
+    "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "lo0.16384", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/32"], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "lo0.16385", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti4", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "fti2", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}]'
+- command: interface show --mtu='! 1514 !9192' --namespace=vmx --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx junos
+  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lo0.16385",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/1", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/2", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/3", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae0", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ge-0/0/0", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "TOR4CRP-DGW-RT01", "ifname": "ae1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 1518, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti0", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti1", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti2", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti3", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti4", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lo0.16384", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": ["127.0.0.1/32"], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti6", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti5", "state":
+    "up", "adminState": "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 20, "master":
+    "", "ipAddressList": ["10.0.20.3/29"], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "em1.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"], "ip6AddressList":
+    ["fe80::5206:ff:fe0f:1/64", "fec0::a:0:0:4/64"], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "irb.101", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 101, "master":
+    "", "ipAddressList": ["172.16.11.254/24"], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "irb.201", "state": "up", "adminState": "up", "type": "vlan", "mtu": 1500, "vlan":
+    201, "master": "", "ipAddressList": ["172.16.21.254/24"], "ip6AddressList": [],
+    "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "VRF-B", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "ae1.10", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
+    "vlan": 10, "master": "", "ipAddressList": ["10.0.10.3/29"], "ip6AddressList":
+    [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01",
+    "ifname": "vtep", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "rbeb", "state": "up", "adminState": "up", "type": "remote-beb", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname":
+    "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
+    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "lo0", "state":
+    "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "fti7", "state": "up", "adminState":
+    "up", "type": "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace":
+    "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "VRF-A", "state": "up", "adminState":
+    "up", "type": "vrf", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1631009088901}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "fti7", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "lo0.16384", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/32"], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "em1.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2",
+    "128.0.0.4/2"], "ip6AddressList": ["fe80::5206:ff:fe03:1/64", "fec0::a:0:0:4/64"],
+    "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "vtep", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "rbeb",
+    "state": "up", "adminState": "up", "type": "remote-beb", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "pp0", "state": "up",
+    "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti6", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti1", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti4", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti3", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti2", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti0", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "dsc",
+    "state": "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
+    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
+    "CRP-DIS-SW01", "ifname": "ae1", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/5", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae2", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/0", "state": "up", "adminState": "up", "type": "flexible-ethernet",
+    "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "fti5", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/4", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae2", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/0", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti6", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "lo0.16384", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/32"], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "em1.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2",
+    "128.0.0.4/2"], "ip6AddressList": ["fe80::5206:ff:fe0b:1/64", "fec0::a:0:0:4/64"],
+    "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "vtep", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "rbeb",
+    "state": "up", "adminState": "up", "type": "remote-beb", "mtu": 65536, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423},
+    {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "pp0", "state": "up",
+    "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti7", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti5", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti4", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "lo0.16385", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti3", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti1", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti0", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01", "ifname": "dsc",
+    "state": "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace":
+    "vmx", "hostname": "CRP-ACC-SW01", "ifname": "ae1", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname":
+    "CRP-ACC-SW01", "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond",
+    "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/3", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "ge-0/0/1", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 1518, "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
+    "ifname": "fti2", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "fti1", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "fti0", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "fti5", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "dsc", "state": "up", "adminState": "up", "type": "null", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti2", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "esi", "state": "up", "adminState": "up", "type": "vtep", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "fti4", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "ge-0/0/2.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["10.0.100.0/31"], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "em1.0", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 1500, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.4/8", "128.0.0.1/2",
+    "128.0.0.4/2"], "ip6AddressList": ["fe80::5206:ff:fe01:1/64", "fec0::a:0:0:4/64"],
+    "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "fti6", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "fti7", "state": "up", "adminState": "up", "type": "flexible-tunnel-interface",
+    "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01",
+    "ifname": "lo0", "state": "up", "adminState": "up", "type": "loopback", "mtu":
+    65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089434}, {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname":
+    "pp0", "state": "up", "adminState": "up", "type": "pppoe", "mtu": 1532, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434},
+    {"namespace": "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "rbeb", "state":
+    "up", "adminState": "up", "type": "remote-beb", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace":
+    "vmx", "hostname": "TOR1BBN-PE-RT01", "ifname": "vtep", "state": "up", "adminState":
+    "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "fti3", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "ge-0/0/3.0", "state": "down", "adminState": "up",
+    "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "lo0.16384", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": ["127.0.0.1/32"],
+    "ip6AddressList": [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname":
+    "TOR1BBN-PE-RT01", "ifname": "lo0.16385", "state": "up", "adminState": "up", "type":
+    "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089434}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
+    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ge-0/0/3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 1518,
+    "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ge-0/0/2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 1518,
+    "vlan": 0, "master": "ae0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "rbeb", "state": "up", "adminState": "up", "type": "remote-beb", "mtu": 65536,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ge-0/0/0", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 1518,
+    "vlan": 0, "master": "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "ae1", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ge-0/0/1", "state":
+    "up", "adminState": "up", "type": "bond_slave", "mtu": 1518, "vlan": 0, "master":
+    "ae1", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "dsc", "state":
+    "up", "adminState": "up", "type": "null", "mtu": 65536, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "esi", "state": "up", "adminState":
+    "up", "type": "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti0", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "vtep", "state": "up", "adminState": "up", "type":
+    "vtep", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "VRF-A", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
+    "VRF-B", "state": "up", "adminState": "up", "type": "vrf", "mtu": 1500, "vlan":
+    0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864},
+    {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "lo0", "state":
+    "up", "adminState": "up", "type": "loopback", "mtu": 65536, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ae1.20", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 20, "master": "", "ipAddressList":
+    ["10.0.20.2/29"], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "em1.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 1500, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.4/8", "128.0.0.1/2", "128.0.0.4/2"], "ip6AddressList": ["fe80::5206:ff:fe0d:1/64",
+    "fec0::a:0:0:4/64"], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "irb.100", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 1500, "vlan": 100, "master": "", "ipAddressList": ["172.16.10.254/24"],
+    "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "irb.200", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 1500, "vlan": 200, "master": "", "ipAddressList": ["172.16.20.254/24"],
+    "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "lo0.16384", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    ["127.0.0.1/32"], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace":
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "lo0.16385", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti7", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti6", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti5", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti4", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti3", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti2", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "fti1", "state": "up", "adminState": "up", "type":
+    "flexible-tunnel-interface", "mtu": 65536, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname":
+    "TOR1CRP-DGW-RT01", "ifname": "pp0", "state": "up", "adminState": "up", "type":
+    "pppoe", "mtu": 1532, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae1.10", "state": "up", "adminState": "up", "type": "subinterface",
+    "mtu": 65536, "vlan": 10, "master": "", "ipAddressList": ["10.0.10.2/29"], "ip6AddressList":
+    [], "timestamp": 1631009089864}]'

--- a/tests/integration/sqcmds/vmx-samples/swport.yml
+++ b/tests/integration/sqcmds/vmx-samples/swport.yml
@@ -1,0 +1,48 @@
+description: Testing verbs for interface switchport
+tests:
+- command: interface show --columns=vlan --vlan='!100 10' --state=up --namespace=vmx
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface unique vmx switchport
+  output: '[{"vlan": 10}, {"vlan": 0}, {"vlan": 0}, {"vlan": 0}, {"vlan": 10}]'
+- command: interface show --columns=vlan --vlan='!100 20' --state=up --namespace=vmx
+    --columns='hostname ifname state adminState type vlan vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx switchport
+  output: '[{"hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "state": "up", "adminState":
+    "up", "type": "subinterface", "vlan": 20, "vlanList": []}, {"hostname": "CRP-DIS-SW01",
+    "ifname": "ge-0/0/0", "state": "up", "adminState": "up", "type": "flexible-ethernet",
+    "vlan": 0, "vlanList": [10, 20]}, {"hostname": "CRP-DIS-SW01", "ifname": "ae1",
+    "state": "up", "adminState": "up", "type": "bond", "vlan": 0, "vlanList": [10,
+    20]}, {"hostname": "CRP-DIS-SW01", "ifname": "ae2", "state": "up", "adminState":
+    "up", "type": "bond", "vlan": 0, "vlanList": [10, 20]}, {"hostname": "TOR1CRP-DGW-RT01",
+    "ifname": "ae1.20", "state": "up", "adminState": "up", "type": "subinterface",
+    "vlan": 20, "vlanList": []}]'
+- command: interface show --columns=vlan --vlan='!100 20' --state=up --namespace=vmx
+    --columns='hostname ifname state adminState type vlanList' --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx switchport
+  output: '[{"hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "state": "up", "adminState":
+    "up", "type": "subinterface", "vlanList": []}, {"hostname": "CRP-DIS-SW01", "ifname":
+    "ge-0/0/0", "state": "up", "adminState": "up", "type": "flexible-ethernet", "vlanList":
+    [10, 20]}, {"hostname": "CRP-DIS-SW01", "ifname": "ae1", "state": "up", "adminState":
+    "up", "type": "bond", "vlanList": [10, 20]}, {"hostname": "CRP-DIS-SW01", "ifname":
+    "ae2", "state": "up", "adminState": "up", "type": "bond", "vlanList": [10, 20]},
+    {"hostname": "TOR1CRP-DGW-RT01", "ifname": "ae1.20", "state": "up", "adminState":
+    "up", "type": "subinterface", "vlanList": []}]'
+- command: interface show --columns=vlan --vlan='!100 !200' --state=up --namespace=vmx
+    --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx switchport
+  output: '[{"vlan": 0}, {"vlan": 20}, {"vlan": 101}, {"vlan": 201}, {"vlan": 10},
+    {"vlan": 0}, {"vlan": 0}, {"vlan": 0}, {"vlan": 0}, {"vlan": 101}, {"vlan": 201},
+    {"vlan": 10}, {"vlan": 20}]'
+- command: interface show --columns=vlan --vlan='101' --namespace=vmx --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx switchport
+  output: '[{"vlan": 0}, {"vlan": 101}, {"vlan": 0}, {"vlan": 101}]'
+- command: interface show --columns=vlan --vlan='101 201' --namespace=vmx --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show vmx switchport
+  output: '[{"vlan": 0}, {"vlan": 101}, {"vlan": 0}, {"vlan": 101}, {"vlan": 0}, {"vlan":
+    201}, {"vlan": 0}, {"vlan": 201}]'


### PR DESCRIPTION
This patchset fixes the following issues:

- VLAN filter with interfaces wasn't working correctly if you passed any operators such as !, <, >= etc.
- Any numeric filter that took an operator had to be given without a space between the operator and the number (>1500, not > 1500). This caused weird errors being reported which was confusing and not indicative of the problem. Instead of detecting this to throw a good error, this patch just fixes it
- The fix above had side-effects percolating into other areas of code, but none were breaking changes
- WHen the user specifies both </<= and >/>=, it typically makes sense only as an AND, i.e. the user is looking for a number between the two. This is now handled correctly
Tests have been updated to handle the first two cases. Need to add tests for the last bullet