### PR TITLE
sq-poller: ios/iosxe set max concurrent cmds to 1 to avoid broken cmd output

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -528,10 +528,14 @@ class Node:
             elif self.devtype == "eos":
                 self.__class__ = EosNode
             elif self.devtype == "iosxe":
+                # Since we need to create one single interactive session with
+                # ios and iosxe, we cannot concurrently issue commands
+                self.batch_size = 1
                 self.__class__ = IosXENode
             elif self.devtype == "iosxr":
                 self.__class__ = IosXRNode
             elif self.devtype == "ios":
+                self.batch_size = 1
                 self.__class__ = IOSNode
             elif self.devtype.startswith("junos"):
                 self.__class__ = JunosNode


### PR DESCRIPTION
## Description

Since with ios and iosxe we need to use one single interactive ssh session, we cannot allow concurrent cmds. This patch force the batch size to 1, so that no more than 1 command at a time can be executed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
