### PR TITLE
sq-poller: store previous result if there aren't changes

### DIFF
--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -628,6 +628,7 @@ class Service(SqPlugin):
                 hostname=[hostname],
                 namespace=[namespace]).query('active')
             prev_res = df.to_dict('records')
+            self.previous_results[key] = prev_res
 
         if result or prev_res:
             adds, dels = self.get_diff(prev_res, result)


### PR DESCRIPTION
## Description

A bug in the poller caused the worker to always access the previous result from the dataset if no changes in data were detected. This caused the worker, in some cases, to access the data at every polling interval, until a change was detected. This PR fixes this bug storing the previous result as soon as it is accessed from the dataset.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)