### PR TITLE
NXOS: routes timestamp parser fix for older versions

### DIFF
--- a/suzieq/poller/worker/services/routes.py
+++ b/suzieq/poller/worker/services/routes.py
@@ -228,7 +228,9 @@ class RoutesService(Service):
             # Right now we only store the timestamp of the first NH change
             # The correct thing to do is to take all NH timestamps, and take
             # the latest one: TODO
-            lastChange = entry.get('statusChangeTimestamp', [''])[0]
+            lastChange = entry.get('statusChangeTimestamp', [''])
+            if isinstance(lastChange, list):
+                lastChange = lastChange[0]
             if lastChange:
                 entry['statusChangeTimestamp'] = get_timestamp_from_cisco_time(
                     lastChange, raw_data[0]['timestamp']/1000)


### PR DESCRIPTION
When a route had a single nexthop, the timestamp returned was not a list in one of the older NXOS releases. This caused the parser to hiccup. This patch fixes that by checking if the timestamp is a list before attempting to suck out a value.

## Proposed Release Note Entry

Better handle older NXOS version route table entries with a single nexthop

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
