### PR TITLE
Drop table describe

### DIFF
--- a/suzieq/cli/sqcmds/TableCmd.py
+++ b/suzieq/cli/sqcmds/TableCmd.py
@@ -1,9 +1,5 @@
-import time
-
-import pandas as pd
 from nubia import command
 
-from suzieq.cli.nubia_patch import argument
 from suzieq.cli.sqcmds.command import SqTableCommand
 from suzieq.sqobjects.tables import TablesObj
 
@@ -34,25 +30,3 @@ class TableCmd(SqTableCommand):
             format=format,
             sqobj=TablesObj,
         )
-
-    @ command("describe")
-    @ argument("table", description="interface name to qualify")
-    def describe(self, table: str = "tables"):
-        """
-        Describe fields in table
-        """
-
-        if not table:
-            df = pd.DataFrame({'error': ['ERROR: Must specify a table']})
-            return self._gen_output(df)
-
-        if self.columns != ['default']:
-            df = pd.DataFrame(
-                {'error': ['ERROR: Cannot specify columns for command']})
-            return self._gen_output(df)
-
-        now = time.time()
-        df = self.sqobj.describe(table=table)
-        self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
-
-        return self._gen_output(df, dont_strip_cols=True)

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -768,17 +768,6 @@ def query_topology(verb: CommonVerbs, request: Request,
     return read_shared(function_name, verb, request, locals())
 
 
-@ app.get("/api/v2/table/describe")
-def query_table_describe(
-        request: Request,
-        token: str = Depends(get_api_key),
-        format: str = None,
-        table: str = None,
-):
-    function_name = inspect.currentframe().f_code.co_name
-    return read_shared(function_name, 'describe', request, locals())
-
-
 @app.get("/api/v2/table/{verb}")
 def query_table(
         verb: CommonVerbs, request: Request,

--- a/tests/integration/all_cndcn/dual-attach_bgp_docker-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_bgp_docker-samples/table.yml
@@ -124,8 +124,3 @@ tests:
     rows": 0, "namespaces": 0, "devices": 0}, {"table": "TOTAL", "first_time": 1594706580036,
     "latest_time": 1594727745821, "intervals": 85, "all rows": 505, "namespaces":
     1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_bgp_docker
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_bgp_docker/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_bgp_numbered-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_bgp_numbered-samples/table.yml
@@ -132,8 +132,3 @@ tests:
     1, "all rows": 20, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time":
     1594437577600, "latest_time": 1594727746316, "intervals": 85, "all rows": 715,
     "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_bgp_numbered
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_bgp_numbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_bgp_unnumbered-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_bgp_unnumbered-samples/table.yml
@@ -132,8 +132,3 @@ tests:
     1, "all rows": 20, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time":
     1594437073943, "latest_time": 1594727746466, "intervals": 85, "all rows": 760,
     "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_bgp_unnumbered
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_bgp_unnumbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_evpn_centralized-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_evpn_centralized-samples/table.yml
@@ -140,8 +140,3 @@ tests:
     1, "all rows": 30, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time":
     1594434801156, "latest_time": 1594727746740, "intervals": 85, "all rows": 955,
     "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_evpn_centralized
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_evpn_centralized/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_evpn_distributed-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_evpn_distributed-samples/table.yml
@@ -144,8 +144,3 @@ tests:
     1, "all rows": 35, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time":
     1594434327980, "latest_time": 1594727746472, "intervals": 85, "all rows": 945,
     "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_evpn_distributed
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_evpn_distributed/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_evpn_ospf-ibgp-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_evpn_ospf-ibgp-samples/table.yml
@@ -157,8 +157,3 @@ tests:
     rows": 35, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time": 1594433847013,
     "latest_time": 1594727746543, "intervals": 85, "all rows": 925, "namespaces":
     1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_evpn_ospf-ibgp
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_evpn_ospf-ibgp/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_ospf_docker-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_ospf_docker-samples/table.yml
@@ -128,8 +128,3 @@ tests:
     "first_time": null, "latest_time": null, "intervals": 0, "all rows": 0, "namespaces":
     0, "devices": 0}, {"table": "TOTAL", "first_time": 1594435492494, "latest_time":
     1594727745750, "intervals": 78, "all rows": 490, "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_ospf_docker
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_ospf_docker/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_ospf_numbered-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_ospf_numbered-samples/table.yml
@@ -144,8 +144,3 @@ tests:
     rows": 20, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time": 1594706822756,
     "latest_time": 1594727746667, "intervals": 75, "all rows": 695, "namespaces":
     1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_ospf_numbered
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_ospf_numbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/dual-attach_ospf_unnumbered-samples/table.yml
+++ b/tests/integration/all_cndcn/dual-attach_ospf_unnumbered-samples/table.yml
@@ -144,8 +144,3 @@ tests:
     1, "all rows": 20, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time":
     1594435777893, "latest_time": 1594727746748, "intervals": 80, "all rows": 680,
     "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=dual-attach_ospf_unnumbered
-  data-directory: /tmp/suzieq-tests-parquet/dual-attach_ospf_unnumbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_bgp_docker-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_bgp_docker-samples/table.yml
@@ -128,8 +128,3 @@ tests:
     "intervals": 1, "all rows": 16, "namespaces": 1, "devices": 1}, {"table": "TOTAL",
     "first_time": 1594389609275, "latest_time": 1594793458538, "intervals": 135, "all
     rows": 840, "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=single-attach_bgp_docker
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_bgp_docker/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_bgp_numbered-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_bgp_numbered-samples/table.yml
@@ -129,8 +129,3 @@ tests:
     "devices": 1}, {"table": "TOTAL", "first_time": 1594390550801, "latest_time":
     1594793458521, "intervals": 149, "all rows": 972, "namespaces": 1, "devices":
     1}]'
