### PR TITLE
Fix namespace filter matching when there is a partial match

### DIFF
--- a/suzieq/db/parquet/parquetdb.py
+++ b/suzieq/db/parquet/parquetdb.py
@@ -638,8 +638,8 @@ class SqParquetDB(SqDB):
             if operator.and_ == op:
                 res = True
             for filter_val in filter_list:
-                res = op(res, bool(re.search(
-                    f'namespace={filter_val}', ns_to_test)))
+                ns_to_test = ns_to_test.split('namespace=')[-1]
+                res = op(res, bool(re.fullmatch(filter_val, ns_to_test)))
             return res
 
         if not namespaces:

--- a/tests/integration/sqcmds/common-samples/common-errors.yml
+++ b/tests/integration/sqcmds/common-samples/common-errors.yml
@@ -4,3 +4,139 @@ tests:
   data-directory: tests/data/parquet/
   marks: topology summarize
   output: '{}'
+- command: device show --namespace=ospf --format=json
+  data-directory: tests/data/parquet/
+  marks: device show
+  output: '[]'
+- command: device show --namespace=ospf-ibgp --format=json
+  data-directory: tests/data/parquet/
+  marks: device show
+  output: '[{"namespace": "ospf-ibgp", "hostname": "server103", "model": "vm", "version":
+    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "192.168.123.150", "bootupTimestamp": 1616680845.0, "timestamp": 1616681581595},
+    {"namespace": "ospf-ibgp", "hostname": "server101", "model": "vm", "version":
+    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "192.168.123.184", "bootupTimestamp": 1616680816.0, "timestamp": 1616681581632},
+    {"namespace": "ospf-ibgp", "hostname": "server104", "model": "vm", "version":
+    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "192.168.123.197", "bootupTimestamp": 1616680858.0, "timestamp": 1616681581652},
+    {"namespace": "ospf-ibgp", "hostname": "edge01", "model": "vm", "version": "16.04.7
+    LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive", "address":
+    "192.168.123.180", "bootupTimestamp": 1616681014.0, "timestamp": 1616681581705},
+    {"namespace": "ospf-ibgp", "hostname": "server102", "model": "vm", "version":
+    "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "192.168.123.134", "bootupTimestamp": 1616680827.0, "timestamp": 1616681581705},
+    {"namespace": "ospf-ibgp", "hostname": "exit01", "model": "VX", "version": "4.2.1",
+    "vendor": "Cumulus", "architecture": "x86_64", "status": "alive", "address": "192.168.123.188",
+    "bootupTimestamp": 1616681014.0, "timestamp": 1616681582726}, {"namespace": "ospf-ibgp",
+    "hostname": "leaf02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus",
+    "architecture": "x86_64", "status": "alive", "address": "192.168.123.239", "bootupTimestamp":
+    1616681016.0, "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf04", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.202", "bootupTimestamp":
+    1616681014.0, "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname":
+    "leaf03", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.248", "bootupTimestamp":
+    1616681014.0, "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname":
+    "spine01", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.135", "bootupTimestamp":
+    1616681014.0, "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname":
+    "exit02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.136", "bootupTimestamp":
+    1616681015.0, "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname":
+    "spine02", "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "192.168.123.16", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.30", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582903}, {"namespace": "ospf-ibgp", "hostname": "internet",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.237", "bootupTimestamp": 1616681016.0,
+    "timestamp": 1616681582980}]'
+- command: device show --namespace=~^ospf-.* --format=json
+  data-directory: tests/data/parquet/
+  marks: device show
+  output: '[{"namespace": "ospf-single", "hostname": "server102", "model": "vm", "version":
+    "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "10.255.2.68", "bootupTimestamp": 1616351835.0, "timestamp": 1616352402600},
+    {"namespace": "ospf-single", "hostname": "server103", "model": "vm", "version":
+    "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "10.255.2.182", "bootupTimestamp": 1616351788.0, "timestamp": 1616352402601},
+    {"namespace": "ospf-single", "hostname": "server101", "model": "vm", "version":
+    "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "10.255.2.78", "bootupTimestamp": 1616351831.0, "timestamp": 1616352402606},
+    {"namespace": "ospf-single", "hostname": "server104", "model": "vm", "version":
+    "16.04.6 LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive",
+    "address": "10.255.2.219", "bootupTimestamp": 1616351815.0, "timestamp": 1616352402611},
+    {"namespace": "ospf-single", "hostname": "edge01", "model": "vm", "version": "16.04.6
+    LTS", "vendor": "Ubuntu", "architecture": "x86-64", "status": "alive", "address":
+    "10.255.2.109", "bootupTimestamp": 1616351812.0, "timestamp": 1616352402798},
+    {"namespace": "ospf-single", "hostname": "leaf01", "model": "VX", "version": "4.3.0",
+    "vendor": "Cumulus", "architecture": "x86_64", "status": "alive", "address": "10.255.2.23",
+    "bootupTimestamp": 1616351988.0, "timestamp": 1616352403833}, {"namespace": "ospf-single",
+    "hostname": "spine02", "model": "VX", "version": "4.3.0", "vendor": "Cumulus",
+    "architecture": "x86_64", "status": "alive", "address": "10.255.2.60", "bootupTimestamp":
+    1616351988.0, "timestamp": 1616352403840}, {"namespace": "ospf-single", "hostname":
+    "spine01", "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture":
+    "x86_64", "status": "alive", "address": "10.255.2.217", "bootupTimestamp": 1616351988.0,
+    "timestamp": 1616352403840}, {"namespace": "ospf-single", "hostname": "internet",
+    "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "10.255.2.239", "bootupTimestamp": 1616351807.0,
+    "timestamp": 1616352403840}, {"namespace": "ospf-single", "hostname": "exit02",
+    "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "10.255.2.41", "bootupTimestamp": 1616351989.0,
+    "timestamp": 1616352403840}, {"namespace": "ospf-single", "hostname": "exit01",
+    "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "10.255.2.88", "bootupTimestamp": 1616351989.0,
+    "timestamp": 1616352403840}, {"namespace": "ospf-single", "hostname": "leaf02",
+    "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "10.255.2.203", "bootupTimestamp": 1616351988.0,
+    "timestamp": 1616352403841}, {"namespace": "ospf-single", "hostname": "leaf03",
+    "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "10.255.2.254", "bootupTimestamp": 1616351988.0,
+    "timestamp": 1616352403841}, {"namespace": "ospf-single", "hostname": "leaf04",
+    "model": "VX", "version": "4.3.0", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "10.255.2.10", "bootupTimestamp": 1616351988.0,
+    "timestamp": 1616352403841}, {"namespace": "ospf-ibgp", "hostname": "server103",
+    "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64",
+    "status": "alive", "address": "192.168.123.150", "bootupTimestamp": 1616680845.0,
+    "timestamp": 1616681581595}, {"namespace": "ospf-ibgp", "hostname": "server101",
+    "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64",
+    "status": "alive", "address": "192.168.123.184", "bootupTimestamp": 1616680816.0,
+    "timestamp": 1616681581632}, {"namespace": "ospf-ibgp", "hostname": "server104",
+    "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64",
+    "status": "alive", "address": "192.168.123.197", "bootupTimestamp": 1616680858.0,
+    "timestamp": 1616681581652}, {"namespace": "ospf-ibgp", "hostname": "edge01",
+    "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64",
+    "status": "alive", "address": "192.168.123.180", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681581705}, {"namespace": "ospf-ibgp", "hostname": "server102",
+    "model": "vm", "version": "16.04.7 LTS", "vendor": "Ubuntu", "architecture": "x86-64",
+    "status": "alive", "address": "192.168.123.134", "bootupTimestamp": 1616680827.0,
+    "timestamp": 1616681581705}, {"namespace": "ospf-ibgp", "hostname": "leaf04",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.202", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf02",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.239", "bootupTimestamp": 1616681016.0,
+    "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "exit01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.188", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582726}, {"namespace": "ospf-ibgp", "hostname": "leaf03",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.248", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "spine01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.135", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582844}, {"namespace": "ospf-ibgp", "hostname": "exit02",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.136", "bootupTimestamp": 1616681015.0,
+    "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname": "spine02",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.16", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582902}, {"namespace": "ospf-ibgp", "hostname": "leaf01",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.30", "bootupTimestamp": 1616681014.0,
+    "timestamp": 1616681582903}, {"namespace": "ospf-ibgp", "hostname": "internet",
+    "model": "VX", "version": "4.2.1", "vendor": "Cumulus", "architecture": "x86_64",
+    "status": "alive", "address": "192.168.123.237", "bootupTimestamp": 1616681016.0,
+    "timestamp": 1616681582980}]'


### PR DESCRIPTION
## Description

The namespace always matched with a partial match, this means that if a filter like:
`device show namespace=dc`
matches both `dc-01` and `dc-02` match.
This PR fixes this issue and require the filter to match the entire namespace name.
Additionally, the the `$` token didn't work, fixed now.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
