### PR TITLE
Add SuzieQ GUI port 3000 error message

### DIFF
--- a/suzieq/gui/sq_gui.py
+++ b/suzieq/gui/sq_gui.py
@@ -53,6 +53,15 @@ def gui_main(*args):
                 'stlit' / 'suzieq-gui.py'
             thisprog = str(thisprog)
 
+    if userargs.port == '3000':
+        # due to a streamlit issue, starting a server on port 3000 will cause
+        # the SuzieQ gui to show an empty page
+        # Issue: https://github.com/netenglabs/suzieq/issues/847
+        print('Port 3000 is not allowed. Please choose a different port.\n\n'
+              'For more details, check '
+              'https://github.com/netenglabs/suzieq/issues/847')
+        return
+
     # validate the config file before starting the gui
     load_sq_config(config_file=userargs.config)
 


### PR DESCRIPTION
## Related Issue

#847 

## Description

Due to a bug in the streamlit library, the port 3000 cannot be used to start the SuzieQ gui. For futher details, check Issue #847

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
