### PR TITLE
Path improv

### DIFF
--- a/suzieq/engines/pandas/engineobj.py
+++ b/suzieq/engines/pandas/engineobj.py
@@ -105,15 +105,15 @@ class SqPandasEngine(SqEngineObj):
         return column.apply(lambda x: any(v in x for v in values))
 
     def _is_in_subnet(self, addr: pd.Series, net: str) -> pd.Series:
-        """Check if the IP addresses in a Pandas dataframe
-        belongs to the given subnet
+        """check which of the addresses belongs to a given subnet
 
+        Used to implement the prefix filter of arpnd/address/dhcp
         Args:
-            addr (PandasObject): the collection of ip addresses to check
-            net: (str): network id of the subnet
+            addr (pd.Series): the pandas series of ip addresses to check
+            net: (str): the IP network to check the addresses against
 
         Returns:
-            PandasObject: A collection of bool reporting the result
+            pd.Series: A collection of bool reporting the result
         """
         network = ip_network(net)
         if isinstance(addr.iloc[0], np.ndarray):
@@ -125,6 +125,34 @@ class SqPandasEngine(SqEngineObj):
         else:
             return addr.apply(lambda a: (
                 False if not a else ip_address(a.split("/")[0]) in network)
+            )
+
+    def _in_subnet_series(self, addr: str, net: pd.Series) -> pd.Series:
+        """Check if an addr is in any of series' subnets
+
+        unlike is_in_subnet which checks if a pandas series of addresses
+        belongs in a given subnet, this routine checks if a given address
+        belongs to any of the provided pandas series of subnets. THis is
+        currently used in path to identify an SVI for a given address
+
+        Args:
+            addr (str): the address we're checking for
+            net: (pd.Series): the pandas series of subnets
+
+        Returns:
+            pd.Series: A collection of bool reporting the result
+        """
+        address = ip_address(addr)
+        if isinstance(net.iloc[0], np.ndarray):
+            return net.apply(lambda x, network:
+                             False if not x.any()
+                             else any(address in ip_network(a, strict=False)
+                                      for a in x if a != '0.0.0.0/0'),
+                             args=(address,))
+        else:
+            return net.apply(lambda a: (
+                False if not a or a == '0.0.0.0/0'
+                else address in ip_network(a, strict=False))
             )
 
     def _check_ipvers(self,  addr: pd.Series, version: int) -> pd.Series:

--- a/tests/integration/sqcmds/cumulus-samples/path.yml
+++ b/tests/integration/sqcmds/cumulus-samples/path.yml
@@ -1959,9 +1959,111 @@ tests:
 - command: path show --dest=172.16.2.104 --src=172.16.1.104 --namespace=dual-evpn
     --format=json
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: Invalid src 172.16.1.104"}]'
   marks: path show cumulus
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit01",
+    "iif": "vlan13", "oif": "swp1", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup":
+    "172.16.2.0/24", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1",
+    "hopError": "", "timestamp": 1616644822008}, {"pathid": 1, "hopCount": 1, "namespace":
+    "dual-evpn", "hostname": "spine01", "iif": "swp6", "oif": "swp3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null,
+    "nexthopIp": "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 1, "hopCount":
+    2, "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822941},
+    {"pathid": 2, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit02", "iif":
+    "vlan13", "oif": "swp1", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822167}, {"pathid": 2, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp5", "oif": "swp3", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 2, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp1", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822941},
+    {"pathid": 3, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit01", "iif":
+    "vlan13", "oif": "swp1", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 3, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822983},
+    {"pathid": 4, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit02", "iif":
+    "vlan13", "oif": "swp1", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822167}, {"pathid": 4, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine01", "iif": "swp5", "oif": "swp4", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 4, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp1", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822983},
+    {"pathid": 5, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit01", "iif":
+    "vlan13", "oif": "swp2", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine02", "iif": "swp6", "oif": "swp3", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 5, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822941},
+    {"pathid": 6, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit02", "iif":
+    "vlan13", "oif": "swp2", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822167}, {"pathid": 6, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine02", "iif": "swp5", "oif": "swp3", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 6, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf03", "iif": "swp2", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822941},
+    {"pathid": 7, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit01", "iif":
+    "vlan13", "oif": "swp2", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine02", "iif": "swp6", "oif": "swp4", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 7, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822983},
+    {"pathid": 8, "hopCount": 0, "namespace": "dual-evpn", "hostname": "exit02", "iif":
+    "vlan13", "oif": "swp2", "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch":
+    true, "inMtu": 9000, "outMtu": 9216, "protocol": "kernel", "ipLookup": "172.16.2.0/24",
+    "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "169.254.0.1", "hopError":
+    "", "timestamp": 1616644822167}, {"pathid": 8, "hopCount": 1, "namespace": "dual-evpn",
+    "hostname": "spine02", "iif": "swp5", "oif": "swp4", "vrf": "default", "isL2":
+    true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol":
+    "bgp", "ipLookup": "10.0.0.134", "vtepLookup": "", "macLookup": null, "nexthopIp":
+    "", "hopError": "", "timestamp": 1616644822008}, {"pathid": 8, "hopCount": 2,
+    "namespace": "dual-evpn", "hostname": "leaf04", "iif": "swp2", "oif": "bond02",
+    "vrf": "default", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    1500, "outMtu": 1500, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "Dst MTU != Src MTU", "timestamp": 1616644822983}]'
 - command: path show --dest=10.0.0.11 --src=10.0.0.14 --namespace=ospf-single --format=json
   data-directory: tests/data/parquet/
   marks: path show cumulus
@@ -3405,3 +3507,9 @@ tests:
   marks: path top cumulus
   output: '[{"hostname": "leaf04"}, {"hostname": "leaf04"}, {"hostname": "spine01"},
     {"hostname": "leaf01"}, {"hostname": "spine02"}]'
+- command: path show --dest=172.16.2.104 --src=172.16.21.104 --namespace=dual-evpn
+    --format=json
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Unable to find starting node for 172.16.21.104"}]'
+  marks: path show cumulus

--- a/tests/integration/sqcmds/eos-samples/path.yml
+++ b/tests/integration/sqcmds/eos-samples/path.yml
@@ -155,9 +155,152 @@ tests:
     1623025174543}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=eos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: Invalid src 172.16.1.104"}]'
   marks: path show eos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "eos", "hostname": "leaf02",
+    "iif": "Vlan10", "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1623025174530}, {"pathid": 1, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 1, "hopCount": 2, "namespace": "eos", "hostname": "leaf03", "iif":
+    "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569}, {"pathid": 1, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 2, "hopCount": 0, "namespace": "eos", "hostname": "leaf01",
+    "iif": "Vlan10", "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1623025174542}, {"pathid": 2, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 2, "hopCount": 2, "namespace": "eos", "hostname": "leaf03", "iif":
+    "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569}, {"pathid": 2, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 3, "hopCount": 0, "namespace": "eos", "hostname": "leaf02",
+    "iif": "Vlan10", "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1623025174530}, {"pathid": 3, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549},
+    {"pathid": 3, "hopCount": 2, "namespace": "eos", "hostname": "leaf03", "iif":
+    "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569}, {"pathid": 3, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 4, "hopCount": 0, "namespace": "eos", "hostname": "leaf01",
+    "iif": "Vlan10", "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1623025174542}, {"pathid": 4, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet3", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.13", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549},
+    {"pathid": 4, "hopCount": 2, "namespace": "eos", "hostname": "leaf03", "iif":
+    "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025175569}, {"pathid": 4, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 5, "hopCount": 0, "namespace": "eos", "hostname": "leaf02",
+    "iif": "Vlan10", "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1623025174530}, {"pathid": 5, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 5, "hopCount": 2, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 5, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 6, "hopCount": 0, "namespace": "eos", "hostname": "leaf01",
+    "iif": "Vlan10", "oif": "Ethernet1", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1623025174542}, {"pathid": 6, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine01", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174547},
+    {"pathid": 6, "hopCount": 2, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet1", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 6, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 7, "hopCount": 0, "namespace": "eos", "hostname": "leaf02",
+    "iif": "Vlan10", "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1623025174530}, {"pathid": 7, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine02", "iif": "Ethernet2", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549},
+    {"pathid": 7, "hopCount": 2, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 7, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}, {"pathid": 8, "hopCount": 0, "namespace": "eos", "hostname": "leaf01",
+    "iif": "Vlan10", "oif": "Ethernet2", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9164, "outMtu": 1500, "protocol": "ibgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1623025174542}, {"pathid": 8, "hopCount": 1, "namespace":
+    "eos", "hostname": "spine02", "iif": "Ethernet1", "oif": "Ethernet4", "vrf": "default",
+    "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 1500, "outMtu": 1500,
+    "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134", "macLookup":
+    "", "nexthopIp": "10.0.0.14", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025174549},
+    {"pathid": 8, "hopCount": 2, "namespace": "eos", "hostname": "leaf04", "iif":
+    "Ethernet2", "oif": "Port-Channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 1500, "outMtu": 9214, "protocol": "connected",
+    "ipLookup": "172.16.3.0/24", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025176019}, {"pathid": 8, "hopCount":
+    3, "namespace": "eos", "hostname": "server302", "iif": "bond0", "oif": "bond0",
+    "vrf": "evpn-vrf", "isL2": false, "overlay": false, "mtuMatch": false, "inMtu":
+    9216, "outMtu": 9216, "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup":
+    "", "nexthopIp": "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp":
+    1623025175379}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=eos
   data-directory: tests/data/parquet/
   marks: path show eos
@@ -996,3 +1139,8 @@ tests:
   marks: path top eos
   output: '[{"hostname": "server101"}, {"hostname": "server101"}, {"hostname": "server101"},
     {"hostname": "server101"}, {"hostname": "server101"}]'
+- command: path show --dest=172.16.3.202 --src=172.16.21.104 --format=json --namespace=eos
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Unable to find starting node for 172.16.21.104"}]'
+  marks: path show eos

--- a/tests/integration/sqcmds/junos-samples/path.yml
+++ b/tests/integration/sqcmds/junos-samples/path.yml
@@ -47,9 +47,43 @@ tests:
     "", "hopError": "Hop MTU < Src Mtu", "timestamp": 1623025802263}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=junos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: Invalid src 172.16.1.104"}]'
   marks: path show junos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "junos", "hostname": "leaf01",
+    "iif": "irb.10", "oif": "xe-0/0/0.0", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 1500, "outMtu": 9200, "protocol": "evpn", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1623025801173}, {"pathid": 1, "hopCount": 1, "namespace":
+    "junos", "hostname": "spine01", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
+    9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.12", "hopError": "", "timestamp": 1623025802890},
+    {"pathid": 1, "hopCount": 2, "namespace": "junos", "hostname": "leaf02", "iif":
+    "xe-0/0/0.0", "oif": "xe-0/0/3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol": "evpn", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1623025797587}, {"pathid": 1, "hopCount": 3, "namespace":
+    "junos", "hostname": "server202", "iif": "eth1", "oif": "eth1", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1623025795928},
+    {"pathid": 2, "hopCount": 0, "namespace": "junos", "hostname": "leaf01", "iif":
+    "irb.10", "oif": "xe-0/0/1.0", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 1500, "outMtu": 9200, "protocol": "evpn", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.12", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1623025801173}, {"pathid": 2, "hopCount": 1, "namespace":
+    "junos", "hostname": "spine02", "iif": "xe-0/0/0.0", "oif": "xe-0/0/1.0", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9200, "outMtu":
+    9200, "protocol": "ospf", "ipLookup": "10.0.0.12", "vtepLookup": "10.0.0.12",
+    "macLookup": "", "nexthopIp": "10.0.0.12", "hopError": "", "timestamp": 1623025802688},
+    {"pathid": 2, "hopCount": 2, "namespace": "junos", "hostname": "leaf02", "iif":
+    "xe-0/0/1.0", "oif": "xe-0/0/3", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9200, "outMtu": 1514, "protocol": "evpn", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1623025797587}, {"pathid": 2, "hopCount": 3, "namespace":
+    "junos", "hostname": "server202", "iif": "eth1", "oif": "eth1", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": false, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1623025795928}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=junos
   data-directory: tests/data/parquet/
   marks: path show junos
@@ -337,3 +371,8 @@ tests:
   marks: path top junos
   output: '[{"hostname": "server101"}, {"hostname": "server101"}, {"hostname": "spine01"},
     {"hostname": "leaf02"}, {"hostname": "spine02"}]'
+- command: path show --dest=172.16.3.202 --src=172.16.21.104 --format=json --namespace=junos
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Unable to find starting node for 172.16.21.104"}]'
+  marks: path show junos

--- a/tests/integration/sqcmds/nxos-samples/path.yml
+++ b/tests/integration/sqcmds/nxos-samples/path.yml
@@ -154,9 +154,151 @@ tests:
     "", "nexthopIp": "", "hopError": "", "timestamp": 1619275257671}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.104 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
-  error:
-    error: '[{"error": "ERROR: Invalid src 172.16.1.104"}]'
   marks: path show nxos
+  output: '[{"pathid": 1, "hopCount": 0, "namespace": "nxos", "hostname": "leaf01",
+    "iif": "Vlan10", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    false, "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1619275257674}, {"pathid": 1, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "", "timestamp": 1619275257467},
+    {"pathid": 1, "hopCount": 2, "namespace": "nxos", "hostname": "leaf03", "iif":
+    "Ethernet1/1", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257018}, {"pathid": 1, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 2, "hopCount": 0, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "Vlan10", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1619275257446}, {"pathid": 2, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "", "timestamp": 1619275257467},
+    {"pathid": 2, "hopCount": 2, "namespace": "nxos", "hostname": "leaf03", "iif":
+    "Ethernet1/1", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257018}, {"pathid": 2, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 3, "hopCount": 0, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "Vlan10", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1619275257674}, {"pathid": 3, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/3", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "", "timestamp": 1619275257123},
+    {"pathid": 3, "hopCount": 2, "namespace": "nxos", "hostname": "leaf03", "iif":
+    "Ethernet1/2", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257018}, {"pathid": 3, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 4, "hopCount": 0, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "Vlan10", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1619275257446}, {"pathid": 4, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/3", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.13", "hopError": "", "timestamp": 1619275257123},
+    {"pathid": 4, "hopCount": 2, "namespace": "nxos", "hostname": "leaf03", "iif":
+    "Ethernet1/2", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257018}, {"pathid": 4, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 5, "hopCount": 0, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "Vlan10", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1619275257674}, {"pathid": 5, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine01", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "", "timestamp": 1619275257467},
+    {"pathid": 5, "hopCount": 2, "namespace": "nxos", "hostname": "leaf04", "iif":
+    "Ethernet1/1", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257479}, {"pathid": 5, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 6, "hopCount": 0, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "Vlan10", "oif": "Ethernet1/1", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.21",
+    "hopError": "", "timestamp": 1619275257446}, {"pathid": 6, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine01", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "", "timestamp": 1619275257467},
+    {"pathid": 6, "hopCount": 2, "namespace": "nxos", "hostname": "leaf04", "iif":
+    "Ethernet1/1", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257479}, {"pathid": 6, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 7, "hopCount": 0, "namespace": "nxos", "hostname": "leaf01", "iif":
+    "Vlan10", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1619275257674}, {"pathid": 7, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine02", "iif": "Ethernet1/1", "oif": "Ethernet1/4", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "", "timestamp": 1619275257123},
+    {"pathid": 7, "hopCount": 2, "namespace": "nxos", "hostname": "leaf04", "iif":
+    "Ethernet1/2", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257479}, {"pathid": 7, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321},
+    {"pathid": 8, "hopCount": 0, "namespace": "nxos", "hostname": "leaf02", "iif":
+    "Vlan10", "oif": "Ethernet1/2", "vrf": "evpn-vrf", "isL2": false, "overlay": false,
+    "mtuMatch": true, "inMtu": 9000, "outMtu": 9216, "protocol": "bgp", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "10.0.0.134", "macLookup": "", "nexthopIp": "10.0.0.22",
+    "hopError": "", "timestamp": 1619275257446}, {"pathid": 8, "hopCount": 1, "namespace":
+    "nxos", "hostname": "spine02", "iif": "Ethernet1/2", "oif": "Ethernet1/4", "vrf":
+    "default", "isL2": true, "overlay": true, "mtuMatch": true, "inMtu": 9216, "outMtu":
+    9216, "protocol": "ospf", "ipLookup": "10.0.0.134", "vtepLookup": "10.0.0.134",
+    "macLookup": "", "nexthopIp": "10.0.0.14", "hopError": "", "timestamp": 1619275257123},
+    {"pathid": 8, "hopCount": 2, "namespace": "nxos", "hostname": "leaf04", "iif":
+    "Ethernet1/2", "oif": "port-channel4", "vrf": "evpn-vrf", "isL2": false, "overlay":
+    true, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216, "protocol": "hmm", "ipLookup":
+    "172.16.3.202/32", "vtepLookup": "", "macLookup": "", "nexthopIp": "172.16.3.202",
+    "hopError": "", "timestamp": 1619275257479}, {"pathid": 8, "hopCount": 3, "namespace":
+    "nxos", "hostname": "server302", "iif": "bond0", "oif": "bond0", "vrf": "evpn-vrf",
+    "isL2": false, "overlay": false, "mtuMatch": true, "inMtu": 9216, "outMtu": 9216,
+    "protocol": "", "ipLookup": "", "vtepLookup": "", "macLookup": "", "nexthopIp":
+    "", "hopError": "no reverse path, Dst MTU != Src MTU", "timestamp": 1619275256321}]'
 - command: path show --dest=172.16.3.202 --src=172.16.1.101 --format=json --namespace=nxos
   data-directory: tests/data/parquet/
   marks: path show nxos
@@ -954,3 +1096,8 @@ tests:
   marks: path top nxos
   output: '[{"hostname": "server101"}, {"hostname": "leaf01"}, {"hostname": "spine02"},
     {"hostname": "leaf02"}, {"hostname": "server101"}]'
+- command: path show --dest=172.16.3.202 --src=172.16.21.104 --format=json --namespace=nxos
+  data-directory: tests/data/parquet/
+  error:
+    error: '[{"error": "ERROR: Unable to find starting node for 172.16.21.104"}]'
+  marks: path show nxos


### PR DESCRIPTION
Handle path when the source is not in ARP or as interface on a polled node, by seeking the SVI associated with that source.

## Type of change

Enhancement

## New Behavior

Without this patch, if you provide a source IP address that is not in the arpnd table or as the address of an interface on a polled device, the command fails with "invalid src:...". With this patch, we find the SVI associated with the IP and start tracing from that node's SVI. 

If we cannot find an SVI, we flag the error: "unable to find a source node to start for <source IP>"


## Discussion: Benefits and Drawbacks

This is a useful feature for many people using path because the source's ARP entry may have timed out, people are testing a hypothetical source etc.

## Changes to the Documentation

None.

## Proposed Release Note Entry

ENHANCEMENT: path now supports specifying a source IP that may not be in the ARPND table. We determine the SVI node(s) associated with the IP and start the trace from there. Furthermore, the error message associated with a source IP whose source node we cannot locate is made more user-friendly now.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
