### PR TITLE
Fix duplicates on result of filters and fix interval match and namespace filtering

### DIFF
--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -750,6 +750,25 @@ class SqParquetDB(SqDB):
                          **kwargs) -> ds.Expression:
         """The new style of filters using dataset instead of ParquetDataset"""
 
+        def add_rule(new_filter: ds.Expression, collection: ds.Expression,
+                     operation) -> ds.Expression:
+            """Add a rule in the pyarrow filter
+
+            Args:
+                new_filter (pc.Expression): the filter to append
+                collection (pc.Expression): the collection of filters where to
+                    add the new one
+                operation: `operator.or_` or `operator.and_` to append the
+                    new filter to the collection
+
+            Returns:
+                pc.Expression: the concatenated expressions
+            """
+            if collection is not None:
+                return operation(collection, new_filter)
+            else:
+                return new_filter
+
         merge_fields = kwargs.pop('merge_fields', {})
         # The time filters first
         if start_tm and not end_tm:
@@ -763,70 +782,72 @@ class SqParquetDB(SqDB):
             filters = (ds.field("timestamp") != 0)
 
         sch_fields = schema.names
-        # pylint: disable=too-many-nested-blocks
-        for k, v in kwargs.items():
-            if not v:
+
+        for field, filter_vals in kwargs.items():
+            if not filter_vals:
                 continue
-            if k not in sch_fields:
-                self.logger.warning(f'Ignoring invalid field {k} in filter')
+            if field not in sch_fields:
+                self.logger.warning(
+                    f'Ignoring invalid field {field} in filter')
                 continue
 
-            ftype = schema.field(k).type
-            if k in merge_fields:
-                k = merge_fields[k]
+            ftype = schema.field(field).type
+            if field in merge_fields:
+                field = merge_fields[field]
 
-            if isinstance(v, list):
-                infld = []
-                notinfld = []
-                kw_filters = None
-                use_and = False
-                # If user specifies both </<= and >/>=, we treat
-                # it as an and i.e. the user is looking for a val
-                # between the provided < and > numbers.
-                if (any(x.startswith('>') for x in v) and
-                        any(x.startswith('<') for x in v)):
-                    use_and = True
+            infld = []
+            notinfld = []
+            kw_filters = None
 
-                for e in v:
-                    if isinstance(e, str) and e.startswith("!"):
-                        if ftype == 'int64':
-                            notinfld.append(int(e[1:]))
-                        else:
-                            notinfld.append(e[1:])
+            # We would like to reduce if..else, so we want to only work with
+            # lists. If a value is passed, this will be converted to a list
+            # with a single element
+            if not isinstance(filter_vals, list):
+                filter_vals = [filter_vals]
+
+            i = 0
+            while i < len(filter_vals):
+                val = filter_vals[i]
+                if ftype == 'int64':
+                    if isinstance(val, str) and val.startswith('!'):
+                        notinfld.append(int(val[1:]))
+                    elif (isinstance(val, str) and val.startswith('>')
+                            and i+1 < len(filter_vals)
+                            and isinstance(filter_vals[i+1], str)
+                            and filter_vals[i+1].startswith('<')):
+                        # We look for a sequence of >/< to detect an
+                        # interval and combine the rules.
+                        first_rule = self._cons_int_filter(field, val)
+                        second_rule = self._cons_int_filter(
+                            field, filter_vals[i+1])
+                        interval = (first_rule & second_rule)
+                        kw_filters = add_rule(
+                            interval, kw_filters, operator.or_)
+
+                        # Increment one more time, in order to skip the
+                        # rule we already considered
+                        i += 1
                     else:
-                        if ftype == 'int64':
-                            if kw_filters is not None:
-                                if use_and:
-                                    kw_filters = kw_filters & \
-                                        self._cons_int_filter(k, e)
-                                else:
-                                    kw_filters = kw_filters | \
-                                        self._cons_int_filter(k, e)
-                            else:
-                                kw_filters = self._cons_int_filter(k, e)
-                        else:
-                            infld.append(e)
-                if infld and notinfld:
-                    filters = filters & (ds.field(k).isin(infld) &
-                                         ~ds.field(k).isin(notinfld))
-                elif infld:
-                    filters = filters & (ds.field(k).isin(infld))
-                elif notinfld:
-                    filters = filters & (~ds.field(k).isin(notinfld))
-
-                if kw_filters is not None:
-                    filters = filters & (kw_filters)
-            else:
-                if isinstance(v, str) and v.startswith("!"):
-                    if ftype == 'int64':
-                        filters = filters & (ds.field(k) != int(v[1:]))
-                    else:
-                        filters = filters & (ds.field(k) != v[1:])
+                        new_rule = self._cons_int_filter(field, val)
+                        kw_filters = add_rule(
+                            new_rule, kw_filters, operator.or_)
                 else:
-                    if ftype == 'int64':
-                        filters = filters & self._cons_int_filter(k, v)
+                    if isinstance(val, str) and val.startswith('!'):
+                        notinfld.append(val[1:])
                     else:
-                        filters = filters & (ds.field(k) == v)
+                        infld.append(val)
+                i += 1
+
+            if infld and notinfld:
+                filters = filters & (ds.field(field).isin(infld) &
+                                     ~ds.field(field).isin(notinfld))
+            elif infld:
+                filters = filters & (ds.field(field).isin(infld))
+            elif notinfld:
+                filters = filters & (~ds.field(field).isin(notinfld))
+
+            if kw_filters is not None:
+                filters = filters & (kw_filters)
 
         return filters
 

--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List, Tuple, Union
 from ipaddress import ip_network
 import re
 import operator
@@ -87,7 +87,7 @@ class InterfacesObj(SqPandasEngine):
         else:
             return df.reset_index(drop=True)[fields]
 
-    def _check_vlan_match(self, vlan_list: List[str],
+    def _check_vlan_match(self, vlan_filters: List[str],
                           df: pd.DataFrame) -> pd.DataFrame:
         '''Return a dataframe with rows in VLANs requested
 
@@ -100,55 +100,85 @@ class InterfacesObj(SqPandasEngine):
         applies only to interface table.
         '''
 
-        # If there are any VLANs with ! mixed without !, remove the
-        # ! ones. vlanList is an OR list, not an AND list, except
-        # if all are !
-        if any(x.startswith('!') for x in vlan_list):
-            cond = 'and'
-        else:
-            cond = 'or'
-
-        resdf_list = []
-        if (any(x.startswith('>') for x in vlan_list) and
-                any(x.startswith('<') for x in vlan_list)):
-            # if the user specifies both >/>= and </<=, then we
-            # treat this as an and
-            cond = 'and'
-
         opdict = {'<': operator.lt, '>': operator.gt,
                   '<=': operator.le, '>=': operator.ge,
                   '!': operator.ne, '==': operator.eq}
 
-        for vlan in vlan_list:
-            if vlan.startswith(('<=', '>=')):
-                op = vlan[0:2]
-                vlan = vlan[2:].strip()
-            elif vlan.startswith(('<', '>', '!')):
-                op = vlan[0]
-                vlan = vlan[1:].strip()
-            else:
-                op = '=='
+        def _check_cond(vlist: pd.Series, op: Callable, *args):
+            fn = opdict[op]
+            return vlist.apply(lambda ls: any(fn(vlan, *args) for vlan in ls))
 
-            vlan = int(vlan)
-            if op == "!":
-                tmpdf = df[df.apply(
-                    lambda row, vlan: all(opdict[op](v, vlan)
-                                          for v in row.vlanList) and
-                    opdict[op](row.vlan, vlan), args=(vlan,), axis=1)]
-            else:
-                tmpdf = df[df.apply(
-                    lambda x, vlan: any(opdict[op](y, vlan)
-                                        for y in x.vlanList) or
-                    opdict[op](x.vlan, vlan), args=(vlan,), axis=1)]
-            if cond == "or":
-                resdf_list.append(tmpdf.reset_index(drop=True))
-            else:
-                df = tmpdf
+        def _interval(ival, start_val, start_op, end_val, end_op):
+            start_op = opdict[start_op]
+            end_op = opdict[end_op]
+            return start_op(ival, start_val) and end_op(ival, end_val)
 
-        if resdf_list:
-            df = pd.concat(resdf_list)
+        def extract_op(expression: Union[str, int]) -> Tuple[str, int]:
+            op = '=='
+            val = expression
+            if isinstance(expression, str):
+                if expression.startswith(('<=', '>=')):
+                    val = expression[2:]
+                    op = expression[:2]
+                elif expression.startswith(('<', '>')):
+                    val = expression[1:]
+                    op = expression[:1]
+                elif expression.startswith('!'):
+                    val = expression[1:]
+                    op = expression[:1]
+            return op, val
 
-        return df.query('vlanList.str.len() > 0 or vlan != 0')
+        if not vlan_filters:
+            return df
+
+        opdict.update({'><': _interval})
+        not_filters = []
+        match_filters = []
+
+        i = 0
+        while i < len(vlan_filters):
+            op, fval = extract_op(vlan_filters[i])
+            if op.startswith('!'):
+                not_filters.append(
+                    f'(vlan != {fval} '
+                    f'and ~@_check_cond(vlanList, "==", {fval}))')
+            elif (op.startswith('>')
+                  and i+1 < len(vlan_filters)
+                  and isinstance(vlan_filters[i+1], str)
+                  and vlan_filters[i+1].startswith('<')):
+                # In this case we are checking if the user asked for an
+                # an interval. So if we find a sequence of > and <,
+                # we will combine the rules
+                next_op, next_val = extract_op(vlan_filters[i+1])
+                start_rule = f'vlan {op} {fval}'
+                end_rule = f'vlan {next_op} {next_val}'
+                listcheck = (f'@_check_cond(vlanList, "><", {fval}, "{op}", '
+                             f'{next_val}, "{next_op}")')
+                match_filters.append(
+                    f'(({start_rule} and {end_rule}) or {listcheck})')
+                # Increment one more time, in order to skip the
+                # rule we already considered
+                i += 1
+            else:
+                match_filters.append(
+                    f'(vlan {op} {fval} '
+                    f'or @_check_cond(vlanList, "{op}", {fval}))')
+            i += 1
+
+        not_str = ' and '.join(not_filters)
+        match_str = ' or '.join(match_filters)
+        filters = None
+        if not_str and match_str:
+            filters = f'({match_str}) and ({not_str})'
+        elif not_str:
+            filters = not_str
+        elif match_str:
+            filters = match_str
+
+        if filters:
+            filters += ' and (vlanList.str.len() > 0 or vlan != 0)'
+            df = df.query(filters)
+        return df
 
     def aver(self, what="", **kwargs) -> pd.DataFrame:
         """Assert that interfaces are in good state"""

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -1043,23 +1043,3 @@ def deprecated_command_warning(dep_command: str, dep_sub_command: str,
 
     return deprecated_table_function_warning(dep_command, dep_sub_command,
                                              command, sub_command)
-
-
-def reduce_filter_list(filter_list: List[str]) -> List[str]:
-    '''Reduce the list of entries to the minimal set
-    Given a list of filters, some of which contain the NOT such as
-    [123, !245] and ['leaf01', '!~spine.*', '~edge.*'], we ignore the
-    entries which are NOT since they don't contribute to the final
-    result since the presence of NOT implies the list is an AND list
-    not an OR list.
-    '''
-
-    notlist = [x for x in filter_list
-               if isinstance(x, str) and x.startswith('!')]
-    if notlist and notlist != filter_list:
-        # if not is used with non-not, the nots are meaningless
-        newlist = [x for x in filter_list
-                   if not (isinstance(x, str) and x.startswith('!'))]
-    else:
-        newlist = filter_list
-    return newlist

--- a/tests/integration/sqcmds/cumulus-samples/interface.yml
+++ b/tests/integration/sqcmds/cumulus-samples/interface.yml
@@ -4841,3 +4841,481 @@ tests:
     "ifname": "evpn-vrf", "state": "up", "adminState": "up", "type": "vrf", "mtu":
     65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
     1616681582844}]'
