### PR TITLE
Fix Junos SRX/MX, ios and nxos parsing issues

### DIFF
--- a/suzieq/config/bgp.yml
+++ b/suzieq/config/bgp.yml
@@ -166,7 +166,7 @@ apply:
           "TABLE_peraf/ROW_peraf/[*]?/TABLE_persaf/ROW_persaf/[*]/pfxsent: pfxSent?|0",
           "TABLE_peraf/ROW_peraf/[*]?/TABLE_persaf/ROW_persaf/[*]/sendextcommunity: extendComm?|",
           "TABLE_peraf/ROW_peraf/[*]?/TABLE_persaf/ROW_persaf/[*]/sendextcommunity: sendComm?|",
-          "TABLE_peraf/ROW_peraf/[0]?/TABLE_persaf/ROW_persaf/[*]/rrconfigured: rrclient?|",
+          "TABLE_peraf/ROW_peraf/[0]?/TABLE_persaf/ROW_persaf/[*]/rrconfigured: rrclient?|[],
           "TABLE_peraf/ROW_peraf/[0]?/TABLE_persaf/ROW_persaf/[*]/firstconvgtime: _firstconvgtime",
           "TABLE_peraf/ROW_peraf/[*]?/TABLE_persaf/ROW_persaf/[*]/defaultoriginate: defaultOrig",
           "TABLE_peraf/ROW_peraf/[*]?/TABLE_persaf/ROW_persaf/[*]/insoftreconfigallowed: softReconfig",

--- a/suzieq/config/macs.yml
+++ b/suzieq/config/macs.yml
@@ -52,7 +52,7 @@ apply:
     version: all
     command: show bridge mac-table | display json | no-more
     normalize: 'l2ald-rtb-macdb/[0]/l2ald-mac-entry/*/[
-    "l2-mac-routing-instance/[0]/data: bd?|",
+    "l2-mac-bridging-domain/[0]/data: bd?|",
     "l2-bridge-vlan/[0]/data: vlan",
     "l2-mac-entry/[*]/l2-mac-address/[0]/data: macaddr",
     "l2-mac-entry/[*]/l2-mac-logical-interface/[0]/data: oif",

--- a/suzieq/config/routes.yml
+++ b/suzieq/config/routes.yml
@@ -93,24 +93,25 @@ apply:
     copy: junos-qfx
 
   junos-mx:
-      - command: show route protocol direct | display json | no-more
-        normalize: 'route-information/[0]/route-table/*:table-name:vrf/rt/*/[
-        "rt-destination/[0]/data: prefix",
-        "rt-prefix-length/[0]/data: _rtlen?|0",
-        "rt-entry/[0]/protocol-name/[0]/data: protocol",
-        "rt-entry/[0]/preference/[0]/data: preference?|0",
-        "rt-entry/[0]/age/[0]/attributes: statusChangeTimestamp?|",
-        "rt-entry/[0]/metric/[0]/data: metric?|0",
-        "rt-entry/[0]/active-tag/[0]/data: _activeTag",
-        "rt-entry/[0]/as-path/[0]/data: asPathList?|[]",
-        "rt-entry/[0]/validation-state/[0]/data: validState?|",
-        "rt-entry/[0]/nh/[*]/to/[0]/data: nexthopIps",
-        "rt-entry/[0]/nh/[*]/via/[0]/data: oifs",
-        "rt-entry/[0]/nh/[0]/nh-local-interface/[0]/data: _localif?|",
-        "rt-entry/[0]/nh-type/[0]/data: action?|forward",
-        "rt-entry/[0]/rt-tag/[0]/data: routeTag?|",
-        "hardwareProgrammed: hardwareProgrammed?|unknown",
-        ]'
+    version: all
+    command: show route protocol direct | display json | no-more
+    normalize: 'route-information/[0]/route-table/*:table-name:vrf/rt/*/[
+    "rt-destination/[0]/data: prefix",
+    "rt-prefix-length/[0]/data: _rtlen?|0",
+    "rt-entry/[0]/protocol-name/[0]/data: protocol",
+    "rt-entry/[0]/preference/[0]/data: preference?|0",
+    "rt-entry/[0]/age/[0]/attributes: statusChangeTimestamp?|",
+    "rt-entry/[0]/metric/[0]/data: metric?|0",
+    "rt-entry/[0]/active-tag/[0]/data: _activeTag",
+    "rt-entry/[0]/as-path/[0]/data: asPathList?|[]",
+    "rt-entry/[0]/validation-state/[0]/data: validState?|",
+    "rt-entry/[0]/nh/[*]/to/[0]/data: nexthopIps",
+    "rt-entry/[0]/nh/[*]/via/[0]/data: oifs",
+    "rt-entry/[0]/nh/[0]/nh-local-interface/[0]/data: _localif?|",
+    "rt-entry/[0]/nh-type/[0]/data: action?|forward",
+    "rt-entry/[0]/rt-tag/[0]/data: routeTag?|",
+    "hardwareProgrammed: hardwareProgrammed?|unknown",
+    ]'
 
   junos-es:
     copy: junos-qfx

