### PR TITLE
sq-poller: remove rest implementation for Cumulus

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1568,6 +1568,15 @@ class CumulusNode(Node):
 class LinuxNode(CumulusNode):
     '''Linux server node'''
 
+    async def _rest_connect(self):
+        raise NotImplementedError(
+            f'{self.address}: REST transport is not supported')
+
+    async def _rest_gather(self, service_callback, cmd_list, cb_token,
+                           oformat="json", timeout=None, reconnect=True):
+        raise NotImplementedError(
+            f'{self.address}: REST transport is not supported')
+
 
 class IosXRNode(Node):
     '''IOSXR Node specific implementation'''


### PR DESCRIPTION
## Description

Even though the documentation says Cumulus didn't support REST, the Cumulus Node class actually had a not working implementation of the REST communication. This PR removes it, as dead code.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