-- command: table describe --format=json --namespace=single-attach_bgp_numbered
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_bgp_numbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_bgp_unnumbered-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_bgp_unnumbered-samples/table.yml
@@ -129,8 +129,3 @@ tests:
     "devices": 1}, {"table": "TOTAL", "first_time": 1594390069872, "latest_time":
     1594793458299, "intervals": 135, "all rows": 864, "namespaces": 1, "devices":
     1}]'
-- command: table describe --format=json --namespace=single-attach_bgp_unnumbered
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_bgp_unnumbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_evpn_centralized-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_evpn_centralized-samples/table.yml
@@ -136,8 +136,3 @@ tests:
     1, "all rows": 24, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time":
     1594386755273, "latest_time": 1594793458372, "intervals": 131, "all rows": 976,
     "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=single-attach_evpn_centralized
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_evpn_centralized/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_evpn_distributed-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_evpn_distributed-samples/table.yml
@@ -137,8 +137,3 @@ tests:
     "devices": 1}, {"table": "TOTAL", "first_time": 1594386286625, "latest_time":
     1594793458445, "intervals": 134, "all rows": 1128, "namespaces": 1, "devices":
     1}]'
-- command: table describe --format=json --namespace=single-attach_evpn_distributed
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_evpn_distributed/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_evpn_ospf-ibgp-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_evpn_ospf-ibgp-samples/table.yml
@@ -152,8 +152,3 @@ tests:
     rows": 32, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time": 1594385818743,
     "latest_time": 1594793458421, "intervals": 133, "all rows": 1200, "namespaces":
     1, "devices": 1}]'
-- command: table describe --format=json --namespace=single-attach_evpn_ospf-ibgp
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_evpn_ospf-ibgp/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_ospf_docker-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_ospf_docker-samples/table.yml
@@ -129,8 +129,3 @@ tests:
     0, "devices": 0}, {"table": "TOTAL", "first_time": 1594387419879, "latest_time":
     1594793458545, "intervals": 117, "all rows": 736, "namespaces": 1, "devices":
     1}]'
-- command: table describe --format=json --namespace=single-attach_ospf_docker
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_ospf_docker/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_ospf_numbered-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_ospf_numbered-samples/table.yml
@@ -132,8 +132,3 @@ tests:
     "intervals": 1, "all rows": 16, "namespaces": 1, "devices": 1}, {"table": "TOTAL",
     "first_time": 1594388905410, "latest_time": 1594793458575, "intervals": 120, "all
     rows": 944, "namespaces": 1, "devices": 1}]'
-- command: table describe --format=json --namespace=single-attach_ospf_numbered
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_ospf_numbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/all_cndcn/single-attach_ospf_unnumbered-samples/table.yml
+++ b/tests/integration/all_cndcn/single-attach_ospf_unnumbered-samples/table.yml
@@ -133,8 +133,3 @@ tests:
     rows": 16, "namespaces": 1, "devices": 1}, {"table": "TOTAL", "first_time": 1594387702485,
     "latest_time": 1594793458570, "intervals": 128, "all rows": 872, "namespaces":
     1, "devices": 1}]'
