### PR TITLE
Fix device version ne

### DIFF
--- a/suzieq/engines/pandas/device.py
+++ b/suzieq/engines/pandas/device.py
@@ -117,9 +117,11 @@ class DeviceObj(SqPandasEngine):
             df = df.loc[df.status.isin(status)]
         if os_version:
             opdict = {'>': operator.gt, '<': operator.lt, '>=': operator.ge,
-                      '<=': operator.le, '=': operator.eq, '!=': operator.ne}
+                      '<=': operator.le, '=': operator.eq, '!': operator.ne}
             op = operator.eq
             for osv in os_version:
+                # Introduced in 0.19.1, we do this for backwards compatibility
+                osv = osv.replace('!=', '!')
                 for elem, val in opdict.items():
                     if osv.startswith(elem):
                         osv = osv.replace(elem, '')

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -409,7 +409,11 @@ class Node:
                 f'Detected {devtype} for {self.address}:{self.port},'
                 f' {hostname}')
             self._set_devtype(devtype, version_str)
-            self._set_hostname(hostname)
+            # We don't set the hostname here because the real hostname
+            # is retrieved via a different command on some platforms
+            # and can contain the FQDN. The hostname stored with a
+            # record needs to be one that is also used in LLDP so that we
+            # can find interface peers
             self.current_exception = None
 
     async def _detect_node_type(self):


### PR DESCRIPTION
When version string in device command is given a ! such as "!9.3.7", it doesn' work. version expects "!=9.3.7". This is inconsistent with what all the other filters take for not equal to. 

To stay backwards compatible, I decided to continue to support !=. Added an additional test for !