### PR TITLE
Device namespace fixes

### DIFF
--- a/suzieq/config/schema/namespace.avsc
+++ b/suzieq/config/schema/namespace.avsc
@@ -62,6 +62,12 @@
             "description": "Is MLAG used in this namespace"
         },
         {
+            "name": "lastUpdate",
+            "type": "timestamp",
+            "display": 8,
+            "description": "The last time the poller updated this namespace"
+        },
+        {
             "name": "namespace",
             "type": "string",
             "key": 0,

--- a/suzieq/engines/pandas/namespace.py
+++ b/suzieq/engines/pandas/namespace.py
@@ -92,7 +92,6 @@ class NamespaceObj(SqPandasEngine):
         if 'sqvers' in fields:
             newdf['sqvers'] = self.schema.version
         newdf['active'] = True
-        newdf = self._handle_user_query_str(newdf, user_query)
 
         # Look for the rest of info only in selected namepaces
         newdf['lastUpdate'] = nsgrp['timestamp'].max() \

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -405,12 +405,14 @@ tests:
     {"name": "hasOspf", "type": "boolean", "key": "", "display": 4, "description":
     "Is OSPF used in this namespace"}, {"name": "hasVxlan", "type": "boolean", "key":
     "", "display": 6, "description": "Is VXLAN used in this namespace"}, {"name":
-    "lastUpdate", "type": "timestamp", "key": "", "display": 8, "description": "Time
-    when any service was last polled"}, {"name": "namespace", "type": "string", "key":
-    0, "display": 0, "description": "Namespace associated with this record"}, {"name":
-    "serviceCnt", "type": "long", "key": "", "display": 2, "description": "Number
-    of services polled in this namespace"}, {"name": "sqvers", "type": "string", "key":
-    "", "display": "", "description": "Schema version, not selectable"}]'
+    "lastUpdate", "type": "timestamp", "key": "", "display": 8, "description": "The
+    last time the poller updated this namespace"}, {"name": "lastUpdate", "type":
+    "timestamp", "key": "", "display": 8, "description": "Time when any service was
+    last polled"}, {"name": "namespace", "type": "string", "key": 0, "display": 0,
+    "description": "Namespace associated with this record"}, {"name": "serviceCnt",
+    "type": "long", "key": "", "display": 2, "description": "Number of services polled
+    in this namespace"}, {"name": "sqvers", "type": "string", "key": "", "display":
+    "", "description": "Schema version, not selectable"}]'
 - command: path describe --format=json
   data-directory: tests/data/parquet
   marks: path describe


### PR DESCRIPTION
## Description

Three somewhat related bug fixes:
* namespace table: user query was applied too early resulting in either query failures or the wrong data being filtered
* namespace table: the schema didn't contain the lastUpdate column
* device: the filters such as os, vendor etc didn't work correctly because of an incorrect merge with the poller table. There's still a corner case where it fails. 

## Type of change

These are bug fixes. One test was updated to handle the changes caused by these fixes.

## New Behavior

namespace show honors the user filters plus query-str correctly.

## Proposed Release Note Entry

* namespace's schema reflects the actual namespace columns
* namespace honors the filters the user specifies
* device honors the os/vendor/model filters the user specifies.

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