-- command: table describe --format=json --namespace=single-attach_ospf_unnumbered
-  data-directory: /tmp/suzieq-tests-parquet/single-attach_ospf_unnumbered/parquet-out
-  error:
-    error: '[{"error": "ERROR: Must specify a table"}]'
-  marks: table describe

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -601,23 +601,6 @@ tests:
     {"type": "array", "items": {"type": "float", "name": "wrQsize"}}, "key": "", "display":
     7, "description": "[min, max, avg] of write queue size, computed over the greater
     between the last 5 mins and the polling period"}]'
-- command: table describe --table=network --format=json
-  data-directory: tests/data/parquet
-  marks: table describe
-  output: '[{"name": "bondMembers", "type": "string", "key": "", "display": 7, "description":
-    "Member ports of a bond interface"}, {"name": "hostname", "type": "string", "key":
-    "", "display": 1, "description": "Hostname associated with this record"}, {"name":
-    "ifname", "type": "string", "key": "", "display": 6, "description": "Interface
-    name"}, {"name": "ipAddress", "type": "string", "key": "", "display": 3, "description":
-    "Interface IP address"}, {"name": "l2miss", "type": "boolean", "key": "", "display":
-    9, "description": "MAC address not found for address"}, {"name": "macaddr", "type":
-    "string", "key": "", "display": 5, "description": "Interface mac address"}, {"name":
-    "namespace", "type": "string", "key": "", "display": 0, "description": "Namespace
-    associated with this record"}, {"name": "type", "type": "string", "key": "", "display":
-    8, "description": "How is this address connected to network"}, {"name": "vlan",
-    "type": "float", "key": "", "display": 4, "description": "Interface vlan"}, {"name":
-    "vrf", "type": "string", "key": "", "display": 2, "description": "VRF associated
-    with session"}]'
 - command: table describe --format=json
   data-directory: tests/data/parquet
   marks: table describe
@@ -633,8 +616,3 @@ tests:
     {"name": "sqvers", "type": "string", "key": "", "display": "", "description":
     "Schema version, not selectable"}, {"name": "table", "type": "string", "key":
     "", "display": 1, "description": "Table name"}]'
-- command: table describe --table=floop --format=json
-  data-directory: tests/data/parquet
-  error:
-    error: '[{"error": "ERROR: incorrect table name floop"}]'
-  marks: table describe

--- a/tests/integration/sqcmds/cumulus-samples/table.yml
+++ b/tests/integration/sqcmds/cumulus-samples/table.yml
@@ -200,42 +200,6 @@ tests:
     "allRows": 20, "namespaceCnt": 2, "deviceCnt": 6}, {"table": "TOTAL", "firstTime":
     1616352402449, "lastTime": 1652587637124, "intervals": 376, "allRows": 2724, "namespaceCnt":
     2, "deviceCnt": 14}]'
-- command: table describe --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
-  data-directory: tests/data/parquet/
-  marks: table describe
-  output: '[{"name": "allRows", "type": "long", "key": "", "display": 5, "description":
-    "Total number of records across all time"}, {"name": "deviceCnt", "type": "long",
-    "key": "", "display": 7, "description": "Total number of devices in database"},
-    {"name": "firstTime", "type": "float", "key": "", "display": 2, "description":
-    "Timestamp of first entry in database"}, {"name": "intervals", "type": "long",
-    "key": "", "display": 4, "description": "Number of records in latest entry"},
-    {"name": "lastTime", "type": "float", "key": "", "display": 3, "description":
-    "Timestamp of last entry in database"}, {"name": "namespaceCnt", "type": "long",
-    "key": "", "display": 6, "description": "Total number of namespaces in database"},
-    {"name": "sqvers", "type": "string", "key": "", "display": "", "description":
-    "Schema version, not selectable"}, {"name": "table", "type": "string", "key":
-    "", "display": 1, "description": "Table name"}]'
-- command: table describe --namespace=dual-evpn --format=json
-  data-directory: tests/data/parquet/
-  marks: table describe
-  output: '[{"name": "allRows", "type": "long", "key": "", "display": 5, "description":
-    "Total number of records across all time"}, {"name": "deviceCnt", "type": "long",
-    "key": "", "display": 7, "description": "Total number of devices in database"},
-    {"name": "firstTime", "type": "float", "key": "", "display": 2, "description":
-    "Timestamp of first entry in database"}, {"name": "intervals", "type": "long",
-    "key": "", "display": 4, "description": "Number of records in latest entry"},
-    {"name": "lastTime", "type": "float", "key": "", "display": 3, "description":
-    "Timestamp of last entry in database"}, {"name": "namespaceCnt", "type": "long",
-    "key": "", "display": 6, "description": "Total number of namespaces in database"},
-    {"name": "sqvers", "type": "string", "key": "", "display": "", "description":
-    "Schema version, not selectable"}, {"name": "table", "type": "string", "key":
-    "", "display": 1, "description": "Table name"}]'
-- command: table describe --table=floop --format=json --namespace='ospf-single dual-evpn
-    ospf-ibgp'
-  data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: incorrect table name floop"}]'
-  marks: table describe
 - command: table unique --format=json --namespace='ospf-single dual-evpn ospf-ibgp'
   data-directory: tests/data/parquet/
   marks: table unique

