### PR TITLE
ignore unknown tables

### DIFF
--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -47,7 +47,8 @@ class SqParquetDB(SqDB):
         folder = self._get_table_directory(None, False)
         dirs = Path(folder).glob('*')
         tables = [str(x.stem) for x in dirs
-                  if not str(x.stem).startswith(('_', 'coalesced'))]
+                  if not str(x.stem).startswith(('_', 'coalesced'))
+                  and x.is_dir()]
 
         return tables
 

--- a/suzieq/engines/pandas/tables.py
+++ b/suzieq/engines/pandas/tables.py
@@ -18,22 +18,14 @@ class TableObj(SqPandasEngine):
         df = pd.DataFrame()
         columns = kwargs.pop('columns', ['default'])
         fields = self.schema.get_display_fields(columns)
-        unknown_tables = []
         tables = []
 
         for table in table_list:
-            table_obj = self._get_table_sqobj(table)
-
-            if not table_obj:
-                # This is a table without an sqobject backing store
-                # this happens either because we haven't yet implemented the
-                # table functions or because this table is collapsed into a
-                # single table as in the case of ospf
-                unknown_tables.append(table)
-                table_inst = self._get_table_sqobj('tables')
-                table_inst.table = table
-            else:
-                table_inst = table_obj
+            try:
+                table_inst = self._get_table_sqobj(table)
+            except ModuleNotFoundError:
+                # ignore unknown tables
+                continue
 
             info = {'table': table}
             info.update(table_inst.get_table_info(


### PR DESCRIPTION
## Description

In case a directory with a name which is not associated with any sqobject was stored inside the `data-directory`, the `sqobject.get` function of `tables` was crashing. 
The reason is that the `get_sqobject` function, called inside `tables.get()`, with an invalid table as input parameter raises a `ModuleNotFound` exception which wasn't catched.
Now, if this appens, the tables sqobject simply ignores it.

This PR removes some dead code inside `tables.get`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)