### PR TITLE
Interfaces Parser: EOS parser fixes for admin state

### DIFF
--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -151,11 +151,9 @@ class InterfaceService(Service):
             adm_state = entry.get('adminState', 'down')
             if adm_state == 'notconnect':
                 entry['reason'] = 'notconnect'
-                entry['adminState'] = 'down'
                 entry['state'] = 'notConnected'
             elif adm_state == 'errdisabled':
                 entry['reason'] = 'errdisabled'
-                entry['adminState'] = 'down'
                 entry['state'] = 'errDisabled'
             elif adm_state == 'connected':
                 entry['adminState'] = 'up'


### PR DESCRIPTION
When EOS port state was not connected or error disabled, we incorrectly set the admin state to down. Fixed.

## New Behavior

EOS interfaces' adminState is set based on admin state only.

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