--- a/suzieq/config/vlan.yml
+++ b/suzieq/config/vlan.yml
@@ -81,7 +81,7 @@ apply:
     normalize: 'l2ald-bridge-instance-information/l2ald-bridge-instance-group/*/[
     "l2rtb-bridge-vlan/[0]/data: vlan",
     "l2rtb-interface-name/*/data: interfaces?|",
-    "l2rtb-bridging-domain/[0]/data: vlanName",
+    "l2rtb-name/[0]/data: vlanName?|",
     "l2rtb-instance-state/[0]/data: state",
     ]'
 

--- a/suzieq/engines/pandas/bgp.py
+++ b/suzieq/engines/pandas/bgp.py
@@ -122,8 +122,8 @@ class BgpObj(SqPandasEngine):
 
         self._summarize_on_add_with_query = [
             ('failedPeerCnt', 'state == "NotEstd"', 'peer'),
-            ('iBGPPeerCnt', 'asn == peerAsn', 'peer'),
-            ('eBGPPeerCnt', 'asn != peerAsn', 'peer'),
+            ('iBGPPeerCnt', 'asn == peerAsn', 'peer', 'count'),
+            ('eBGPPeerCnt', 'asn != peerAsn', 'peer', 'count'),
             ('rrClientPeerCnt', 'rrclient.str.lower() == "true"', 'peer',
              'count'),
         ]

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1846,7 +1846,8 @@ class JunosNode(Node):
                            ['attributes'])
             except Exception:
                 self.logger.warning(
-                    f'Unable to parse junos boot time from {data}')
+                    f'{self.address}:{self.port} Unable to parse junos boot '
+                    f'time from {data}')
                 timestr = '{"junos:seconds": "0"}'
             self.bootupTimestamp = (get_timestamp_from_junos_time(
                 timestr, output[0]['timestamp']/1000)/1000)

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1853,7 +1853,7 @@ class JunosNode(Node):
 
         if (len(output) > 1) and (output[1]["status"] == 0):
             data = output[1]["data"]
-            hmatch = re.search(r'\nHostname:\s+(\S+)\n', data)
+            hmatch = re.search(r'\bHostname:\s+(\S+)\b', data)
             if hmatch:
                 self._set_hostname(hmatch.group(1))
 

--- a/suzieq/poller/worker/services/bgp.py
+++ b/suzieq/poller/worker/services/bgp.py
@@ -219,9 +219,9 @@ class BgpService(Service):
                 new_entry['pfxSuppressRx'] = 0
                 for table in val:
                     vrf = table
-                    if vrf == "inet.0":
+                    if vrf.startswith("inet."):
                         vrf = "default"
-                    elif vrf == "inet6.0":
+                    elif vrf.startswith("inet6."):
                         vrf = "default"
                     elif vrf == "bgp.evpn.0":
                         vrf = "default"

--- a/suzieq/poller/worker/services/bgp.py
+++ b/suzieq/poller/worker/services/bgp.py
@@ -339,7 +339,8 @@ class BgpService(Service):
                 entry.pop('afAdvertised')
                 entry.pop('afRcvd')
 