+- command: interface show --mtu='>= 9000 <9500' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "server101", "ifname": "eth1",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server101", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.101/24"], "ip6AddressList": [], "timestamp":
+    1616681581492}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server103", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.1.103/24"], "ip6AddressList": [], "timestamp":
+    1616681581509}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server104", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.2.104/24"], "ip6AddressList": [], "timestamp":
+    1616681581517}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "bond0", "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan":
+    0, "master": "", "ipAddressList": ["172.16.2.102/24"], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth1", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server102", "ifname":
+    "eth2", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000,
+    "vlan": 0, "master": "bond0", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681581595}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "bridge",
+    "state": "up", "adminState": "up", "type": "bridge", "mtu": 9216, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": ["fe80::900d:55ff:fe8d:b541/64"], "timestamp":
+    1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp1", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"], "ip6AddressList":
+    ["fe80::5054:ff:feff:73be/64"], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp",
+    "hostname": "exit01", "ifname": "swp2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.101/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe28:db32/64"], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp5.2", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 2, "master": "",
+    "ipAddressList": ["169.254.254.1/30"], "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp5.3", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 3, "master": "evpn-vrf", "ipAddressList": ["169.254.254.5/30"],
+    "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "vlan4001", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4001, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": ["fe80::900d:55ff:fe8d:b541/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "ifname": "swp5.4", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 4, "master": "internet-vrf", "ipAddressList": ["169.254.254.9/30"],
+    "ip6AddressList": ["fe80::5054:ff:fe81:c154/64"], "timestamp": 1616681582085},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "ifname": "swp6", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "internet-vrf",
+    "ipAddressList": ["169.254.127.1/31"], "ip6AddressList": ["fe80::5054:ff:fecf:70e0/64"],
+    "timestamp": 1616681582085}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    ["fe80::5054:ff:fe83:94bc/64"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": ["fe80::5054:ff:fecf:3b50/64"], "timestamp": 1616681582129},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp4", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": ["fe80::5054:ff:fe7a:b002/64"],
+    "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "ifname": "swp3", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList":
+    ["fe80::5054:ff:feb0:3559/64"], "timestamp": 1616681582129}, {"namespace": "ospf-ibgp",
+    "hostname": "spine01", "ifname": "swp2", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.22/32"],
+    "ip6AddressList": ["fe80::5054:ff:feeb:d477/64"], "timestamp": 1616681582129},
+    {"namespace": "ospf-ibgp", "hostname": "spine01", "ifname": "swp1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": ["fe80::5054:ff:fe51:eb3d/64"],
+    "timestamp": 1616681582129}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "swp2", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"], "ip6AddressList":
+    ["fe80::5054:ff:fe5f:a0b6/64"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList":
+    ["fe80::5054:ff:fe5d:5d83/64"], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp",
+    "hostname": "exit02", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.102/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe93:9e21/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "bridge", "state":
+    "up", "adminState": "up", "type": "bridge", "mtu": 9216, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": ["fe80::e8c9:a5ff:fe5f:c7ca/64"], "timestamp":
+    1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.2",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 2, "master":
+    "", "ipAddressList": ["169.254.253.1/30"], "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "swp5.3", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 3, "master": "evpn-vrf", "ipAddressList": ["169.254.253.5/30"],
+    "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "vlan4001", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4001, "master":
+    "evpn-vrf", "ipAddressList": [], "ip6AddressList": ["fe80::e8c9:a5ff:fe5f:c7ca/64"],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "internet-vrf", "ipAddressList": ["169.254.127.3/31"],
+    "ip6AddressList": ["fe80::5054:ff:fe54:b41d/64"], "timestamp": 1616681582248},
+    {"namespace": "ospf-ibgp", "hostname": "exit02", "ifname": "swp5.4", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4, "master": "internet-vrf",
+    "ipAddressList": ["169.254.253.9/30"], "ip6AddressList": ["fe80::5054:ff:fe5d:5d83/64"],
+    "timestamp": 1616681582248}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan24-v0",
+    "state": "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0,
+    "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vxlan4001", "state": "up", "adminState": "up",
+    "type": "vxlan", "mtu": 9216, "vlan": 4001, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vni24", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "swp6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu":
+    9000, "vlan": 0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan4001", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9216, "vlan": 4001, "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList":
+    ["fe80::4639:39ff:feff:4094/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.12/32"],
+    "ip6AddressList": ["fe80::5054:ff:fed5:33ac/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "swp2", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": ["fe80::5054:ff:fec7:a486/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.2/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d543/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "peerlink", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "bridge", "state": "up", "adminState":
+    "up", "type": "bridge", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325},
+    {"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf02", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "internet", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["169.254.127.0/31"],
+    "ip6AddressList": ["fe80::5054:ff:fe88:3d81/64"], "timestamp": 1616681582344},
+    {"namespace": "ospf-ibgp", "hostname": "internet", "ifname": "swp2", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master":
+    "", "ipAddressList": ["169.254.127.2/31"], "ip6AddressList": ["fe80::5054:ff:fecd:78c7/64"],
+    "timestamp": 1616681582344}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.13/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan4001", "state": "up", "adminState": "up",
+    "type": "vlan", "mtu": 9216, "vlan": 4001, "master": "evpn-vrf", "ipAddressList":
+    [], "ip6AddressList": ["fe80::4639:39ff:feff:4095/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vlan24", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 24, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.2.13/24"], "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan24-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:24/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "swp6", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond01", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 13, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp3", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.13/32"], "ip6AddressList": ["fe80::5054:ff:fea1:a5be/64"], "timestamp":
+    1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "swp1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.13/32"], "ip6AddressList": ["fe80::5054:ff:fedb:8ed/64"],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.1/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d545/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "peerlink", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "bridge", "state": "up", "adminState":
+    "up", "type": "bridge", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "swp4", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vni13", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vxlan4001", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9216, "vlan": 4001, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan24-v0", "state": "up", "adminState": "up", "type": "macvlan", "mtu":
+    9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList":
+    ["fe80::4639:39ff:feff:24/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan":
+    0, "master": "bond02", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vlan4001",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9216, "vlan": 4001,
+    "master": "evpn-vrf", "ipAddressList": [], "ip6AddressList": ["fe80::4639:39ff:feff:4095/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan13", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.14/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan24", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.14/24"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp3", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "swp2", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.14/32"], "ip6AddressList": ["fe80::5054:ff:feb5:4a7b/64"], "timestamp":
+    1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "swp1",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0,
+    "master": "", "ipAddressList": ["10.0.0.14/32"], "ip6AddressList": ["fe80::5054:ff:fe13:2a2c/64"],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.2/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "peerlink", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 1, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bridge", "state": "up", "adminState":
+    "up", "type": "bridge", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "bond02", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": ["fe80::5054:ff:fea7:ba2d/64"], "timestamp": 1616681582843},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp3", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": ["fe80::5054:ff:fe25:b05b/64"],
+    "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "ifname": "swp2", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList":
+    ["fe80::5054:ff:fed1:da/64"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+    "hostname": "spine02", "ifname": "swp1", "state": "up", "adminState": "up", "type":
+    "ethernet", "mtu": 9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"],
+    "ip6AddressList": ["fe80::5054:ff:fe54:3d39/64"], "timestamp": 1616681582843},
+    {"namespace": "ospf-ibgp", "hostname": "spine02", "ifname": "swp6", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": ["fe80::5054:ff:fe5d:daac/64"],
+    "timestamp": 1616681582843}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "ifname": "swp5", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList":
+    ["fe80::5054:ff:fee5:e3d4/64"], "timestamp": 1616681582843}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vxlan4001", "state": "up", "adminState": "up",
+    "type": "vxlan", "mtu": 9216, "vlan": 4001, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan4001", "state": "up", "adminState": "up",
+    "type": "vlan", "mtu": 9216, "vlan": 4001, "master": "evpn-vrf", "ipAddressList":
+    [], "ip6AddressList": ["fe80::4639:39ff:feff:4094/64"], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan24-v0", "state":
+    "up", "adminState": "up", "type": "macvlan", "mtu": 9000, "vlan": 0, "master":
+    "evpn-vrf", "ipAddressList": ["172.16.2.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:24/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.11/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond01", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "bridge", "state": "up", "adminState": "up", "type": "bridge", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "peerlink.4094", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9000, "vlan": 4094, "master": "", "ipAddressList": ["169.254.1.1/30"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "swp1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9216, "vlan": 0, "master": "",
+    "ipAddressList": ["10.0.0.11/32"], "ip6AddressList": ["fe80::5054:ff:fee6:f5c/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "swp2", "state": "up", "adminState": "up", "type": "ethernet", "mtu":
+    9216, "vlan": 0, "master": "", "ipAddressList": ["10.0.0.11/32"], "ip6AddressList":
+    ["fe80::5054:ff:fee6:5037/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp3", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp4", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "peerlink", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp5", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond01", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "swp6", "state": "up", "adminState": "up", "type":
+    "bond_slave", "mtu": 9000, "vlan": 0, "master": "bond02", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan13-v0", "state": "up", "adminState": "up",
+    "type": "macvlan", "mtu": 9000, "vlan": 0, "master": "evpn-vrf", "ipAddressList":
+    ["172.16.1.1/24"], "ip6AddressList": ["fe80::4639:39ff:feff:13/64"], "timestamp":
+    1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vni24",
+    "state": "up", "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vlan13", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.1.11/24"], "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}]'
+- command: interface show --vlan='>=13 <=24' --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show cumulus
+  output: '[{"namespace": "ospf-ibgp", "hostname": "leaf02", "ifname": "vlan13", "state":
+    "up", "adminState": "up", "type": "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.1.12/24"], "ip6AddressList": ["fe80::5054:ff:fe33:b7b8/64"],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.12/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe33:b7b8/64"], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "ifname": "vni24", "state": "up", "adminState": "up", "type":
+    "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bond02", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582325}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.13/24"], "ip6AddressList":
+    ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.13/24"],
+    "ip6AddressList": ["fe80::5054:ff:fe30:f282/64"], "timestamp": 1616681582391},
+    {"namespace": "ospf-ibgp", "hostname": "leaf03", "ifname": "vni13", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf03", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf03", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "ifname": "vni24", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582391}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.14/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.14/24"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d541/64"], "timestamp": 1616681582523},
+    {"namespace": "ospf-ibgp", "hostname": "leaf04", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf04", "ifname": "vni13", "state": "up", "adminState":
+    "up", "type": "vxlan", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf04", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "bond01", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582523}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vlan24", "state": "up", "adminState": "up", "type": "vlan", "mtu":
+    9000, "vlan": 24, "master": "evpn-vrf", "ipAddressList": ["172.16.2.11/24"], "ip6AddressList":
+    ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "vlan13", "state": "up", "adminState": "up", "type":
+    "vlan", "mtu": 9000, "vlan": 13, "master": "evpn-vrf", "ipAddressList": ["172.16.1.11/24"],
+    "ip6AddressList": ["fe80::4a47:ff:fee9:d547/64"], "timestamp": 1616681582844},
+    {"namespace": "ospf-ibgp", "hostname": "leaf01", "ifname": "vni24", "state": "up",
+    "adminState": "up", "type": "vxlan", "mtu": 9000, "vlan": 24, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace":
+    "ospf-ibgp", "hostname": "leaf01", "ifname": "bond01", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9000, "vlan": 13, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf01", "ifname": "bond02", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9000, "vlan": 24, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "peerlink", "state": "up", "adminState": "up", "type": "bond", "mtu":
+    9000, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "ifname": "vni13", "state": "up", "adminState": "up", "type": "vxlan", "mtu":
+    9000, "vlan": 13, "master": "bridge", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1616681582844}]'

