### PR TITLE
Set vrf to dvrf if port is trunk

### DIFF
--- a/suzieq/engines/pandas/path.py
+++ b/suzieq/engines/pandas/path.py
@@ -42,7 +42,8 @@ class PathObj(SqPandasEngine):
                 .get(namespace=namespace, state='up',
                      columns=['namespace', 'hostname', 'ifname', 'mtu', 'type',
                               'ipAddressList', 'ip6AddressList', 'state',
-                              'vlan', 'master', 'macaddr', 'timestamp', 'portmode']) \
+                              'vlan', 'master', 'macaddr', 'timestamp',
+                              'portmode']) \
                 .explode('ipAddressList') \
                 .fillna({'ipAddressList': ''}) \
                 .explode('ip6AddressList') \
@@ -222,7 +223,8 @@ class PathObj(SqPandasEngine):
                     f'ipAddressList.str.startswith("{addr}")')
             else:
                 # No address, but a bridge interface as the master
-                if iifdf.iloc[0]['vlan'] and iifdf.iloc[0]['portmode'] != 'trunk':
+                if (iifdf.iloc[0]['vlan'] and
+                   iifdf.iloc[0]['portmode'] != 'trunk'):
                     # Check if there's an SVI, assuming format is vlan*
                     # TODO: Handle trunk
                     vlan = iifdf.iloc[0]['vlan']

--- a/suzieq/engines/pandas/path.py
+++ b/suzieq/engines/pandas/path.py
@@ -42,7 +42,7 @@ class PathObj(SqPandasEngine):
                 .get(namespace=namespace, state='up',
                      columns=['namespace', 'hostname', 'ifname', 'mtu', 'type',
                               'ipAddressList', 'ip6AddressList', 'state',
-                              'vlan', 'master', 'macaddr', 'timestamp']) \
+                              'vlan', 'master', 'macaddr', 'timestamp', 'portmode']) \
                 .explode('ipAddressList') \
                 .fillna({'ipAddressList': ''}) \
                 .explode('ip6AddressList') \
@@ -222,7 +222,7 @@ class PathObj(SqPandasEngine):
                     f'ipAddressList.str.startswith("{addr}")')
             else:
                 # No address, but a bridge interface as the master
-                if iifdf.iloc[0]['vlan']:
+                if iifdf.iloc[0]['vlan'] and iifdf.iloc[0]['portmode'] != 'trunk':
                     # Check if there's an SVI, assuming format is vlan*
                     # TODO: Handle trunk
                     vlan = iifdf.iloc[0]['vlan']


### PR DESCRIPTION
## Description
In case of vxlan, it's very common to have trunk ports facing towards the servers. I observed if the devices_iifs is `{'iif': 'Ethernet1/26', 'mtu': 9216, 'outMtu': 9216, 'overlay': '', 'protocol': '', 'hopError': [], 'lookup': '1.1.1.1', 'macaddr': None, 'vrf': 'vrf1', 'mtuMatch': True, 'is_l2': False, 'nhip': '', 'overlay_nhip': '', 'oif': 'Ethernet1/26', 'timestamp': Timestamp('2022-09-16 16:13:09.461000-0700', tz='America/Los_Angeles'), 'l3_visited_devices': set(), 'l2_visited_devices': set()}`, the vrf was being set to native vlan which causes issue in routing path. 

The fix will just set the vrf to empty so that it gets overwritten to dvrf in https://github.com/netenglabs/suzieq/blob/aa4fbd6baeb20e2fb912d9cf2414810b9612d5f3/suzieq/engines/pandas/path.py#L968


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

The source will no longer get attributed to native vlan vrf .


## Proposed Release Note Entry

Set vrf to vrf of the ip if the port is trunk


- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
