### PR TITLE
More miscellaneous fixes

### DIFF
--- a/suzieq/engines/pandas/network.py
+++ b/suzieq/engines/pandas/network.py
@@ -27,6 +27,10 @@ class NetworkObj(SqPandasEngine):
         query_str = kwargs.pop('query_str', '')
         fields = self.schema.get_display_fields(['default'])
 
+        if ((self.iobj.start_time and self.iobj.end_time) or
+                (self.iobj.view == 'all')):
+            fields.insert(0, 'active')
+            fields.append('timestamp')
         dflist = []
         if isinstance(addrlist, str):
             addrlist = [addrlist]

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -821,8 +821,10 @@ class InterfaceService(Service):
                 elif 'Autostate Enabled' in state:
                     entry['state'] = 'down'
                     entry['reason'] = state.split(',')[1].strip()
-                elif 'disabled' in state:
+                elif 'err-disabled' in state:
                     entry['state'] = 'errDisabled'
+                elif 'disabled' in state:
+                    entry['state'] = 'down'
                 elif 'monitoring' in state:
                     entry['state'] = 'down'
                 elif 'suspended' in state:

--- a/suzieq/shared/confutils.py
+++ b/suzieq/shared/confutils.py
@@ -132,7 +132,8 @@ def _get_swport_interfaces_iosy(conf: CiscoConfParse,
 
     pm_dict = {}
     if what == 'access':
-        for intf in conf.find_objects_w_child('^interface ', '.*access'):
+        for intf in conf.find_objects_w_child(r'^interface ',
+                                              r'^\s+switchport.*access'):
             ifname = intf.text.split('interface')[1].strip()
             acc_vlan = intf.re_match_iter_typed(r'^.*vlan\s+(\d+)')
             if acc_vlan.isnumeric():
@@ -141,7 +142,8 @@ def _get_swport_interfaces_iosy(conf: CiscoConfParse,
                 pm_dict[ifname] = 0
 
     if what == 'trunk':
-        for intf in conf.find_objects_w_child('^interface', '.*trunk'):
+        for intf in conf.find_objects_w_child(r'^interface',
+                                              r'^\s+switchport.*trunk'):
             ifname = intf.text.split('interface')[1].strip()
             nvlan = intf.re_match_iter_typed(r'.*native vlan\s+(\d+)',
                                              default='1')


### PR DESCRIPTION
This PR contains a few more errors, some reported by users and others found during testing:

* With view=all, the network find command didn't display active and timestamp fields (regression)
* When an interface is administratively down on an IOS device, we incorrectly marked it as errDisabled
* The regexp used to identify access and trunk ports was wrong and ended up tagging certain interfaces as access even though they weren't

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
