### PR TITLE
Return value from jump_host validator

### DIFF
--- a/suzieq/poller/controller/utils/inventory_models.py
+++ b/suzieq/poller/controller/utils/inventory_models.py
@@ -45,6 +45,7 @@ class DeviceModel(BaseModel):
             uri = parse_url(value)
             assert uri.scheme is None, \
                 'format username@jumphost[:port] required'
+            return value
         except ValueError:
             assert False, f'Invalid jumphost format: {value}'
 

--- a/tests/unit/poller/controller/data/exp-inventory.yaml
+++ b/tests/unit/poller/controller/data/exp-inventory.yaml
@@ -11,7 +11,7 @@ devices:
   dev0:
     devtype: null
     ignore-known-hosts: false
-    jump-host: null
+    jump-host: user@192.0.2.0
     jump-host-key-file: null
     name: dev0
     port: null

--- a/tests/unit/poller/controller/data/inventory.yaml
+++ b/tests/unit/poller/controller/data/inventory.yaml
@@ -16,6 +16,7 @@ auths:
 devices:
 - name: dev0
   transport: ssh
+  jump-host: user@192.0.2.0
   per-cmd-auth: False
   retries-on-auth-fail: 0
 

--- a/tests/unit/poller/controller/test_controller_inventory.py
+++ b/tests/unit/poller/controller/test_controller_inventory.py
@@ -230,3 +230,18 @@ def test_get_sensitive_data(monkeypatch):
 
     monkeypatch.setattr('getpass.getpass', lambda x: sens_value)
     assert sens_value == get_sensitive_data('ask')
+
+
+@pytest.mark.poller
+@pytest.mark.controller
+@pytest.mark.poller_unit_tests
+@pytest.mark.controller_unit_tests
+@pytest.mark.controller_inventory
+def test_device_validations(default_inventory):
+    inventory = default_inventory
+
+    # Invalid jump-host
+    inventory['devices'][0]['jump-host'] = 'scheme://user@192.0.1.0:2222'
+    with pytest.raises(InventorySourceError,
+                    match="format username@jumphost\\[:port\\] required"):
+        validate_raw_inventory(inventory)


### PR DESCRIPTION
## Test inclusion requirements

- Tests updated + added for the device jump-host validator

## Related Issue

Fixes #784

## Description

In #738 @ddutt removed the return value from `jump_host_validator`. This was noted in a review on the PR, but was closed with 'fixed' with no fix.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

Bug fix - behaviour returns to designed

## Contrast to Current Behavior

`jump-host` works as designed

## Discussion: Benefits and Drawbacks

This is a bug fix

## Changes to the Documentation

No changes required

## Proposed Release Note Entry

Fix `jump-host` configuration parsing

## Comments

I have (so far) been unable to run all the tests - they are still running.
The tests I have changed (i.e. in `tests/unit/poller/controller/test_controller_inventory.py`) work fine.

## Double Check

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
