### PR TITLE
Interface parser fixes

### DIFF
--- a/suzieq/config/interfaces.yml
+++ b/suzieq/config/interfaces.yml
@@ -210,7 +210,7 @@ apply:
           "linklocal-addr: _linklocal"
           ]'
 
-        - command: show interface | egrep '^\w|Hardware|MTU|reset|Description'
+        - command: show interface | egrep '^\w|Hardware|MTU|reset|Description|flapped'
           textfsm: textfsm_templates/nxos_show_int_grep.tfsm
           _entryType: mtumac
 

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -877,8 +877,12 @@ class InterfaceService(Service):
                                            'type': 'bond_slave'}
 
             if entry['adminState'] == 'administratively down':
-                entry['state'] = 'down'
                 entry['adminState'] = 'down'
+            else:
+                # IOS reports the admin state as down when the oper state
+                # (line protocol) is down. administratively down is what
+                # is administratively down.
+                entry['adminState'] = 'up'
 
             entry['macaddr'] = convert_macaddr_format_to_colon(
                 entry.get('macaddr', '0000.0000.0000'))


### PR DESCRIPTION
This patch addresses two fixes:

- NXOS parser didn't record the timestamp of the link flap. At some point during parsing fixes this got accidentally dropped
- IOS interface parser recorded adminState as is when the operational state was down. Instead the adminState should be down only when the words "administratively disabled" is in the state string. 

Both were problems reported by user. Manual testing confirmed that the fix is in, and that before the fixes the output was wrong.

- Using the NXOS testbed, flap a link and ensure that the statusChangeTimestamp field updates correctly.
- Using IOS testbed, find a link with notConnected state and confirm that the adminState is up (because it is administratively up).

These fixes need to go in the 0.20.0 release

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
