### PR TITLE
EOS evpnVni: change to command in post 4.23F

### DIFF
--- a/suzieq/config/evpnVni.yml
+++ b/suzieq/config/evpnVni.yml
@@ -35,7 +35,7 @@ apply:
 
   eos:
     version: all
-    command: show interfaces Vxlan $
+    command: show interfaces Vxlan 1-$
     normalize: 'interfaces/*/[
     "vlanToVniMap: _vlan2VniMap",
     "vlanToVtepList: _vlan2VtepMap?|{}",


### PR DESCRIPTION
## Description

Command used for EOS to retrieve EVPN info was incorrect for versions post-4.23.5M (the version we last tested). With newer versions, the command needs to be fixed. Fortunately, the fix also works in older versions such as 4.23.5M.

## Type of change

Bug fix for supporting newer EOS versions

## New Behavior

EVPN tables are polled with newer EOS versions.

## Contrast to Current Behavior

EVPN tables were not polled with newer EVPN versions.

## Proposed Release Note Entry

* EVPN table polling fix for newer versions of EOS (4.29.2F, for example).

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
