### PR TITLE
confutils: portmode regexp string fixup

### DIFF
--- a/suzieq/shared/confutils.py
+++ b/suzieq/shared/confutils.py
@@ -132,7 +132,8 @@ def _get_swport_interfaces_iosy(conf: CiscoConfParse,
 
     pm_dict = {}
     if what == 'access':
-        for intf in conf.find_objects_w_child('^interface ', '.*access'):
+        for intf in conf.find_objects_w_child(r'^interface ',
+                                              r'^\s+switchport.*access'):
             ifname = intf.text.split('interface')[1].strip()
             acc_vlan = intf.re_match_iter_typed(r'^.*vlan\s+(\d+)')
             if acc_vlan.isnumeric():
@@ -141,7 +142,8 @@ def _get_swport_interfaces_iosy(conf: CiscoConfParse,
                 pm_dict[ifname] = 0
 
     if what == 'trunk':
-        for intf in conf.find_objects_w_child('^interface', '.*trunk'):
+        for intf in conf.find_objects_w_child(r'^interface',
+                                              r'^\s+switchport.*trunk'):
             ifname = intf.text.split('interface')[1].strip()
             nvlan = intf.re_match_iter_typed(r'.*native vlan\s+(\d+)',
                                              default='1')


### PR DESCRIPTION
When an interface has a port ACL such as this:
```
interface Ethernet1/1
  no switchport
  mtu 9216
  ip access-group foo in
  ip access-group bar out
  ip address 10.16.1.95/31
  ip pim sparse-mode
```

We incorrectly detected this as an access port instead of a routed port. This patch fixes the regexp to match access ports to avoid this bug.

Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>



- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