--- a/tests/integration/sqcmds/eos-samples/interface.yml
+++ b/tests/integration/sqcmds/eos-samples/interface.yml
@@ -1189,38 +1189,32 @@ tests:
     1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname": "Vlan20",
     "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master":
     "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
-    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "exit01", "ifname":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf03", "ifname":
     "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
     0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
-    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Vxlan1",
-    "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176020},
-    {"namespace": "eos", "hostname": "leaf03", "ifname": "Vxlan1", "state": "up",
-    "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge",
-    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
-    "eos", "hostname": "leaf03", "ifname": "Vlan20", "state": "up", "adminState":
-    "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master": "evpn-vrf", "ipAddressList":
-    ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025176023},
-    {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan30", "state": "up",
-    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
-    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
-    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel1",
-    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan20",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vlan30", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    30, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
     "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
-    {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel4", "state":
-    "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master": "bridge",
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel3", "state":
+    "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge",
     "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
-    "eos", "hostname": "leaf03", "ifname": "Port-Channel3", "state": "up", "adminState":
-    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
-    [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
-    "leaf01", "ifname": "Port-Channel4", "state": "up", "adminState": "up", "type":
-    "bond", "mtu": 9214, "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    "eos", "hostname": "leaf01", "ifname": "Port-Channel4", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 30, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname":
+    "leaf01", "ifname": "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan",
+    "mtu": -1, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
     [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
-    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
-    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
-    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan30",
-    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
-    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    "Vlan30", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    30, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
     [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
     "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
     "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
@@ -1971,3 +1965,157 @@ tests:
     "ifname": "gr-0/0/0", "state": "up", "adminState": "up", "type": "gre", "mtu":
     65536, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
     1623025179345}]'
+- command: interface show --mtu='> 9012 <9216' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos
+  output: '[{"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel1",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 1, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan30", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan1006",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 1006,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet3",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 10, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Vlan10", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master": "evpn-vrf",
+    "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet6",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025175798}, {"namespace": "eos", "hostname": "leaf02", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798},
+    {"namespace": "eos", "hostname": "leaf02", "ifname": "Ethernet5", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025175798}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Vlan1006", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 1006, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0"], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel1", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 1, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Vlan20", "state": "up", "adminState": "up", "type": "vlan",
+    "mtu": 9164, "vlan": 20, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0",
+    "172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Vlan30", "state": "up", "adminState":
+    "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master": "evpn-vrf", "ipAddressList":
+    ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList": [], "timestamp": 1623025176018},
+    {"namespace": "eos", "hostname": "leaf04", "ifname": "Ethernet4", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel4",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Ethernet5", "state": "up", "adminState":
+    "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9214, "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176018}, {"namespace": "eos", "hostname": "exit01", "ifname": "Vlan4094",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 4094,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "exit02", "ifname": "Vlan4094",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 4094,
+    "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList": [], "timestamp":
+    1623025176020}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel4",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 30, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023},
+    {"namespace": "eos", "hostname": "leaf03", "ifname": "Ethernet6", "state": "up",
+    "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan": 0, "master": "Port-Channel1",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace":
+    "eos", "hostname": "leaf03", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname":
+    "leaf03", "ifname": "Ethernet5", "state": "up", "adminState": "up", "type": "bond_slave",
+    "mtu": 9214, "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vlan20", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    20, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Ethernet4", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel4", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 30, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet5",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Ethernet4",
+    "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214, "vlan":
+    0, "master": "Port-Channel4", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan30",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 30, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.3.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Vlan1006", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    1006, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Ethernet3", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel3", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel3", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 10, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname": "Vlan10",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 10, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.1.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Ethernet6", "state": "up", "adminState": "up", "type": "bond_slave", "mtu": 9214,
+    "vlan": 0, "master": "Port-Channel1", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025176024}, {"namespace": "eos", "hostname": "leaf01", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176024}]'
+- command: interface show --vlan='>=13 <=24' --namespace=eos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show eos
+  output: '[{"namespace": "eos", "hostname": "leaf04", "ifname": "Vxlan1", "state":
+    "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan": 0, "master": "bridge",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace":
+    "eos", "hostname": "leaf04", "ifname": "Port-Channel3", "state": "up", "adminState":
+    "up", "type": "bond", "mtu": 9214, "vlan": 20, "master": "bridge", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname":
+    "leaf04", "ifname": "Port-Channel1", "state": "up", "adminState": "up", "type":
+    "bond", "mtu": 9214, "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf04", "ifname":
+    "Vlan20", "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan":
+    20, "master": "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176018}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Vxlan1", "state": "up", "adminState": "up", "type": "vxlan", "mtu": -1, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Vlan20",
+    "state": "up", "adminState": "up", "type": "vlan", "mtu": 9164, "vlan": 20, "master":
+    "evpn-vrf", "ipAddressList": ["0.0.0.0/0", "172.16.2.254/24"], "ip6AddressList":
+    [], "timestamp": 1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname":
+    "Port-Channel1", "state": "up", "adminState": "up", "type": "bond", "mtu": 9214,
+    "vlan": 1, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025176023}, {"namespace": "eos", "hostname": "leaf03", "ifname": "Port-Channel3",
+    "state": "up", "adminState": "up", "type": "bond", "mtu": 9214, "vlan": 20, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025176023}]'

