### PR TITLE
Analyzer bug fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -374,7 +374,7 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "coverage"
-version = "6.4.3"
+version = "7.0.4"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -2263,15 +2263,15 @@ pytz = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -2427,7 +2427,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">3.8.1, < 3.10"
-content-hash = "d4ec5f8bca35cf320a1e0424fd4df77bbd649dab67769eaa770527a76b1bc8a0"
+content-hash = "de5088fef88616bdd12f3a13f5f0cb782434a6b71e1554f4113a389022bc501d"
 
 [metadata.files]
 aiofiles = [
@@ -2659,47 +2659,57 @@ configargparse = [
     {file = "ConfigArgParse-0.15.2.tar.gz", hash = "sha256:558738aff623d6667aa5b85df6093ad3828867de8a82b66a6d458fb42567beb3"},
 ]
 coverage = [
-    {file = "coverage-6.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f50d3a822947572496ea922ee7825becd8e3ae6fbd2400cd8236b7d64b17f285"},
-    {file = "coverage-6.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d5191d53afbe5b6059895fa7f58223d3751c42b8101fb3ce767e1a0b1a1d8f87"},
-    {file = "coverage-6.4.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04010af3c06ce2bfeb3b1e4e05d136f88d88c25f76cd4faff5d1fd84d11581ea"},
-    {file = "coverage-6.4.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6630d8d943644ea62132789940ca97d05fac83f73186eaf0930ffa715fbdab6b"},
-    {file = "coverage-6.4.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05de0762c1caed4a162b3e305f36cf20a548ff4da0be6766ad5c870704be3660"},
-    {file = "coverage-6.4.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0e3a41aad5919613483aad9ebd53336905cab1bd6788afd3995c2a972d89d795"},
-    {file = "coverage-6.4.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a2738ba1ee544d6f294278cfb6de2dc1f9a737a780469b5366e662a218f806c3"},
-    {file = "coverage-6.4.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a0d2df4227f645a879010461df2cea6b7e3fb5a97d7eafa210f7fb60345af9e8"},
-    {file = "coverage-6.4.3-cp310-cp310-win32.whl", hash = "sha256:73a10939dc345460ca0655356a470dd3de9759919186a82383c87b6eb315faf2"},
-    {file = "coverage-6.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:53c8edd3b83a4ddba3d8c506f1359401e7770b30f2188f15c17a338adf5a14db"},
-    {file = "coverage-6.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f1eda5cae434282712e40b42aaf590b773382afc3642786ac3ed39053973f61f"},
-    {file = "coverage-6.4.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59fc88bc13e30f25167e807b8cad3c41b7218ef4473a20c86fd98a7968733083"},
-    {file = "coverage-6.4.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75314b00825d70e1e34b07396e23f47ed1d4feedc0122748f9f6bd31a544840"},
-    {file = "coverage-6.4.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52f8b9fcf3c5e427d51bbab1fb92b575a9a9235d516f175b24712bcd4b5be917"},
-    {file = "coverage-6.4.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5a559aab40c716de80c7212295d0dc96bc1b6c719371c20dd18c5187c3155518"},
-    {file = "coverage-6.4.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:306788fd019bb90e9cbb83d3f3c6becad1c048dd432af24f8320cf38ac085684"},
-    {file = "coverage-6.4.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:920a734fe3d311ca01883b4a19aa386c97b82b69fbc023458899cff0a0d621b9"},
-    {file = "coverage-6.4.3-cp37-cp37m-win32.whl", hash = "sha256:ab9ef0187d6c62b09dec83a84a3b94f71f9690784c84fd762fb3cf2d2b44c914"},
-    {file = "coverage-6.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:39ebd8e120cb77a06ee3d5fc26f9732670d1c397d7cd3acf02f6f62693b89b80"},
-    {file = "coverage-6.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bc698580216050b5f4a34d2cdd2838b429c53314f1c4835fab7338200a8396f2"},
-    {file = "coverage-6.4.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:877ee5478fd78e100362aed56db47ccc5f23f6e7bb035a8896855f4c3e49bc9b"},
-    {file = "coverage-6.4.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:555a498999c44f5287cc95500486cd0d4f021af9162982cbe504d4cb388f73b5"},
-    {file = "coverage-6.4.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eff095a5aac7011fdb51a2c82a8fae9ec5211577f4b764e1e59cfa27ceeb1b59"},
-    {file = "coverage-6.4.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5de1e9335e2569974e20df0ce31493d315a830d7987e71a24a2a335a8d8459d3"},
-    {file = "coverage-6.4.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:7856ea39059d75f822ff0df3a51ea6d76307c897048bdec3aad1377e4e9dca20"},
-    {file = "coverage-6.4.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:411fdd9f4203afd93b056c0868c8f9e5e16813e765de962f27e4e5798356a052"},
-    {file = "coverage-6.4.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:cdf7b83f04a313a21afb1f8730fe4dd09577fefc53bbdfececf78b2006f4268e"},
-    {file = "coverage-6.4.3-cp38-cp38-win32.whl", hash = "sha256:ab2b1a89d2bc7647622e9eaf06128a5b5451dccf7c242deaa31420b055716481"},
-    {file = "coverage-6.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:0e34247274bde982bbc613894d33f9e36358179db2ed231dd101c48dd298e7b0"},
-    {file = "coverage-6.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b104b6b1827d6a22483c469e3983a204bcf9c6bf7544bf90362c4654ebc2edf3"},
-    {file = "coverage-6.4.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:adf1a0d272633b21d645dd6e02e3293429c1141c7d65a58e4cbcd592d53b8e01"},
-    {file = "coverage-6.4.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff9832434a9193fbd716fbe05f9276484e18d26cc4cf850853594bb322807ac3"},
-    {file = "coverage-6.4.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:923f9084d7e1d31b5f74c92396b05b18921ed01ee5350402b561a79dce3ea48d"},
-    {file = "coverage-6.4.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d64304acf79766e650f7acb81d263a3ea6e2d0d04c5172b7189180ff2c023c"},
-    {file = "coverage-6.4.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:fc294de50941d3da66a09dca06e206297709332050973eca17040278cb0918ff"},
-    {file = "coverage-6.4.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a42eaaae772f14a5194f181740a67bfd48e8806394b8c67aa4399e09d0d6b5db"},
-    {file = "coverage-6.4.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4822327b35cb032ff16af3bec27f73985448f08e874146b5b101e0e558b613dd"},
-    {file = "coverage-6.4.3-cp39-cp39-win32.whl", hash = "sha256:f217850ac0e046ede611312703423767ca032a7b952b5257efac963942c055de"},
-    {file = "coverage-6.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:0a84376e4fd13cebce2c0ef8c2f037929c8307fb94af1e5dbe50272a1c651b5d"},
-    {file = "coverage-6.4.3-pp36.pp37.pp38-none-any.whl", hash = "sha256:068d6f2a893af838291b8809c876973d885543411ea460f3e6886ac0ee941732"},
-    {file = "coverage-6.4.3.tar.gz", hash = "sha256:ec2ae1f398e5aca655b7084392d23e80efb31f7a660d2eecf569fb9f79b3fb94"},
+    {file = "coverage-7.0.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:daf91db39324e9939a9db919ee4fb42a1a23634a056616dae891a030e89f87ba"},
+    {file = "coverage-7.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:55121fe140d7e42cb970999b93cf1c2b24484ce028b32bbd00238bb25c13e34a"},
+    {file = "coverage-7.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c027fbb83a8c78a6e06a0302ea1799fdb70e5cda9845a5e000545b8e2b47ea39"},
+    {file = "coverage-7.0.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:caf82db5b7f16b51ec32fe0bd2da0805b177c807aa8bfb478c7e6f893418c284"},
+    {file = "coverage-7.0.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ba5cc54baf3c322c4388de2a43cc95f7809366f0600e743e5aae8ea9d1038b2"},
+    {file = "coverage-7.0.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:260854160083f8275a9d9d49a05ab0ffc7a1f08f2ccccbfaec94a18aae9f407c"},
+    {file = "coverage-7.0.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ea45f0dba5a993e93b158f1a9dcfff2770e3bcabf2b80dbe7aa15dce0bcb3bf3"},
+    {file = "coverage-7.0.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6abc91f6f8b3cc0ae1034e2c03f38769fba1952ab70d0b26953aa01691265c39"},
+    {file = "coverage-7.0.4-cp310-cp310-win32.whl", hash = "sha256:053cdc47cae08257051d7e934a0de4d095b60eb8a3024fa9f1b2322fa1547137"},
+    {file = "coverage-7.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:1e9e94f2612ee549a4b3ee79cbc61bceed77e69cf38cfa05858bae939a886d16"},
+    {file = "coverage-7.0.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5caa9dd91dcc5f054350dc57a02e053d79633907b9ccffff999568d13dcd19f8"},
+    {file = "coverage-7.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:efc200fa75d9634525b40babc7a16342bd21c101db1a58ef84dc14f4bf6ac0fd"},
+    {file = "coverage-7.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1791e5f74c5b52f76e83fe9f4bb9571cf76d40ee0c51952ee1e4ee935b7e98b9"},
+    {file = "coverage-7.0.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3d9201cfa5a98652b9cef36ab202f17fe3ea83f497b4ba2a8ed39399dfb8fcd4"},
+    {file = "coverage-7.0.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22d8ef6865cb6834cab2b72fff20747a55c714b57b675f7e11c9624fe4f7cb45"},
+    {file = "coverage-7.0.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b84076e3de192fba0f95e279ac017b64c7c6ecd4f09f36f13420f5bed898a9c7"},
+    {file = "coverage-7.0.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:dcfbf8ffc046f20d75fd775a92c378f6fc7b9bded6c6f2ab88b6b9cb5805a184"},
+    {file = "coverage-7.0.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4665a714af31f160403c2e448fb2fef330719d2e04e836b08d60d612707c1041"},
+    {file = "coverage-7.0.4-cp311-cp311-win32.whl", hash = "sha256:2e59aef3fba5758059208c9eff10ae7ded3629e797972746ec33b56844f69411"},
+    {file = "coverage-7.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:2b854f7985b48122b6fe346631e86d67b63293f8255cb59a93d79e3d9f1574e3"},
+    {file = "coverage-7.0.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e44b60b0b49aa85d548d392a2dca2c6a581cd4084e72e9e16bd58bd86ec20816"},
+    {file = "coverage-7.0.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2904d7a0388911c61e7e3beefe48c29dfccaba938fc1158f63190101a21e04c2"},
+    {file = "coverage-7.0.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bc74b64bfa89e2f862ea45dd6ac1def371d7cc883b76680d20bdd61a6f3daa20"},
+    {file = "coverage-7.0.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c06046f54e719da21c79f98ecc0962581d1aee0b3798dc6b12b1217da8bf93f4"},
+    {file = "coverage-7.0.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:bc9c77004970a364a1e5454cf7cb884e4277592b959c287689b2a0fd027ef552"},
+    {file = "coverage-7.0.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0815a09b32384e8ff00a5939ec9cd10efce8742347e019c2daca1a32f5ac2aae"},
+    {file = "coverage-7.0.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a78a80d131c067d67d8a6f9bd3d3f7ea7eac82c1c7259f97d7ab73f723da9d55"},
+    {file = "coverage-7.0.4-cp37-cp37m-win32.whl", hash = "sha256:2b5936b624fbe711ed02dfd86edd678822e5ee68da02b6d231e5c01090b64590"},
+    {file = "coverage-7.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:a63922765ee49d5b4c32afb2cd5516812c8665f3b78e64a0dd005bdfabf991b1"},
+    {file = "coverage-7.0.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d68f2f7bddb3acdd3b36ef7f334b9d14f30b93e094f808fbbd8d288b8f9e2f9b"},
+    {file = "coverage-7.0.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9dafdba3b2b9010abab08cb8c0dc6549bfca6e1630fe14d47b01dca00d39e694"},
+    {file = "coverage-7.0.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0322354757b47640535daabd2d56384ff3cad2896248fc84d328c5fad4922d5c"},
+    {file = "coverage-7.0.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e8267466662aff93d66fa72b9591d02122dfc8a729b0a43dd70e0fb07ed9b37"},
+    {file = "coverage-7.0.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f684d88eb4924ed0630cf488fd5606e334c6835594bb5fe36b50a509b10383ed"},
+    {file = "coverage-7.0.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:70c294bb15ba576fb96b580db35895bf03749d683df044212b74e938a7f6821f"},
+    {file = "coverage-7.0.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:34c0457e1ba450ae8b22dc8ea2fd36ada1010af61291e4c96963cd9d9633366f"},
+    {file = "coverage-7.0.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b75aff2c35ceaa299691e772f7bf7c8aeab25f46acea2be3dd04cccb914a9860"},
+    {file = "coverage-7.0.4-cp38-cp38-win32.whl", hash = "sha256:6c5554d55668381e131577f20e8f620d4882b04ad558f7e7f3f1f55b3124c379"},
+    {file = "coverage-7.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:c82f34fafaf5bc05d222fcf84423d6e156432ca35ca78672d4affd0c09c6ef6c"},
+    {file = "coverage-7.0.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b8dfb5fed540f77e814bf4ec79619c241af6b4578fa1093c5e3389bbb7beab3f"},
+    {file = "coverage-7.0.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee32a080bab779b71c4d09a3eb5254bfca43ee88828a683dab27dfe8f582516e"},
+    {file = "coverage-7.0.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dfbee0bf0d633be3a2ab068f5a5731a70adf147d0ba17d9f9932b46c7c5782b"},
+    {file = "coverage-7.0.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32dc010713455ac0fe2fddb0e48aa43875cc7eb7b09768df10bad8ce45f9c430"},
+    {file = "coverage-7.0.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9cb88a3019ad042eaa69fc7639ef077793fedbf313e89207aa82fefe92c97ebd"},
+    {file = "coverage-7.0.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:73bc6114aab7753ca784f87bcd3b7613bc797aa255b5bca45e5654070ae9acfb"},
+    {file = "coverage-7.0.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:92f135d370fcd7a6fb9659fa2eb716dd2ca364719cbb1756f74d90a221bca1a7"},
+    {file = "coverage-7.0.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f3d485e6ec6e09857bf2115ece572d666b7c498377d4c70e66bb06c63ed177c2"},
+    {file = "coverage-7.0.4-cp39-cp39-win32.whl", hash = "sha256:c58921fcd9914b56444292e7546fe183d079db99528142c809549ddeaeacd8e9"},
+    {file = "coverage-7.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:f092d9f2ddaa30235d33335fbdb61eb8f3657af519ef5f9dd6bdae65272def11"},
+    {file = "coverage-7.0.4-pp37.pp38.pp39-none-any.whl", hash = "sha256:cb8cfa3bf3a9f18211279458917fef5edeb5e1fdebe2ea8b11969ec2ebe48884"},
+    {file = "coverage-7.0.4.tar.gz", hash = "sha256:f6c4ad409a0caf7e2e12e203348b1a9b19c514e7d078520973147bf2d3dcbc6f"},
 ]
 cryptography = [
     {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:ef15c2df7656763b4ff20a9bc4381d8352e6640cfeb95c2972c38ef508e75181"},
@@ -3997,8 +4007,8 @@ tzlocal = [
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+    {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},
+    {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]
 uvicorn = [
     {file = "uvicorn-0.14.0-py3-none-any.whl", hash = "sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ xmltodict = "^0.12.0"
 streamlit-aggrid = "^0.2.2"
 ciscoconfparse = "^1.6.21"
 notebook = "6.4.12"
+urllib3 = "^1.26.12"
 
 [tool.poetry.dev-dependencies]
 pylint = "*"

--- a/suzieq/cli/sqcmds/command.py
+++ b/suzieq/cli/sqcmds/command.py
@@ -474,6 +474,13 @@ class SqTableCommand(SqCommand):
             **self.lvars,
             **kwargs
         )
+
+        # for readability syntesize output when dict has more than 3 items
+        for index, row in summarize_df.iterrows():
+            for col in summarize_df:
+                if isinstance(row[col], dict) and len(row[col]) > 3:
+                    summarize_df.loc[index, col] = len(row[col])
+
         self.ctxt.exec_time = "{:5.4f}s".format(time.time() - now)
         return self._gen_output(summarize_df, json_orient='columns')
 

--- a/suzieq/engines/pandas/device.py
+++ b/suzieq/engines/pandas/device.py
@@ -109,10 +109,10 @@ class DeviceObj(SqPandasEngine):
                            self.cfg.get('analyzer', {}).get('timezone',
                                                             None)))
             uptime_cols = pd.to_timedelta(uptime_cols, unit='s')
-            df.insert(len(df.columns)-1, 'uptime', uptime_cols)
+            df['uptime'] = uptime_cols
 
         if df.empty:
-            return df
+            return df.reset_index(drop=True)[fields]
 
         # The poller merge kills the filtering we did earlier, so redo:
         if status:

--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -622,21 +622,13 @@ class SqPandasEngine(SqEngineObj):
         if not field_name:
             field_name = field
 
-        count_per_ns = self.nsgrp[field].nunique()
-
         for n in self.ns.keys():
-            if 3 >= count_per_ns[n] > 0:
-                # can't do a value_counts on all groups, incase one of the
-                # groups other groups doesn't have data
-                unique_for_ns = self.nsgrp.get_group(n)[field].value_counts()
-                value = unique_for_ns.to_dict()
-                # Filter numm entries if category because of how pandas
-                # behaves here
-                if self.nsgrp[field].dtype[n].name == 'category':
-                    value = dict(filter(lambda x: x[1] != 0, value.items()))
-
-            else:
-                value = count_per_ns[n]
+            unique_for_ns = self.nsgrp.get_group(n)[field].value_counts()
+            value = unique_for_ns.to_dict()
+            # Filter numm entries if category because of how pandas
+            # behaves here
+            if self.nsgrp[field].dtype[n].name == 'category':
+                value = dict(filter(lambda x: x[1] != 0, value.items()))
 
             self.ns[n].update({field_name: value})
 

--- a/suzieq/engines/pandas/fs.py
+++ b/suzieq/engines/pandas/fs.py
@@ -13,6 +13,9 @@ class FsObj(SqPandasEngine):
         columns = kwargs.get('columns', ['default'])
         fields = self.schema.get_display_fields(columns)
 
+        self._add_active_to_fields(
+            kwargs.get('view', self.iobj.view), fields, [])
+
         df = super().get(**kwargs)
 
         if df.empty:

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -119,27 +119,17 @@ class OspfObj(SqPandasEngine):
                 df['ipAddress_x'] == "",
                 df['ipAddress_y'], df['ipAddress_x'])
 
-        if columns == ['*']:
-            df = df.drop(columns=['area_y', 'instance_y', 'vrf_y',
-                                  'ipAddress_x', 'ipAddress_y', 'areaStub_y',
-                                  'sqvers_x', 'timestamp_y'],
-                         errors='ignore') \
-                .rename(columns={
-                    'instance_x': 'instance', 'areaStub_x': 'areaStub',
-                    'area_x': 'area', 'vrf_x': 'vrf',
-                    'state_x': 'ifState', 'state_y': 'adjState',
-                    'active_x': 'active', 'timestamp_x': 'timestamp'}) \
-                .fillna({'peerIP': '-', 'numChanges': 0,
-                         'lastChangeTime': 0})
-        else:
-            df = df.rename(columns={'vrf_x': 'vrf', 'area_x': 'area',
-                                    'state_x': 'ifState',
-                                    'state_y': 'adjState',
-                                    'timestamp_x': 'timestamp'})
-            df = df.drop(list(df.filter(regex='_y$')), axis=1) \
-                   .drop(columns=['ipAddress_x'], errors='ignore') \
-                   .fillna({'peerIP': '-', 'numChanges': 0,
-                            'lastChangeTime': 0})
+        df = df.rename(columns={
+            'instance_x': 'instance', 'areaStub_x': 'areaStub',
+            'area_x': 'area', 'vrf_x': 'vrf',
+            'state_x': 'ifState', 'state_y': 'adjState',
+            'active_x': 'active', 'timestamp_x': 'timestamp'})
+
+        df = df.drop(columns=list(df.filter(regex='_y$|_x$')),
+                     errors='ignore') \
+            .fillna({'peerIP': '-', 'numChanges': 0,
+                     'lastChangeTime': 0})
+
         if df.empty:
             return df
 
@@ -166,8 +156,6 @@ class OspfObj(SqPandasEngine):
             df.drop(columns=['passive'], inplace=True)
 
         final_df = df
-        if 'active_x' in final_df.columns:
-            final_df = final_df.rename(columns={'active_x': 'active'})
         if 'peerHostname' in cols or 'peerIfname' in cols:
             final_df = self._get_peernames(final_df, cols, hostname=hostname,
                                            **kwargs)

--- a/suzieq/restServer/query.py
+++ b/suzieq/restServer/query.py
@@ -366,6 +366,7 @@ def query_device(verb: CommonVerbs, request: Request,
                  version: List[str] = Query(None),
                  what: str = None,
                  status: List[DeviceStatus] = Query(None),
+                 ignore_neverpoll: bool = None,
                  count: str = None, reverse: str = None,
                  ):
     function_name = inspect.currentframe().f_code.co_name

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -248,15 +248,20 @@ def get_sensitive_data(input_method: str, ask_message: str = '') -> str:
 
 def sq_get_config_file(config_file):
     """Get the path to the suzieq config file"""
-
+    default_path = '{home}/.suzieq/suzieq-cfg.yml'
     if config_file:
         cfgfile = config_file
     elif os.path.exists("./suzieq-cfg.yml"):
         cfgfile = "./suzieq-cfg.yml"
-    elif os.path.exists(os.getenv("HOME") + "/.suzieq/suzieq-cfg.yml"):
-        cfgfile = os.getenv("HOME") + "/.suzieq/suzieq-cfg.yml"
+    elif (os.getenv('HOME')
+            and os.path.exists(default_path.format(home=os.getenv('HOME')))):
+        return default_path.format(home=os.getenv('HOME'))
     else:
-        cfgfile = None
+        if not os.getenv('HOME'):
+            logger.warning(
+                'Unable to determine the HOME directory, is $HOME env var '
+                'properly set?')
+        return None
     return cfgfile
 
 

--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -536,6 +536,12 @@ class SqObject(SqPlugin):
             return columns
         elif fun == 'summarize':
             return []
+        elif fun == 'get':
+            fields = self.schema.get_display_fields(columns)
+            if (kwargs.get('view', self.view) == 'all' and
+                    'active' not in fields):
+                fields.insert(0, 'active')
+            return fields
         return self.schema.get_display_fields(columns)
 
     def _is_result_empty(self, result: pd.DataFrame) -> bool:

--- a/suzieq/sqobjects/path.py
+++ b/suzieq/sqobjects/path.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from suzieq.sqobjects.basicobj import SqObject
 
 
@@ -10,3 +11,9 @@ class PathObj(SqObject):
                                 'vrf', 'src', 'dest', 'query_str']
         self._valid_summarize_args = ['namespace', 'hostname', 'src',
                                       'dest', 'vrf', 'query_str']
+
+    def get(self, **kwargs) -> pd.DataFrame:
+        view = kwargs.get('view', self.view)
+        if view == 'all':
+            raise AttributeError("Cannot use 'view=all' with this table")
+        return super().get(**kwargs)

--- a/suzieq/sqobjects/topology.py
+++ b/suzieq/sqobjects/topology.py
@@ -1,4 +1,6 @@
 from typing import List
+
+import pandas as pd
 from suzieq.sqobjects.basicobj import SqObject
 
 
@@ -20,6 +22,12 @@ class TopologyObj(SqObject):
         }
         self._valid_summarize_args = ['namespace', 'hostname', 'via',
                                       'query_str']