--- a/tests/integration/sqcmds/nxos-samples/table.yml
+++ b/tests/integration/sqcmds/nxos-samples/table.yml
@@ -108,21 +108,6 @@ tests:
     "allRows": 4, "namespaceCnt": 1, "deviceCnt": 1}, {"table": "TOTAL", "firstTime":
     1619275257018, "lastTime": 1658656300612, "intervals": 13, "allRows": 172, "namespaceCnt":
     1, "deviceCnt": 1}]'
-- command: table describe --format=json --namespace=nxos
-  data-directory: tests/data/parquet/
-  marks: table describe nxos
-  output: '[{"name": "allRows", "type": "long", "key": "", "display": 5, "description":
-    "Total number of records across all time"}, {"name": "deviceCnt", "type": "long",
-    "key": "", "display": 7, "description": "Total number of devices in database"},
-    {"name": "firstTime", "type": "float", "key": "", "display": 2, "description":
-    "Timestamp of first entry in database"}, {"name": "intervals", "type": "long",
-    "key": "", "display": 4, "description": "Number of records in latest entry"},
-    {"name": "lastTime", "type": "float", "key": "", "display": 3, "description":
-    "Timestamp of last entry in database"}, {"name": "namespaceCnt", "type": "long",
-    "key": "", "display": 6, "description": "Total number of namespaces in database"},
-    {"name": "sqvers", "type": "string", "key": "", "display": "", "description":
-    "Schema version, not selectable"}, {"name": "table", "type": "string", "key":
-    "", "display": 1, "description": "Table name"}]'
 - command: table unique --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: table unique nxos

--- a/tests/integration/sqcmds/panos-samples/table.yml
+++ b/tests/integration/sqcmds/panos-samples/table.yml
@@ -122,11 +122,6 @@ tests:
     1639476254419, "intervals": 4, "allRows": 14, "namespaceCnt": 1, "deviceCnt":
     6}, {"table": "TOTAL", "firstTime": 1639476253357, "lastTime": 1652587501957,
     "intervals": 216, "allRows": 1609, "namespaceCnt": 1, "deviceCnt": 14}]'
-- command: table describe --table=floop --format=json --namespace=panos
-  data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: incorrect table name floop"}]'
-  marks: table describe
 - command: table unique --format=json --namespace=panos
   data-directory: tests/data/parquet/
   marks: table unique

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -403,8 +403,6 @@ def get_supported_verbs(sqobj: SqObject) -> List[str]:
             supported_verbs = [e.value for e in CommonExtraVerbs]
         else:
             supported_verbs = [e.value for e in CommonVerbs]
-        if sqobj.table == 'tables':
-            supported_verbs.append('describe')
 
     if sqobj.table == 'network':
         supported_verbs += [e.value for e in NetworkVerbs]

--- a/tests/integration/test_sqcmds.py
+++ b/tests/integration/test_sqcmds.py
@@ -264,9 +264,10 @@ def test_context_start_time_filtering(setup_nubia, get_cmd_object_dict, cmd):
 
 
 @pytest.mark.sqcmds
-@pytest.mark.parametrize('table', TABLES)
-def test_table_describe(setup_nubia, table):
-    out = _test_command('TableCmd', 'describe', {"table": table})
+@pytest.mark.describe
+@pytest.mark.table
+def test_table_describe(setup_nubia):
+    out = _test_command('TableCmd', 'describe', None)
     assert out == 0
 
 


### PR DESCRIPTION
## Description

Remove the `table` command `describe` from the commands allowed in SuzieQ. 
The same result of `table describe [table={other}]` can be returned using `{other} describe`
This change also affects REST server

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