--- a/tests/integration/sqcmds/junos-samples/interface.yml
+++ b/tests/integration/sqcmds/junos-samples/interface.yml
@@ -3287,3 +3287,128 @@ tests:
   data-directory: tests/data/parquet/
   marks: interface unique junos
   output: '[]'
+- command: interface show --mtu='> 9012 <9216' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos
+  output: '[{"namespace": "junos", "hostname": "exit01", "ifname": "xe-0/0/0", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master":
+    "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025801370}, {"namespace":
+    "junos", "hostname": "exit01", "ifname": "xe-0/0/1", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025801370}, {"namespace": "junos",
+    "hostname": "exit01", "ifname": "xe-0/0/0.0", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.31/32"], "ip6AddressList": [], "timestamp": 1623025801370}, {"namespace":
+    "junos", "hostname": "exit01", "ifname": "xe-0/0/1.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.31/32"], "ip6AddressList": [], "timestamp": 1623025801370}, {"namespace":
+    "junos", "hostname": "exit01", "ifname": "xe-0/0/2.2", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9194, "vlan": 2, "master": "", "ipAddressList":
+    ["169.254.254.1/30"], "ip6AddressList": [], "timestamp": 1623025801370}, {"namespace":
+    "junos", "hostname": "exit01", "ifname": "xe-0/0/2.3", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9194, "vlan": 3, "master": "evpn-vrf", "ipAddressList":
+    ["169.254.254.5/30"], "ip6AddressList": [], "timestamp": 1623025801370}, {"namespace":
+    "junos", "hostname": "exit01", "ifname": "xe-0/0/2.4", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9194, "vlan": 4, "master": "internet-vrf",
+    "ipAddressList": ["169.254.254.9/30"], "ip6AddressList": [], "timestamp": 1623025801370},
+    {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/1.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": [], "timestamp": 1623025801371},
+    {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/0.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.12/32"], "ip6AddressList": [], "timestamp": 1623025801371},
+    {"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025801371}, {"namespace":
+    "junos", "hostname": "leaf02", "ifname": "xe-0/0/0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025801371}, {"namespace": "junos",
+    "hostname": "exit02", "ifname": "xe-0/0/2.2", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 9194, "vlan": 2, "master": "", "ipAddressList":
+    ["169.254.253.1/30"], "ip6AddressList": [], "timestamp": 1623025801614}, {"namespace":
+    "junos", "hostname": "exit02", "ifname": "xe-0/0/2.3", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9194, "vlan": 3, "master": "evpn-vrf", "ipAddressList":
+    ["169.254.253.5/30"], "ip6AddressList": [], "timestamp": 1623025801614}, {"namespace":
+    "junos", "hostname": "exit02", "ifname": "xe-0/0/2.4", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9194, "vlan": 4, "master": "internet-vrf",
+    "ipAddressList": ["169.254.253.9/30"], "ip6AddressList": [], "timestamp": 1623025801614},
+    {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/0.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.32/32"], "ip6AddressList": [], "timestamp": 1623025801614},
+    {"namespace": "junos", "hostname": "exit02", "ifname": "xe-0/0/1", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025801614}, {"namespace":
+    "junos", "hostname": "exit02", "ifname": "xe-0/0/0", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025801614}, {"namespace": "junos",
+    "hostname": "exit02", "ifname": "xe-0/0/1.0", "state": "up", "adminState": "up",
+    "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.32/32"], "ip6AddressList": [], "timestamp": 1623025801614}, {"namespace":
+    "junos", "hostname": "spine02", "ifname": "xe-0/0/1.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.22/32"], "ip6AddressList": [], "timestamp": 1623025801643}, {"namespace":
+    "junos", "hostname": "spine02", "ifname": "xe-0/0/0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.22/32"], "ip6AddressList": [], "timestamp": 1623025801643}, {"namespace":
+    "junos", "hostname": "spine02", "ifname": "xe-0/0/3", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025801643}, {"namespace": "junos",
+    "hostname": "spine02", "ifname": "xe-0/0/2", "state": "up", "adminState": "up",
+    "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1623025801643}, {"namespace": "junos", "hostname":
+    "spine02", "ifname": "xe-0/0/1", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 9214, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025801643}, {"namespace": "junos", "hostname": "spine02", "ifname":
+    "xe-0/0/0", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9214,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025801643}, {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/3.0",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan":
+    0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": [], "timestamp":
+    1623025801643}, {"namespace": "junos", "hostname": "spine02", "ifname": "xe-0/0/2.0",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan":
+    0, "master": "", "ipAddressList": ["10.0.0.22/32"], "ip6AddressList": [], "timestamp":
+    1623025801643}, {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/3",
+    "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9214, "vlan": 0,
+    "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025803099},
+    {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/0.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp": 1623025803099},
+    {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/1.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp": 1623025803099},
+    {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/2.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp": 1623025803099},
+    {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/3.0", "state":
+    "up", "adminState": "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master":
+    "", "ipAddressList": ["10.0.0.21/32"], "ip6AddressList": [], "timestamp": 1623025803099},
+    {"namespace": "junos", "hostname": "spine01", "ifname": "xe-0/0/0", "state": "up",
+    "adminState": "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "",
+    "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025803099}, {"namespace":
+    "junos", "hostname": "leaf01", "ifname": "xe-0/0/1.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.11/32"], "ip6AddressList": [], "timestamp": 1623025803099}, {"namespace":
+    "junos", "hostname": "leaf01", "ifname": "xe-0/0/0.0", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 9200, "vlan": 0, "master": "", "ipAddressList":
+    ["10.0.0.11/32"], "ip6AddressList": [], "timestamp": 1623025803099}, {"namespace":
+    "junos", "hostname": "leaf01", "ifname": "xe-0/0/1", "state": "up", "adminState":
+    "up", "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList":
+    [], "ip6AddressList": [], "timestamp": 1623025803099}, {"namespace": "junos",
+    "hostname": "leaf01", "ifname": "xe-0/0/0", "state": "up", "adminState": "up",
+    "type": "ethernet", "mtu": 9214, "vlan": 0, "master": "", "ipAddressList": [],
+    "ip6AddressList": [], "timestamp": 1623025803099}, {"namespace": "junos", "hostname":
+    "spine01", "ifname": "xe-0/0/1", "state": "up", "adminState": "up", "type": "ethernet",
+    "mtu": 9214, "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [],
+    "timestamp": 1623025803099}, {"namespace": "junos", "hostname": "spine01", "ifname":
+    "xe-0/0/2", "state": "up", "adminState": "up", "type": "ethernet", "mtu": 9214,
+    "vlan": 0, "master": "", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1623025803099}]'
+- command: interface show --vlan='>=13 <=24' --namespace=junos --format=json
+  data-directory: tests/data/parquet/
+  marks: interface show junos
+  output: '[{"namespace": "junos", "hostname": "leaf02", "ifname": "xe-0/0/2", "state":
+    "up", "adminState": "up", "type": "ethernet", "mtu": 1514, "vlan": 20, "master":
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1623025801371},
+    {"namespace": "junos", "hostname": "leaf02", "ifname": "irb.20", "state": "up",
+    "adminState": "up", "type": "vlan", "mtu": 1500, "vlan": 20, "master": "evpn-vrf",
+    "ipAddressList": ["172.16.2.254/24"], "ip6AddressList": [], "timestamp": 1623025801371}]'

