### PR TITLE
sq-coalescer: fix old schemas handling and migration

### DIFF
--- a/suzieq/db/parquet/migratedb.py
+++ b/suzieq/db/parquet/migratedb.py
@@ -27,8 +27,13 @@ def get_migrate_fn(table_name: str, from_vers: str,
 
 def generic_migration(df: pd.DataFrame, table: str,
                       schema: Schema) -> pd.DataFrame:
-    """When we don't need a specific migration function, it is possible to
-    use the generic one.
+    """The generic migration fuction tries to perform the conversion from an
+    old schema to the new one:
+      - Creating the missing fields and writing a default value
+      - Checking if there are type mismatches and try a simple conversion
+      - Removing all the fields which are not in the schema anymore
+    This function allows to perform automatic conversion whenever possible,
+    to perform more complex actions we need a specific conversion function.
 
     Args:
         df (pd.DataFrame): DataFrame to migrate

--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -22,6 +22,7 @@ from suzieq.shared.schema import Schema, SchemaForTable
 from suzieq.db.parquet.pq_coalesce import (SqCoalesceState,
                                            coalesce_resource_table)
 from suzieq.db.parquet.migratedb import get_migrate_fn
+from suzieq.shared.utils import get_default_per_vals
 
 
 PARQUET_VERSION = '2.4'
@@ -205,7 +206,7 @@ class SqParquetDB(SqDB):
             partition_cols = ['sqvers', 'namespace', 'hostname']
 
         schema_def = dict(zip(schema.names, schema.types))
-        defvals = self._get_default_vals()
+        defvals = get_default_per_vals()
 
         if data_format == "pandas":
             if isinstance(data, pd.DataFrame):
@@ -389,7 +390,7 @@ class SqParquetDB(SqDB):
         """
 
         current_vers = schema.version
-        defvals = self._get_default_vals()
+        defvals = get_default_per_vals()
         arrow_schema = schema.get_arrow_schema()
         schema_def = dict(zip(arrow_schema.names, arrow_schema.types))
 
@@ -852,16 +853,3 @@ class SqParquetDB(SqDB):
             return f'{folder}/{table_name}'
         else:
             return folder
-
-    def _get_default_vals(self) -> dict:
-        return({
-            pa.string(): "",
-            pa.int32(): 0,
-            pa.int64(): 0,
-            pa.float32(): 0.0,
-            pa.float64(): 0.0,
-            pa.date64(): 0.0,
-            pa.bool_(): False,
-            pa.list_(pa.string()): [],
-            pa.list_(pa.int64()): [],
-        })

--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -619,26 +619,6 @@ class SqParquetDB(SqDB):
         else:
             return None
 
-    def _build_master_schema(self, datasets: list) -> pa.lib.Schema:
-        """Build the master schema from the list of diff versions
-        We use this to build the filters and use the right type-based check
-        for a field.
-        """
-        msch = datasets[0].schema
-        msch_set = set(msch)
-        for dataset in datasets[1:]:
-            sch = dataset.schema
-            sch_set = set(sch)
-            if msch_set.issuperset(sch):
-                continue
-            if sch_set.issuperset(msch):
-                msch = sch
-            else:
-                for fld in sch_set-msch_set:
-                    msch.append(fld)
-
-        return msch
-
     def _get_filtered_fileset(self, dataset: ds, namespaces: list) -> ds:
         """Filter the dataset based on the namespace
 

--- a/suzieq/db/parquet/pq_coalesce.py
+++ b/suzieq/db/parquet/pq_coalesce.py
@@ -8,7 +8,7 @@ from itertools import repeat
 from typing import List
 
 import pandas as pd
-import pyarrow.dataset as ds  # put this later due to some numpy dependency
+import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 from suzieq.db.parquet.migratedb import generic_migration, get_migrate_fn
 from suzieq.shared.schema import SchemaForTable
@@ -97,7 +97,7 @@ def write_files(table: str, filelist: List[str], in_basedir: str,
     if filelist:
         files_pervers = defaultdict(list)
         for file in filelist:
-            sqversmatch = re.search(r'sqvers=([0-9]*.[0-9]*)', file)
+            sqversmatch = re.search(r'sqvers=([0-9]+\.[0-9]+)', file)
             if sqversmatch:
                 files_pervers[sqversmatch.group(0)].append(file)
 

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -19,7 +19,7 @@ from packaging import version as version_parse
 from suzieq.poller.worker.services.svcparser \
     import cons_recs_from_json_template
 from suzieq.shared.sq_plugin import SqPlugin
-from suzieq.shared.utils import known_devtypes
+from suzieq.shared.utils import get_default_per_vals, known_devtypes
 from suzieq.version import SUZIEQ_VERSION
 
 # How long b4 declaring node dead
@@ -153,23 +153,9 @@ class Service(SqPlugin):
         else:
             self.node_postcall_list = node_call_list
 
-    def _get_default_vals(self) -> dict:
-        '''Get default values based on type'''
-        return({
-            pa.string(): "",
-            pa.int32(): 0,
-            pa.int64(): 0,
-            pa.float32(): 0.0,
-            pa.float64(): 0.0,
-            pa.date64(): 0.0,
-            pa.bool_(): False,
-            pa.list_(pa.string()): [],
-            pa.list_(pa.int64()): [],
-        })
-
     def get_empty_record(self):
         '''Return an empty record matching schema'''
-        map_defaults = self._get_default_vals()
+        map_defaults = get_default_per_vals()
 
         defaults = [map_defaults[x] for x in self.schema.types]
         rec = dict(zip(self.schema.names, defaults))
@@ -548,7 +534,7 @@ class Service(SqPlugin):
 
         # Build default data structure
         schema_rec = {}
-        def_vals = self._get_default_vals()
+        def_vals = get_default_per_vals()
 
         ptype_map = {
             pa.string(): str,

--- a/suzieq/shared/exceptions.py
+++ b/suzieq/shared/exceptions.py
@@ -1,6 +1,10 @@
 """List of Exceptions specific to Suzieq, across all the modules."""
 
 
+class SqCoalescerCriticalError(Exception):
+    """Raised when a critical error occuur inside the coalescer"""
+
+
 class NoLLdpError(Exception):
     """No LLDP error."""
 
@@ -27,6 +31,10 @@ class UserQueryError(Exception):
 
 class UnknownDevtypeError(Exception):
     """Unknown dev type error."""
+
+
+class SqVersConversionError(SqCoalescerCriticalError):
+    """Raised if there is an error while converting the data"""
 
 
 class SqPollerConfError(Exception):

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List
 from tzlocal import get_localzone
 
 import pandas as pd
+import pyarrow as pa
 import yaml
 from dateparser import parse
 from dateutil.relativedelta import relativedelta
@@ -1043,3 +1044,23 @@ def deprecated_command_warning(dep_command: str, dep_sub_command: str,
 
     return deprecated_table_function_warning(dep_command, dep_sub_command,
                                              command, sub_command)
+
+
+def get_default_per_vals() -> Dict:
+    """For each pyarrow type get the default type.
+
+    Returns:
+        Dict: mapping between type and default value
+    """
+    return({
+        pa.string(): "",
+        pa.int32(): 0,
+        pa.int64(): 0,
+        pa.float32(): 0.0,
+        pa.float64(): 0.0,
+        pa.date64(): 0.0,
+        pa.bool_(): False,
+        pa.list_(pa.string()): [],
+        pa.list_(pa.int64()): [],
+        pa.binary(): b''
+    })


### PR DESCRIPTION
## Description

This PR fixes some issues with the coalescer when there are files following an old schema:

- Handle the case in which the coalescer reads file belonging to multiple schemas
- Introduce a "generic migration" function which is executed every time the coealscer converts data belonging to an old schema
- Remove dead code and code reorganization 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)