### PR TITLE
gui: fix xplore page with non-default config path

### DIFF
--- a/suzieq/gui/stlit/xplore.py
+++ b/suzieq/gui/stlit/xplore.py
@@ -127,7 +127,9 @@ class XplorePage(SqGuiPage):
                 st.form_submit_button('Get', on_click=self._fetch_data)
 
             if state.table:
-                state.tables_obj = get_sqobject(state.table)()
+                state.tables_obj = get_sqobject(state.table)(
+                    config_file=self._config_file
+                )
                 fields = state.tables_obj.describe()
                 colist = sorted((filter(lambda x: x not in ['index', 'sqvers'],
                                         fields.name.tolist())))
@@ -558,7 +560,8 @@ class XplorePage(SqGuiPage):
 
         dfcols = sorted((filter(lambda x: x not in ['index', 'sqvers'],
                                 dfcols)))
-        uniq_clicked = get_sqobject(state.table)().unique_default_column[0]
+        uniq_clicked = get_sqobject(state.table)(
+            config_file=self._config_file).unique_default_column[0]
         if 'state' in dfcols:
             uniq_clicked = 'state'
         elif 'status' in dfcols:


### PR DESCRIPTION
## Description

When a configuration file was provided with the `-c` parameter, the explore page tried to retrieve the configuration file from the default location, so raising an error if there was no configuration file in the default location and reading the wrong one otherwise. This PR fixes this issue.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