--- a/tests/integration/sqcmds/vmx-samples/interfaces.yml
+++ b/tests/integration/sqcmds/vmx-samples/interfaces.yml
@@ -1276,33 +1276,21 @@ tests:
 - command: interface show --vlan='> 10 < 100' --namespace=vmx --format=json
   data-directory: tests/data/parquet/
   marks: interface show vmx junos
-  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae0",
+  output: '[{"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20",
+    "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan":
+    20, "master": "", "ipAddressList": ["10.0.20.3/29"], "ip6AddressList": [], "timestamp":
+    1631009088901}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/0",
+    "state": "up", "adminState": "up", "type": "flexible-ethernet", "mtu": 1518, "vlan":
+    0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
+    1631009089182}, {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae1",
     "state": "up", "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master":
-    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009088901},
-    {"namespace": "vmx", "hostname": "TOR4CRP-DGW-RT01", "ifname": "ae1.20", "state":
-    "up", "adminState": "up", "type": "subinterface", "mtu": 65536, "vlan": 20, "master":
-    "", "ipAddressList": ["10.0.20.3/29"], "ip6AddressList": [], "timestamp": 1631009088901},
-    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ge-0/0/0", "state":
-    "up", "adminState": "up", "type": "flexible-ethernet", "mtu": 1518, "vlan": 0,
-    "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
-    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae1", "state": "up",
+    "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182},
+    {"namespace": "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2", "state": "up",
     "adminState": "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge",
     "ipAddressList": [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace":
-    "vmx", "hostname": "CRP-DIS-SW01", "ifname": "ae2", "state": "up", "adminState":
-    "up", "type": "bond", "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList":
-    [], "ip6AddressList": [], "timestamp": 1631009089182}, {"namespace": "vmx", "hostname":
-    "CRP-ACC-SW01", "ifname": "ae1", "state": "up", "adminState": "up", "type": "bond",
-    "mtu": 1518, "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList":
-    [], "timestamp": 1631009089423}, {"namespace": "vmx", "hostname": "CRP-ACC-SW01",
-    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
-    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
-    1631009089423}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname":
-    "ae1.20", "state": "up", "adminState": "up", "type": "subinterface", "mtu": 65536,
-    "vlan": 20, "master": "", "ipAddressList": ["10.0.20.2/29"], "ip6AddressList":
-    [], "timestamp": 1631009089864}, {"namespace": "vmx", "hostname": "TOR1CRP-DGW-RT01",
-    "ifname": "ae0", "state": "up", "adminState": "up", "type": "bond", "mtu": 1518,
-    "vlan": 0, "master": "bridge", "ipAddressList": [], "ip6AddressList": [], "timestamp":
-    1631009089864}]'
+    "vmx", "hostname": "TOR1CRP-DGW-RT01", "ifname": "ae1.20", "state": "up", "adminState":
+    "up", "type": "subinterface", "mtu": 65536, "vlan": 20, "master": "", "ipAddressList":
+    ["10.0.20.2/29"], "ip6AddressList": [], "timestamp": 1631009089864}]'
 - command: interface show --mtu='>= 1514' --namespace=vmx --format=json
   data-directory: tests/data/parquet/
   marks: interface show vmx junos

