### PR TITLE
Poller fix: write deletions with the same timestamp

### DIFF
--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -572,10 +572,12 @@ class Service(SqPlugin):
 
         # pylint: disable=too-many-nested-blocks
         for entry in processed_data or []:
-            entry.update({"hostname": read_from["hostname"]})
-            entry.update({"namespace": read_from["namespace"]})
-            entry.update({"timestamp": read_from["timestamp"]})
-            entry.update({"sqvers": self.version})
+            entry.update({
+                "hostname": read_from["hostname"],
+                "namespace": read_from["namespace"],
+                "timestamp": read_from["timestamp"],
+                "sqvers": self.version
+            })
             for fld, val in schema_rec.items():
                 if fld not in entry:
                     if fld == "active":

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -660,16 +660,23 @@ class Service(SqPlugin):
                 for entry in adds:
                     entry['deviceSession'] = last_device_session
                     records.append(entry)
+                # make sure to use the same timestamp for all the deleted
+                # records. If the result is not empty, use that to get the
+                # timestamp. If the result is empty, use the current timestamp
+                if result:
+                    del_ts = result[0]['timestamp']
+                else:
+                    del_ts = int(datetime.now(
+                        tz=timezone.utc).timestamp() * 1000)
+
                 for entry in dels:
                     if entry.get("active", True):
                         # If there's already an entry marked as deleted
                         # No point in adding one more
-                        entry.update({"active": False})
-                        entry.update(
-                            {"timestamp":
-                             int(datetime.now(tz=timezone.utc).timestamp()
-                                 * 1000)}
-                        )
+                        entry.update({
+                            "active": False,
+                            "timestamp": del_ts
+                        })
                         records.append(entry)
 
                 self._post_work_to_writer(records)


### PR DESCRIPTION
## Test inclusion requirements

In case the PR contains an enhancement or a new platform/service support, some tests have to be added for the new functionality:

- any fix or enhancement SHOULD include relevant new tests or test updates, if any tests need updating.
- a new platform support MUST include the relevant input files similar to what we have in tests/integration/sqcmds/-input directories, along with the relevant tests in the tests/integration/sqcmds/-samples dir. That list MUST include the all.yml file fully filled out.
- any new service (or table) addition MUST include comments about what network OS are supported (along with version) with this command along with test samples for those platforms and input files in the *-input dir

For additional information about tests, follow this [link](https://suzieq.readthedocs.io/en/latest/developer/testing/)

## Description

If the same uncaolesced file has more than one timestamp in the same file we might have issues when coalesced and uncaolesced data coexists in the data-directory.

In order to avoid the problem above, we must force the timestamp of all records written to be the same. Since all the records to write will have the same timestamp, we are going to set that timestamp also for the deletions. If instead no data was returned from the device (f.e. the device was unreachable) we use the current timestamp for the deleted records.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

All the deletions in the same uncaolesced file will have the same timestamp

## Contrast to Current Behavior

A new timestamp for each deleted record will be present in the same uncoalesced file

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