-            if entry.get('rrclient', ''):
+            rrclient = entry.get('rrclient', [])
+            if rrclient and 'true' in rrclient:
                 entry['rrclient'] = 'True'
             else:
                 entry['rrclient'] = 'False'

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -398,11 +398,12 @@ class InterfaceService(Service):
                     vlan = int(vlan)
                     if vlan > 4095:
                         vlan = 0
+                        iftype = 'internal'
                 else:
                     vlan = 0
                     iftype = entry['type']
 
-                if iftype == 'subinterface':
+                if iftype == 'subinterface' or lifname.endswith(".0"):
                     speed = lentry \
                         .get('logical-interface-bandwidth', [{}])[0] \
                         .get('data', entry.get('speed', MISSING_SPEED))

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -497,14 +497,18 @@ class InterfaceService(Service):
                     laddr = elem.get("ifa-local")[0]["data"]
                     if ':' in laddr:
                         plen = (elem.get("ifa-destination",
-                                         [{"data": "0/128"}])[0]
-                                ["data"].split("/")[1])
-                        v6addresses.append(f'{laddr}/{plen}')
+                                         [{"data": "0/128"}])[0]["data"])
+                        if '/' in plen:
+                            v6addresses.append(f'{laddr}/{plen.split("/")[1]}')
+                        else:
+                            v6addresses.append(f'{laddr}/128')
                     else:
                         plen = (elem.get("ifa-destination",
-                                         [{"data": "0/32"}])[0]
-                                ["data"].split("/")[1])
-                        v4addresses.append(f'{laddr}/{plen}')
+                                         [{"data": "0/32"}])[0]["data"])
+                        if '/' in plen:
+                            v4addresses.append(f'{laddr}/{plen.split("/")[1]}')
+                        else:
+                            v4addresses.append(f'{laddr}/32')
                 vlanName = lentry.get('irb-domain', [{}])[0] \
                     .get('irb-bridge', [{}])[0] \
                     .get('data', '')

--- a/suzieq/poller/worker/services/macs.py
+++ b/suzieq/poller/worker/services/macs.py
@@ -111,7 +111,15 @@ class MacsService(Service):
                 for j, mac in enumerate(maclist):
                     new_entry = entry.copy()
                     new_entry['macaddr'] = mac
-                    new_entry['oif'] = oifs[j].split('.')[0]
+                    if not entry['bd']:
+                        if '.' in oifs[j]:
+                            new_entry['oif'], new_entry['vlan'] = \
+                                oifs[j].split('.')
+                        else:
+                            new_entry['oif'] = oifs[j].split('.')[0]
+                    else:
+                        new_entry['oif'] = oifs[j]
+
                     new_entry['flags'] = ''
                     self._add_mackey_protocol(new_entry)
                     new_entries.append(new_entry)

--- a/suzieq/poller/worker/services/routes.py
+++ b/suzieq/poller/worker/services/routes.py
@@ -115,6 +115,10 @@ class RoutesService(Service):
                 drop_entries_idx.append(i)
                 continue
 
+            if entry.get('prefix', None) is None:
+                drop_entries_idx.append(i)
+                continue
+
             vrf = entry.pop("vrf")[0]['data']
             if vrf == "inet.0":
                 vrf = "default"

--- a/suzieq/poller/worker/services/svcparser.py
+++ b/suzieq/poller/worker/services/svcparser.py
@@ -282,7 +282,10 @@ def cons_recs_from_json_template(tmplt_str, in_data):
                         # starting string: 'vrfs/*/peerList/*/[ by
                         # merging the rest lists
                         for entry in result[1:]:
-                            tmpres[0]['rest'].extend(entry[0]['rest'])
+                            # in case of junos routes, we sometimes end up with
+                            # {'rest': 'keepalive'} as an element. Ignore that
+                            if isinstance(tmpres[0]['rest'], list):
+                                tmpres[0]['rest'].extend(entry[0]['rest'])
                         result = tmpres
 
             tmplt_str = tmplt_str[pos + 1:]