--- a/tests/integration/sqcmds/vmx-samples/swport.yml
+++ b/tests/integration/sqcmds/vmx-samples/swport.yml
@@ -44,5 +44,5 @@ tests:
 - command: interface show --columns=vlan --vlan='101 201' --namespace=vmx --format=json
   data-directory: tests/data/parquet/
   marks: interface show vmx switchport
-  output: '[{"vlan": 0}, {"vlan": 101}, {"vlan": 0}, {"vlan": 101}, {"vlan": 0}, {"vlan":
-    201}, {"vlan": 0}, {"vlan": 201}]'
+  output: '[{"vlan": 101}, {"vlan": 101}, {"vlan": 0}, {"vlan": 201}, {"vlan": 0},
+    {"vlan": 201}]'


### PR DESCRIPTION
## Description

This PR fixes three issues in filtering:

Namespace filters has some problems due to the fact that we filter the files, and we directly applied regex on the filename, this caused some problems when for example the regex was looking for a suffix. `.*os` matched both:
```
namespace=nxos/
```
and 
```
namespace=my-ns/hostname=leaf-nxos
```
To fix it we just get the namespace part and filter on it.

A bug in the code caused the output of the show function to have some duplicates when multiple filters combined with OR matched the same rows. We fixes this issue by:
- Building a pandas query string and applying it once for hostname filters
- Removing the duplicates once we filter for the vlan filter in interface

Additionally, with PR #783 we added the possibility to filter by interval. The way we used to detect the interval has some problems, since it wasn't possible to look for extremes so ( i.e. X < 9 and X > 20). With this fix we detect an interval only if we find a sequence of >/>= and </<= and not if we just match them in any position.

Moreover, now we accept any combination of filters, both match and NOT filters are allowed:
i.e.:
```
hostname="~leaf.* !leaf01"
```

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)