### PR TITLE
Initial Junos EVO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ One of Suzieq's powerful capabilities are asserts, which are statements that sho
 
 # Suzieq Data
 
-**Suzieq supports gathering data from Cumulus, EOS, IOS, IOSXE, IOSXR, JunOS(QFX, MX, EX, SRX supported), NXOS and SONIC routers, and Linux servers.** Suzieq gathers:
+**Suzieq supports gathering data from Cumulus, EOS, IOS, IOSXE, IOSXR, JunOS(QFX, EX, MX and SRX platforms and Evolved OS), Palo Alto's Panos (version 8.0 or higher), NXOS and SONIC routers, and Linux servers.** Suzieq gathers:
 
 * Basic device info including serial number, model, version, platform etc.
 * Interfaces

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,24 @@
 # Suzieq
 
-[**Suzieq**](https://github.com/netenglabs/suzieq/) is the first open source, multi-vendor network observability platform application. It is both a framework and an application using that framework, that is focused on 
-**improving your understanding of your network**.  We define observability as the ability of a system to 
-answer either trivial or complex questions that you pose as you go about operating your network. How easily 
-you can answer your questions is a measure of how good the system's observability is. A good observable 
+[**Suzieq**](https://github.com/netenglabs/suzieq/) is the first open source, multi-vendor network observability platform application. It is both a framework and an application using that framework, that is focused on
+**improving your understanding of your network**.  We define observability as the ability of a system to
+answer either trivial or complex questions that you pose as you go about operating your network. How easily
+you can answer your questions is a measure of how good the system's observability is. A good observable
 system goes well beyond what is normally considered monitoring and alerting. Suzieq is primarily meant for use by network engineers and designers.
 
 Suzieq does multiple things:
 
-* We [gather data](https://suzieq.readthedocs.io/en/latest/poller/) using an agentless model using either SSH or REST API as the transport. We gather data from routers, bridges and Linux servers. We support gathering data from Arista EOS, Cisco's IOS, IOS-XE, and IOS-XR platforms, Cisco's NXOS (N7K with versions 8.4.4 or higher, and N9K with versions 9.3.1 or higher), Cumulus Linux, Juniper's Junos(QFX, EX, MX and SRX platforms), Palo Alto's Panos (version 8.0 or higher) and SoNIC devices, besides Linux servers.
+* We [gather data](https://suzieq.readthedocs.io/en/latest/poller/) using an agentless model using either SSH or REST API as the transport. We gather data from routers, bridges and Linux servers. We support gathering data from Arista EOS, Cisco's IOS, IOS-XE, and IOS-XR platforms, Cisco's NXOS (N7K with versions 8.4.4 or higher, and N9K with versions 9.3.1 or higher), Cumulus Linux, Juniper's Junos(QFX, EX, MX and SRX platforms and Evolved OS), Palo Alto's Panos (version 8.0 or higher) and SoNIC devices, besides Linux servers.
 * We normalize the data into a vendor-agnostic format.
-* We store all data in files using the popular big data format, [Parquet](https://parquet.apache.org/). 
+* We store all data in files using the popular big data format, [Parquet](https://parquet.apache.org/).
 * All the analysis are exposed either via a CLI, [GUI](https://suzieq.readthedocs.io/en/latest/gui/), a [REST API](https://suzieq.readthedocs.io/en/latest/rest-server/), or via Python. The output can be rendered in various formats from plain text to JSON and CSV.
 * The analysis engine used in this release is pandas, though we have prototyped with other analysis engines.
 
-With the applications that we build on top of the framework we want to demonstrate a different and more 
+With the applications that we build on top of the framework we want to demonstrate a different and more
 systematic approach to thinking about networks. We want to show how useful it is to think of your network holistically.
 
-You can join the conversation via [slack](https://netenglabs.slack.com). Send email to Dinesh with the email address to send the Slack invitation to. 
+You can join the conversation via [slack](https://netenglabs.slack.com). Send email to Dinesh with the email address to send the Slack invitation to.
 
-We're also looking for collaborators to help us make Suzieq a truly useful multi-vendor, open source platform 
+We're also looking for collaborators to help us make Suzieq a truly useful multi-vendor, open source platform
 for observing all aspects of networking. Please read the [collaboration document](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md) for
 ideas on how you can help.

--- a/suzieq/config/arpnd.yml
+++ b/suzieq/config/arpnd.yml
@@ -91,6 +91,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-mx
+
   nxos:
      - version: < 9.3(0)
        command:

--- a/suzieq/config/bgp.yml
+++ b/suzieq/config/bgp.yml
@@ -248,6 +248,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   panos:
     version: all
     merge: False

--- a/suzieq/config/devconfig.yml
+++ b/suzieq/config/devconfig.yml
@@ -49,6 +49,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   sonic:
     version: all
     command: show runningconfiguration all

--- a/suzieq/config/device.yml
+++ b/suzieq/config/device.yml
@@ -134,6 +134,9 @@ apply:
   junos-qfx10k:
     copy: junos-mx
 
+  junos-evo:
+    copy: junos-mx
+
   panos:
     version: all
     command: <show><system><info/></system></show>

--- a/suzieq/config/evpnVni.yml
+++ b/suzieq/config/evpnVni.yml
@@ -97,6 +97,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   nxos:
     - version: '> 9.3(0)'
       command:

--- a/suzieq/config/interfaces.yml
+++ b/suzieq/config/interfaces.yml
@@ -142,6 +142,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   nxos:
     - version: < 9.3(0)
       command:

--- a/suzieq/config/inventory.yml
+++ b/suzieq/config/inventory.yml
@@ -47,6 +47,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   iosxe:
     version: all
     command: show inventory

--- a/suzieq/config/lldp.yml
+++ b/suzieq/config/lldp.yml
@@ -107,6 +107,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-mx
+
   nxos:
     - version: < 9.3(0)
       command: show lldp neighbors

--- a/suzieq/config/macs.yml
+++ b/suzieq/config/macs.yml
@@ -64,6 +64,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   nxos:
     - version: < 9.3(0)
       command: show mac address-table

--- a/suzieq/config/ospfIf.yml
+++ b/suzieq/config/ospfIf.yml
@@ -100,6 +100,9 @@ apply:
   junos-es:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   nxos:
     - version: < 9.3(0)
       command:

--- a/suzieq/config/ospfNbr.yml
+++ b/suzieq/config/ospfNbr.yml
@@ -90,6 +90,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   nxos:
     - version: < 9.3(0)
       command: show ip ospf neighbor detail vrf all

--- a/suzieq/config/routes.yml
+++ b/suzieq/config/routes.yml
@@ -118,6 +118,9 @@ apply:
   junos-qfx10k:
     copy: junos-qfx
 
+  junos-evo:
+    copy: junos-qfx
+
   nxos:
     - version: < 9.3(0)
       command: show ip route vrf all

--- a/suzieq/config/vlan.yml
+++ b/suzieq/config/vlan.yml
@@ -87,3 +87,6 @@ apply:
 
   junos-qfx10k:
     copy: junos-qfx
+
+  junos-evo:
+    copy: junos-qfx

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -366,6 +366,11 @@ class Node:
                         devtype = 'junos-es'
                 if not devtype:
                     devtype = "junos"
+            elif 'Junos: ' in data:
+                if re.search(r'-EVO\b', data):
+                    devtype = 'junos-evo'
+                else:
+                    devtype = 'junos'
             elif "NX-OS" in data:
                 devtype = "nxos"
             elif "SONiC" in data:
@@ -1868,10 +1873,14 @@ class JunosNode(Node):
 
     async def _fetch_init_dev_data_devtype(self, reconnect: bool):
         """Fill in the boot time of the node by running requisite cmd"""
-        await self._exec_cmd(self._parse_init_dev_data,
-                             ["show system uptime|display json",
-                              "show version"], None, 'mixed',
-                             reconnect=reconnect)
+        if self.devtype == 'junos-evo':
+            cmdlist = ["show system uptime|display json",
+                       'show version node all']
+        else:
+            cmdlist = ["show system uptime|display json",
+                       'show version']
+        await self._exec_cmd(self._parse_init_dev_data, cmdlist, None,
+                             "mixed", reconnect=reconnect)
 
     async def _parse_init_dev_data_devtype(self, output, cb_token) -> None:
         """Parse the uptime command output"""
@@ -1879,7 +1888,8 @@ class JunosNode(Node):
             data = output[0]["data"]
             try:
                 jdata = json.loads(data.replace('\n', '').strip())
-                if self.devtype not in ["junos-mx", "junos-qfx10k"]:
+                if self.devtype not in ["junos-mx", "junos-qfx10k",
+                                        "junos-evo"]:
                     jdata = (jdata['multi-routing-engine-results'][0]
                              ['multi-routing-engine-item'][0])
 
@@ -1897,6 +1907,10 @@ class JunosNode(Node):
             data = output[1]["data"]
             hmatch = re.search(r'\nHostname:\s+(\S+)\n', data)
             if hmatch:
+                # TODO
+                # In case of a VC, we'll need to strip off some chars
+                # at the end such as -re0 or -re1. Lets do this with a
+                # separate option passed via the inventory device setting.
                 self._set_hostname(hmatch.group(1))
 
             self._extract_nos_version(data)

--- a/suzieq/poller/worker/services/device.py
+++ b/suzieq/poller/worker/services/device.py
@@ -131,6 +131,22 @@ class DeviceService(Service):
             entry['bootupTimestamp'] = get_timestamp_from_junos_time(
                 entry['bootupTimestamp'], ms=False)
 
+            if entry.get('version', '').endswith('EVO'):
+                entry['os'] = 'junos-evo'
+                continue
+
+            model = entry.get('model', '')
+            if 'qfx10' in model:
+                entry['os'] = 'junos-qfx10k'
+            elif 'qfx' in model:
+                entry['os'] = 'junos-qfx'
+            elif model.startswith(('mx', 'vmx')):
+                entry['os'] = 'junos-mx'
+            elif 'ex' in model:
+                entry['os'] = 'junos-ex'
+            elif model.startswith(('srx', 'vSRX')):
+                entry['os'] = 'junos-es'
+
         return self._common_data_cleaner(processed_data, raw_data)
 
     def _clean_nxos_data(self, processed_data, raw_data):

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -851,8 +851,8 @@ def init_logger(logname: str,
 def known_devtypes() -> list:
     """Returns the list of known dev types"""
     return(['cumulus', 'eos', 'iosxe', 'iosxr', 'ios', 'junos-mx', 'junos-qfx',
-            'junos-qfx10k', 'junos-ex', 'junos-es', 'linux', 'nxos', 'sonic',
-            'panos'])
+            'junos-qfx10k', 'junos-ex', 'junos-es', 'junos-evo', 'linux',
+            'nxos', 'sonic', 'panos'])
 
 
 def humanize_timestamp(field: pd.Series, tz=None) -> pd.Series:


### PR DESCRIPTION
## Description

This PR introduces initial support for Junos EVO devices. The following services are available:

- aprnd
- bgp
- devconfig
- device
- evpnVni
- interfaces
- inventory
- lldp
- macs
- ospfIf
- ospfNbr
- routes
- vlan

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