--- a/suzieq/poller/worker/services/vlan.py
+++ b/suzieq/poller/worker/services/vlan.py
@@ -130,6 +130,7 @@ class VlanService(Service):
 
         vlan_dict = {}
         drop_indices = []
+        new_entries = []
 
         for i, entry in enumerate(processed_data):
             if entry.get('_entryType', '') == 'vlan':
@@ -164,9 +165,21 @@ class VlanService(Service):
                                   for k, j in enumerate(i.split('-'))]))
                      if '-' in i else [i]) for i in vlans.split(',')), [])
                 for vlan in vlans:
+                    # IOS allows declaring a native VLAN without it being
+                    # declared in show vlan. Handle that
+                    if str(vlan) not in vlan_dict:
+                        vlan_dict[str(vlan)] = {
+                            'vlan': vlan,
+                            'state': 'active',
+                            'vlanName': f'vlan{vlan}',
+                            'interfaces': []
+                        }
+                        new_entries.append(vlan_dict[str(vlan)])
                     vlan_dict[str(vlan)]['interfaces'].append(ifname)
 
         processed_data = np.delete(processed_data, drop_indices).tolist()
+        if new_entries:
+            processed_data.extend(new_entries)
         return processed_data
 
     def _clean_iosxe_data(self, processed_data, raw_data):

--- a/suzieq/poller/worker/services/vlan.py
+++ b/suzieq/poller/worker/services/vlan.py
@@ -109,12 +109,18 @@ class VlanService(Service):
             # We don't need the explicit .<vlan> tag for interfaces
             # to keep it consistent with the other devices, but we
             # cannot remove the VTEP info
-            entry['interfaces'] = [x.split('.')[0].replace('*', '')
-                                   if not x.startswith('vtep')
-                                   else x.replace('*', '')
-                                   for x in entry['interfaces']]
+
+            if entry['vlan'] != 'none':
+                # MX has no VLAN, just BD, and so don't strip vlan
+                # from interface name
+                entry['interfaces'] = [x.split('.')[0].replace('*', '')
+                                       if not x.startswith('vtep')
+                                       else x.replace('*', '')
+                                       for x in entry['interfaces']]
             entry['state'] = entry['state'].lower()
-            entry['vlanName'] = entry['vlanName'].lower()
+            name = entry.get('vlanName', '')
+            if name.startswith('Vlan'):
+                entry['vlanName'] = entry['vlanName'].lower()
 
         processed_data = np.delete(processed_data, drop_indices).tolist()
         return processed_data

--- a/tests/integration/test_parsing_bgp.py
+++ b/tests/integration/test_parsing_bgp.py
@@ -85,7 +85,8 @@ def validate_interfaces(df: pd.DataFrame, datadir: str):
     '''
 
     # Create a new df of namespace/hostname/vrf to oif mapping
-    only_oifs = df.groupby(by=['namespace', 'hostname'])['ifname'] \
+    only_oifs = df.query('state == "Established"') \
+                  .groupby(by=['namespace', 'hostname'])['ifname'] \
                   .unique() \
                   .reset_index() \
                   .explode('ifname') \
@@ -131,4 +132,4 @@ def test_bgp_parsing(table, datadir, get_table_data):
     validate_host_shape(df, ns_dict)
     validate_bgp_data(df)
     validate_interfaces(df.query('ifname != ""').reset_index(), datadir)
-    validate_vrfs(df, 'bgp', datadir)
+    validate_vrfs(df.query('state == "Established"'), 'bgp', datadir)


### PR DESCRIPTION
## Description

This PR fixes a bunch of parsing issues:

- Junos (closes #803)
  - Handle Junos routes corner case 
  - Handle Junos SRX show version correctly
  - Interfaces parser: handle /32 routes in SRX correctly
  - MAC Parser: Junos MX/SRX Fixes 
  - VLAN Parser: Junos SRX/MX BD fixes
  - Interfaces Parser: Junos fixes .0 interfaces & internal ifaces
  - fix boot time parsing error log with junos
- ios
  - Handle unspecified native VLANs 
- nxos
  - Set rrclient correctly 

- test_parsing_*.py updates to account for these changes and a few more to account for valid Junos scenarios

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)