### PR TITLE
sq-poller: fix issues with device connection

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -688,7 +688,8 @@ class Node:
             # Release here because init_dev_data uses this lock as well
             # We need to be sure that devtype is set, otherwise the
             # _fetch_dev_data function is not implemented and will raise.
-            if init_dev_data and self.devtype:
+            # Moreover we want to be connected if we call this function
+            if self._conn and init_dev_data and self.devtype:
                 await self._fetch_init_dev_data()
 
     @abstractmethod

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1434,14 +1434,14 @@ class IosXRNode(Node):
 
         while not self._conn:
 
-            if not self._retry:
-                break
-
             await super()._init_ssh(init_dev_data=False, use_lock=False)
 
             if self.is_connected:
                 self.logger.info(
                     f'Connection succeeded via SSH for {self.hostname}')
+                break
+
+            if not self._retry:
                 break
 
             await asyncio.sleep(backoff_period)

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1644,8 +1644,12 @@ class IosXENode(Node):
             await self._init_ssh()
 
         if not self._conn or not self._stdin:
-            self.logger.error(f'Not connected to {self.address}:{self.port}')
-            await service_callback({}, cb_token)
+            for cmd in cmd_list:
+                self.logger.error(
+                    "Unable to connect to node %s (%s) cmd %s",
+                    self.address, self.hostname, cmd)
+                result.append(self._create_error(cmd))
+            await service_callback(result, cb_token)
             return
 
         timeout = timeout or self.cmd_timeout

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -178,7 +178,11 @@ class Node:
 
         if self.transport == "ssh":
             self.port = self.port or 22
-            await self._init_ssh(init_dev_data=False)
+            # If a devtype is provided do not perform the initial connection
+            # we want to do the connection once. So that we don't need to
+            # open and close it in the case of 'iosxe', 'ios', 'iosxr'.
+            if not self.devtype:
+                await self._init_ssh(init_dev_data=False)
         elif self.transport == "https":
             self.port = self.port or 443
             if self.devtype:


### PR DESCRIPTION
## Description

This PR addresses a set of issues related to the connection with the poller devices:
- ios, iosxe and iosxr: fix initial connection
- ios, iosxe and iosxr: do not disconnect after discovery if devtype is provided
- ios, iosxe: if slow_host is provided increase the initial connection backoff time to 30
- all: do not call device data initialization if connection fails
- ios, iosxe, iosxr: fix deadlock happening in some corner cases
- all: fix max recursion error happening in some corner cases while retrieving the device data 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
