### PR TITLE
sq-poller/coalescer: log env info at startup

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2433,6 +2433,33 @@ files = [
 ]
 
 [[package]]
+name = "psutil"
+version = "5.9.4"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "psutil-5.9.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c1ca331af862803a42677c120aff8a814a804e09832f166f226bfd22b56feee8"},
+    {file = "psutil-5.9.4-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:68908971daf802203f3d37e78d3f8831b6d1014864d7a85937941bb35f09aefe"},
+    {file = "psutil-5.9.4-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:3ff89f9b835100a825b14c2808a106b6fdcc4b15483141482a12c725e7f78549"},
+    {file = "psutil-5.9.4-cp27-cp27m-win32.whl", hash = "sha256:852dd5d9f8a47169fe62fd4a971aa07859476c2ba22c2254d4a1baa4e10b95ad"},
+    {file = "psutil-5.9.4-cp27-cp27m-win_amd64.whl", hash = "sha256:9120cd39dca5c5e1c54b59a41d205023d436799b1c8c4d3ff71af18535728e94"},
+    {file = "psutil-5.9.4-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6b92c532979bafc2df23ddc785ed116fced1f492ad90a6830cf24f4d1ea27d24"},
+    {file = "psutil-5.9.4-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:efeae04f9516907be44904cc7ce08defb6b665128992a56957abc9b61dca94b7"},
+    {file = "psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7"},
+    {file = "psutil-5.9.4-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:16653106f3b59386ffe10e0bad3bb6299e169d5327d3f187614b1cb8f24cf2e1"},
+    {file = "psutil-5.9.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54c0d3d8e0078b7666984e11b12b88af2db11d11249a8ac8920dd5ef68a66e08"},
+    {file = "psutil-5.9.4-cp36-abi3-win32.whl", hash = "sha256:149555f59a69b33f056ba1c4eb22bb7bf24332ce631c44a319cec09f876aaeff"},
+    {file = "psutil-5.9.4-cp36-abi3-win_amd64.whl", hash = "sha256:fd8522436a6ada7b4aad6638662966de0d61d241cb821239b2ae7013d41a43d4"},
+    {file = "psutil-5.9.4-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:6001c809253a29599bc0dfd5179d9f8a5779f9dffea1da0f13c53ee568115e1e"},
+    {file = "psutil-5.9.4.tar.gz", hash = "sha256:3d7f9739eb435d4b1338944abe23f49584bde5395f27487d2ee25ad9a8774a62"},
+]
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
@@ -4270,4 +4297,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "2.0"
 python-versions = ">3.8.1, < 3.10"
-content-hash = "69904701b5ff30f010837a3d19e87553922275ddb0f2e69b1b6b09c2fee04905"
+content-hash = "2760dfc88f0a9b5d4c672b6a6d8998cc127f5d284e034fe0c2d4864b46938de8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ ciscoconfparse = "^1.6.21"
 notebook = "6.4.12"
 urllib3 = "^1.26.12"
 packaging = "^21.3"
+psutil = "^5.9.4"
 
 [tool.poetry.dev-dependencies]
 pylint = "*"

--- a/suzieq/poller/sq_poller.py
+++ b/suzieq/poller/sq_poller.py
@@ -15,7 +15,8 @@ from suzieq.poller.worker.writers.output_worker import OutputWorker
 from suzieq.shared.exceptions import InventorySourceError, PollingError, \
     SqPollerConfError
 from suzieq.shared.utils import (poller_log_params, init_logger,
-                                 load_sq_config, print_version)
+                                 load_sq_config, print_version,
+                                 log_suzieq_info)
 from suzieq.poller.controller.utils.inventory_utils import read_inventory
 
 
@@ -45,6 +46,8 @@ async def start_controller(user_args: argparse.Namespace, config_data: Dict):
             read_inventory(user_args.inventory)
             print('Inventory syntax check passed')
             return
+
+        log_suzieq_info('Poller Controller', logger, show_more=True)
         controller = Controller(user_args, config_data)
         controller.init()
         await controller.run()

--- a/suzieq/poller/worker/sq_worker.py
+++ b/suzieq/poller/worker/sq_worker.py
@@ -8,10 +8,12 @@ import traceback
 from typing import Dict
 
 import uvloop
+
 from suzieq.poller.worker.worker import Worker
 from suzieq.poller.worker.writers.output_worker import OutputWorker
 from suzieq.shared.exceptions import InventorySourceError, SqPollerConfError
-from suzieq.shared.utils import init_logger, load_sq_config, poller_log_params
+from suzieq.shared.utils import (init_logger, load_sq_config, log_suzieq_info,
+                                 poller_log_params)
 
 
 async def start_worker(userargs: argparse.Namespace, cfg: Dict):
