### PR TITLE
sq-poller: fix address in hostname field

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -231,10 +231,6 @@ class Node:
                 # proceeding with the new connection
                 await asyncio.sleep(IOS_TIME_AFTER_DISCOVERY)
 
-            await self._fetch_init_dev_data()
-            if not self.hostname:
-                self.hostname = self.address
-
         return self
 
     @property
@@ -440,15 +436,9 @@ class Node:
         Its only available if we're using ssh as transport
         '''
 
-        devtype = None
-        hostname = None
-
         if self.transport in ['ssh', 'local']:
             try:
                 await self._get_device_type_hostname()
-                # The above fn calls results in invoking a callback fn
-                # that sets the device type
-                devtype = self.devtype
             except Exception:
                 self.logger.exception(f'{self.address}:{self.port}: Node '
                                       'discovery failed due to exception')
@@ -459,17 +449,16 @@ class Node:
                 # In this case there is not point in retrying discovery, it is
                 # likely a bug.
                 self._retry = 0
-                devtype = None
 
-            if not devtype:
+            if not self.devtype:
                 self.logger.debug(
                     f'No devtype for {self.hostname} {self.current_exception}')
                 # We were not able to do the discovery, schedule a new attempt
                 self._schedule_discovery_attempt()
-                return
             else:
-                self._set_devtype(devtype, '')
-                self._set_hostname(hostname)
+                # Need to initialize the node with the device-specific
+                # commands
+                await self._fetch_init_dev_data()
         else:
             self.logger.error(
                 f'Non-SSH transport node {self.address}:{self.port} '
@@ -940,7 +929,11 @@ class Node:
                 async with self._discovery_lock:
                     await self._detect_node_type()
 
-        if not self.devtype:
+        # As after the discovery we call the _init_dev_data() devtype might be
+        # set but the devdata is still not intialized, so discovery is still
+        # pending. In this case we need to fail
+        if (not self.devtype
+                or (self.devtype and self._discovery_lock.locked())):
             result.append(self._create_error(svc_defn.get("service", "-")))
             return await service_callback(result, cb_token)
 

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1072,11 +1072,14 @@ class Node:
         the devtype we are polling.
         """
         # Check whether all the commands has been successful
-        if any(out['status'] not in [0, 200] for out in output):
-            # the last command is the once which failed get why it failed.
-            failed_cmd = output[-1]
-            fail_reason = (f"Cmd `{failed_cmd['cmd']}` failed with reason: "
-                           f"{failed_cmd['data'].get('error', 'None')}")
+        failed_commands = [out for out in output
+                           if out['status'] not in [0, 200]]
+        if failed_commands:
+            # Get the reason for the failure of the commands
+            fail_reason = ''
+            for cmd in failed_commands:
+                fail_reason += (f"Cmd `{cmd['cmd']}` failed with reason: "
+                                f"{cmd['data']}. ")
 
             # Schedule a new connection attempt to retry the discovery of the
             # node
@@ -1092,7 +1095,7 @@ class Node:
             next_time = datetime.fromtimestamp(self._connect_again_at)
             logger.warning(
                 f'{self.address}:{self.port} unable to initialize the device '
-                f'data. {fail_reason}. Disconnecting and scheduling '
+                f'data. {fail_reason} Disconnecting and scheduling '
                 f'another connection attempt from {next_time}.')
         else:
             await self._parse_init_dev_data_devtype(output, cb_token)


### PR DESCRIPTION
## Description

In some cases we were able to see some records having the management address in the hostname field. This patch fixes three reasons causing the problem:

- The device data initialization was not done in a scheduled discovery
- Without the MAX_CMD_PIPELINE  after a re-connection some commands proceeded without waiting the data initialization to complete.
- When the device data initialization failed because of timeout of a command a new attempt was not scheduled.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
