### PR TITLE
Netbox: handle different host url in 'next' section of the response

### DIFF
--- a/suzieq/poller/controller/controller.py
+++ b/suzieq/poller/controller/controller.py
@@ -318,6 +318,7 @@ class Controller:
                         'too much time'
                     )
 
+                logger.debug(f'Received inventory from {inv_src.name}')
                 if cur_inv:
                     cur_inv_count = len(cur_inv)
                     duplicated_devices = [x for x in cur_inv

--- a/tests/unit/poller/controller/test_controller.py
+++ b/tests/unit/poller/controller/test_controller.py
@@ -256,6 +256,9 @@ def mock_plugins():
         self.set_device()
         self._load(inv)
 
+    def mock_get_name(self):
+        return self._name
+
     def mock_set_inventory(self, inv):
         self._inventory = inv.copy()
         if not self._inv_is_set:
@@ -284,12 +287,14 @@ def mock_plugins():
     native_mock = patch.multiple(SqNativeFile, __init__=mock_src_init,
                                  set_inventory=mock_set_inventory,
                                  get_inventory=mock_get_inventory,
+                                 name=mock_get_name,
                                  _load=mock_native_load,
                                  set_device=MagicMock())
 
     netbox_mock = patch.multiple(Netbox, __init__=mock_src_init,
                                  set_inventory=mock_set_inventory,
                                  get_inventory=mock_get_inventory,
+                                 name=mock_get_name,
                                  _load=MagicMock(), run=mock_netbox_run,
                                  set_device=MagicMock())
 


### PR DESCRIPTION
## Related Issue

<!--Add the related issue in the form of #issue-number (Example #100)-->
Fixes #848 

## Description

The Netbox source retrieves the devices one page a time. The next page url to fetch is retrieved via the 'next' section of the Netbox response (see [Netbox pagination docs](https://demo.netbox.dev/static/docs/rest-api/overview/#pagination)).
It may happen that this 'next' section contains a different host or protocol or port if there is a reverse proxy between SuzieQ and Netbox.

This PR substitutes the host, port and protocol of the 'next' url with the host, port and protocol of the previous request.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