@@ -29,6 +31,7 @@ async def start_worker(userargs: argparse.Namespace, cfg: Dict):
     logger = init_logger('suzieq.poller.worker', logfile,
                          loglevel, logsize, log_stdout)
 
+    log_suzieq_info('Poller Worker', logger)
     worker = None
     try:
         worker = Worker(userargs, cfg)

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -1193,5 +1193,10 @@ def log_suzieq_info(name: str, c_logger: logging.Logger = None,
     info_to_show += '\n|-----------------------------------------------------|'
     c_logger.info(info_to_show)
 
+    # Warning if the system has less than 2 cores and 16GB of ram
+    if show_more and (cpu_cores < 2 or mem_info.total < 16 * (1024 ** 3)):
+        c_logger.warning(
+            'Minimum recommended system spec is a modern i7-equivalent or '
+            'higher with 4 cores and 16 GB RAM')
     if prev_level > logging.INFO:
         c_logger.setLevel(prev_level)

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -1179,12 +1179,17 @@ def log_suzieq_info(name: str, c_logger: logging.Logger = None,
             cpu_name = (platform.processor() or '-')
 
         cpu_freq = psutil.cpu_freq()
-        cpu_info = f'{cpu_name} {psutil.cpu_count()} cores - '
+        cpu_cores = psutil.cpu_count()
+        cpu_info = f'{cpu_name} {cpu_cores} cores - '
         cpu_info += f'freq. {cpu_freq.min:.2f}Mhz - {cpu_freq.max:.2f}Mhz'
+        cpu_load_history = ', '.join(
+            f'{(c / cpu_cores) * 100:.1f}%' for c in psutil.getloadavg())
         mem_info = psutil.virtual_memory()
         info_to_show += f'\nPlatform: {platform.platform()} \n' \
             f'CPU: {cpu_info} \n' \
+            f'CPU load 1m, 5m, 15m: {cpu_load_history}\n' \
             f'Memory: total: {mem_info.total}, available: {mem_info.available}'
+
     info_to_show += '\n|-----------------------------------------------------|'
     c_logger.info(info_to_show)
 

--- a/suzieq/utilities/sq_coalescer.py
+++ b/suzieq/utilities/sq_coalescer.py
@@ -15,9 +15,9 @@ from dataclasses import asdict
 
 import pandas as pd
 
-from suzieq.shared.utils import (load_sq_config, init_logger,
-                                 ensure_single_instance,
-                                 get_log_params, get_sleep_time)
+from suzieq.shared.utils import (ensure_single_instance, get_log_params,
+                                 get_sleep_time, init_logger, load_sq_config,
+                                 log_suzieq_info)
 from suzieq.shared.schema import Schema, SchemaForTable
 from suzieq.db import do_coalesce, get_sqdb_engine
 from suzieq.version import SUZIEQ_VERSION
@@ -74,6 +74,8 @@ def run_coalescer(cfg: dict, tables: List[str], periodstr: str, run_once: bool,
         logger.error(f'Aborting. Unable to load schema: {str(ex)}')
         print(f'ERROR: Aborting. Unable to load schema: {str(ex)}')
         sys.exit(1)
+
+    log_suzieq_info('Coalescer', logger)
 
     coalescer_schema = SchemaForTable('sqCoalescer', schemas)
     pqdb = get_sqdb_engine(cfg, 'sqCoalescer', None, logger)


### PR DESCRIPTION
## Description

This PR introduces some additional logging, in the poller controller/worker and coalescer, providing info about the current version of SuzieQ and the environment where it runs.
The logs show:
- Poller worker/controller and coalescer
  - Name of the component and version 
  - Info about the python interpreter
- Poller controller:
  - Info about the platform (OS, kernel version)
  - CPU info
  - Total and available memory 
 
An example of the log at the poller startup:

```
2023-02-13 16:11:45,389 - suzieq.poller.controller - WARNING - log level WARNING
2023-02-13 16:12:00,840 - suzieq.poller.controller - INFO - 
|-----------------------------------------------------|
SuzieQ Poller Controller v0.20.0 
Python version: 3.8.12 (default, Dec 12 2021, 18:37:21) 
[GCC 11.2.0]
Platform: Linux-5.15.0-60-generic-x86_64-with-glibc2.34 
CPU: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz 16 cores - freq. 800.00Mhz - 4600.00Mhz 
CPU load 1m, 5m, 15m: 2.5%, 3.3%, 3.0%
Memory: total: 33370701824, available: 20688240640
|-----------------------------------------------------|
```

## Type of change

- New feature (non-breaking change which adds functionality)
