### PR TITLE
Fix gui redirect + nginx docs

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -15,3 +15,121 @@ Some additional arguments are allowed to set up the GUI:
 
 - `-p --port`: defines in which port the GUI is going to run. By default is `8501`
 - `-c --config`: SuzieQ configuration file to use. Check the [Configuration](config_file.md) page to check the default configuration file location.
+
+## Start a GUI behind an nginx reverse proxy
+
+This section is an step by step guide on how to set up an [nginx](http://nginx.org/en/docs/) reverse proxy for the SuzieQ GUI.
+
+### Requirements
+
+- nginx: [nginx installation guide](http://nginx.org/en/docs/install.html)
+- SuzieQ GUI running
+
+### Configure and start nginx
+
+Move into the nginx config directory
+
+``` shell
+cd /etc/nginx
+```
+
+!!! info
+        Some of the commands below may need `sudo`
+
+Fill the values into the following template and put it in a file under `/etc/nginx/sites-available/suzieq.conf`
+
+```
+server {
+        listen <PROXY_SERVER_PORT> default_server;
+        listen [::]:<PROXY_SERVER_PORT> default_server;
+        server_name <SERVER_NAME>;
+        location /<PROXY_PATH> {
+                proxy_pass <SUZIEQ_GUI_URL>;
+        }
+        # streamlit redirects config
+        location /<PROXY_PATH>/streamlit-components-demo {
+                proxy_pass <SUZIEQ_GUI_URL>/;
+        }
+        location ^~ /<PROXY_PATH>/static {
+                proxy_pass <SUZIEQ_GUI_URL>/static/;
+        }
+        location ^~ /<PROXY_PATH>/healthz {
+                proxy_pass <SUZIEQ_GUI_URL>/healthz;
+        }
+        location ^~ /<PROXY_PATH>/vendor {
+                proxy_pass <SUZIEQ_GUI_URL>/vendor;
+        }
+        location ^~ /<PROXY_PATH>/component {
+                proxy_pass <SUZIEQ_GUI_URL>/component;
+        }
+
+        location /<PROXY_PATH>/stream {
+                proxy_pass <SUZIEQ_GUI_URL>/stream;
+                proxy_http_version 1.1;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header Host $host;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_read_timeout 86400;
+        }
+}
+```
+
+The example below shows a configuration file shows how to create a reverse proxy
+to serve a SuzieQ GUI running on `http:localhost:8501` to be mapped to `http:localhost:80/suzieq`
+
+```
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name localhost;
+        location /suzieq {
+                proxy_pass http://127.0.0.1:8501;
+        }
+        # streamlit redirects config
+        location /suzieq/streamlit-components-demo {
+                proxy_pass http://127.0.0.1:8501/;
+        }
+        location ^~ /suzieq/static {
+                proxy_pass http://127.0.0.1:8501/static/;
+        }
+        location ^~ /suzieq/healthz {
+                proxy_pass http://127.0.0.1:8501/healthz;
+        }
+        location ^~ /suzieq/vendor {
+                proxy_pass http://127.0.0.1:8501/vendor;
+        }
+        location ^~ /suzieq/component {
+                proxy_pass http://127.0.0.1:8501/component;
+        }
+
+        location /suzieq/stream {
+                proxy_pass http://127.0.0.1:8501/stream;
+                proxy_http_version 1.1;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header Host $host;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_read_timeout 86400;
+        }
+}
+```
+
+!!! warning
+        These examples, do **NOT** provide any security.
+        Please check the [nginx documentation](http://nginx.org/en/docs/) to know how add security to your nginx server
+
+
+Now copy the configuration from `/etc/nginx/sites-available` to `/etc/nginx/sites-enabled`.
+It is recommended to use a symbolic link.
+
+``` shell
+ln -s /etc/nginx/sites-available/suzieq.conf /etc/nginx/sites-enabled/suzieq.conf
+```
+
+Now restart the nginx service
+``` shell
+sudo systemctl restart nginx
+```
+
+You can open you browser and connect to your configured nginx to see the SuzieQ GUI

--- a/suzieq/gui/stlit/guiutils.py
+++ b/suzieq/gui/stlit/guiutils.py
@@ -109,21 +109,6 @@ def gui_get_df(table: str,
     return df.reset_index(drop=True)
 
 
-def get_base_url():
-    '''Return the base URL of the page.
-    Usually connections are http://localhost:8501. But the port can change
-    or it can be a remote connection. And so, its useful to get the base
-    URL for use with links on various pages.
-    '''
-    session_id = get_script_run_ctx().session_id
-    session_info = Server.get_current()._get_session_info(session_id)
-
-    if session_info:
-        return f'http://{session_info.ws.request.host}/'
-
-    return 'http://localhost:8501/'
-
-
 def get_session_id():
     '''Return Streamlit's session ID'''
     ctx = get_script_run_ctx()

--- a/suzieq/gui/stlit/path.py
+++ b/suzieq/gui/stlit/path.py
@@ -10,7 +10,7 @@ from st_aggrid import (GridOptionsBuilder, AgGrid, GridUpdateMode,
 
 from suzieq.sqobjects import get_sqobject
 from suzieq.gui.stlit.guiutils import (gui_get_df, set_def_aggrid_options,
-                                       display_help_icon, get_base_url,
+                                       display_help_icon,
                                        get_session_id, SuzieqMainPages)
 from suzieq.gui.stlit.pagecls import SqGuiPage
 
@@ -85,7 +85,7 @@ class PathPage(SqGuiPage):
             nsidx = namespaces.index(state.namespace)
 
         url = '&amp;'.join([
-            f'{get_base_url()}?page=Help&session={get_session_id()}',
+            f'?page=Help&session={get_session_id()}',
             'help=yes',
             'help_on=Path',
         ])
@@ -339,7 +339,7 @@ class PathPage(SqGuiPage):
                         continue
                     hostset.add(hostname)
                     debugURL = '&amp;'.join([
-                        f'{get_base_url()}?page={quote("Path-Debug")}',
+                        f'?page={quote("Path-Debug")}',
                         'lookupType=hop',
                         f'namespace={quote(df.namespace[0])}',
                         f'session={quote(get_session_id())}',
@@ -408,7 +408,7 @@ class PathPage(SqGuiPage):
                 tooltip = '\n'.join(tdf.T.to_string(
                     justify='right').split('\n')[1:])
                 debugURL = '&amp;'.join([
-                    f'{get_base_url()}?page={quote("Path-Debug")}',
+                    f'?page={quote("Path-Debug")}',
                     'lookupType=edge',
                     f'namespace={quote(row.namespace)}',
                     f'session={quote(get_session_id())}',


### PR DESCRIPTION
## Related Issue

<!--Add the related issue in the form of #issue-number (Example #100)-->
Fixes #905 

## Description

The redirects performed by the *path* page are now *relative* and no more *absolute* allowing the users to put the GUI behing a reverse proxy.

It also adds a guide on how to setup an nginx reverse proxy

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