+
+    def get(self, **kwargs) -> pd.DataFrame:
+        view = kwargs.get('view', self.view)
+        if view == 'all':
+            raise AttributeError("Cannot use 'view=all' with this table")
+        return super().get(**kwargs)
 
     def _get_empty_cols(self, columns: List[str], fun: str, **kwargs) \
             -> List[str]:

--- a/tests/integration/sqcmds/common-samples/all.yml
+++ b/tests/integration/sqcmds/common-samples/all.yml
@@ -36553,3 +36553,14 @@ tests:
     "totalTime": [2106.0, 2106.0, 2106.0], "svcQsize": [0.0, 0.0, 0.0], "wrQsize":
     [120.0, 120.0, 120.0], "nodeQsize": [4.0, 4.0, 4.0], "rxBytes": [27779.0, 27779.0,
     27779.0], "pollExcdPeriodCount": 0, "timestamp": 1658656300675}]'
+- command: topology show --view=all --format=json
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Cannot use ''view=all'' with this table"}]'
+  marks: topology show all
+- command: path show --dest=172.16.2.102 --src=172.16.1.103 --namespace=dual-evpn
+    --view=all --format=json
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Cannot use ''view=all'' with this table"}]'
+  marks: path show all

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -571,9 +571,6 @@ def test_rest_arg_consistency(service, verb):
 
         valid_args = set(arglist)
 
