### PR TITLE
Fix bootuptimestamp type

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1484,7 +1484,7 @@ class EosNode(Node):
                     return
             else:
                 data = output[0]["data"]
-            self.bootupTimestamp = data["bootupTimestamp"]
+            self.bootupTimestamp = int(data["bootupTimestamp"])
             self._extract_nos_version(data)
             if not self.version:
                 self.logger.error(f'nodeinit: Error getting version for '

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -607,7 +607,7 @@ class Service(SqPlugin):
         return processed_data
 
     async def commit_data(self, result: Dict, namespace: str, hostname: str,
-                          boot_timestamp: float):
+                          boot_timestamp: int):
         """Write the result data out"""
         records = []
         key = f'{namespace}.{hostname}'

--- a/suzieq/shared/utils.py
+++ b/suzieq/shared/utils.py
@@ -520,7 +520,7 @@ def get_timestamp_from_junos_time(in_data: Tuple[Dict, str],
         delta = relativedelta(seconds=int(secs))
         secs = (datetime.fromtimestamp(relative_to) - delta).timestamp()
 
-    return secs * conversion_unit
+    return int(secs * conversion_unit)
 
 
 def convert_macaddr_format_to_colon(macaddr: str) -> str:


### PR DESCRIPTION
## Description

EOS devices provide a float as the bootup timestamp which conflicts with the assumption throughout the code that this value is an int. As a consequence, everytime we do --run-once=update, all information is updated whether they changed or not, because of how the code attempts to detect if the device has rebooted since last poll. When we're running in continuous poll mode, this problem doesn't happen, because we're relying on data computed as opposed to read from parquet in snapshot mode. 

This patch fixes this issue by ensuring that the bootup timestamp is always int.  

## Type of change

Bug fix

## New Behavior

When poller is run on EOS devices with run-once=update mode, no updates are written if nothing has changed between the last poller run and now. There's no change in continuous polling mode.

## Contrast to Current Behavior

In run-once=update mode, for EOS devices, data is always written on each poller run.

## Proposed Release Note Entry

EOS in snapshot mode correctly writes only data that has changed since the last time the poller ran in snapshot mode.

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