-        if service == 'device':
-            valid_args.remove('ignore_neverpoll')
-
         # In the tests below, we warn when we don't have the exact
         # {service}_{verb} REST function, which prevents us from picking the
         # correct set of args.
@@ -693,8 +690,7 @@ def test_routes_sqobj_consistency():
             args_to_match = get_args_to_match(sqobj, route.verbs)
             args_to_match = {a for a in args_to_match
                              if a not in common_args.union(top_args)}
-            if table == 'device':
-                args_to_match.remove('ignore_neverpoll')
+
             if args_to_match != query_params:
                 assert False, (f'different query params for {table}: expected '
                                f'{args_to_match}. Got {query_params}')

--- a/tests/integration/test_sqcmds.py
+++ b/tests/integration/test_sqcmds.py
@@ -115,7 +115,7 @@ def test_namespace_show_filter(setup_nubia, get_cmd_object_dict, cmd):
     for cmd in cli_commands])
 def test_view_show_filter(setup_nubia, get_cmd_object_dict, cmd):
     s = _test_command(get_cmd_object_dict[cmd], 'show', None, {'view': 'all'})
-    if cmd != 'namespace':
+    if cmd not in ['namespace', 'topology', 'path']:
         assert s == 0
     else:
         assert s == 1


### PR DESCRIPTION
## Description

This PR fixes a bunch of issues on the analyzer side:

- Add the `ignore_neverpoll` filter under /device/show of the rest api that was available in cli and python API
- Reduce the output of the summarize only in the CLI. Python and REST apis always return a dictionary
- Improve renaming logic in pandas/ospf to avoid IndexError exception
- Fix the inclusion of the uptime columns in pandas/device
- Do not crash if the HOME variable is not set
- Add missing urllib3 dependency
- LLDP always returns hostname of the peerhost instead of FQDN

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)