### PR TITLE
Node: fix SONiC detection, and bug fix

### DIFF
--- a/suzieq/config/textfsm_templates/sonic_showsys.tfsm
+++ b/suzieq/config/textfsm_templates/sonic_showsys.tfsm
@@ -9,6 +9,7 @@ Start
   ^${bootupTimestamp}.*$$
   ^\s*Architecture:\s+${architecture}\s*$$
   ^SONiC Software Version\s*:\s*${version}\s*$$
+  ^Software\s+Version\s*:\s*${version}.*$$
   ^Product: Enterprise SONiC Distribution by\s*${vendor}\s*$$
   ^HwSKU\s*:\s+${model}\s*$$
   ^Serial Number: ${serialNumber}

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -2093,7 +2093,7 @@ class SonicNode(Node):
         if (len(output) > 1) and (output[1]["status"] == 0):
             self.hostname = output[1]["data"].strip()
         if (len(output) > 2) and (output[2]["status"] == 0):
-            self._extract_nos_version(output[1]["data"])
+            self._extract_nos_version(output[2]["data"])
 
     def _extract_nos_version(self, data: str) -> None:
         match = re.search(r'Version:\s+SONiC-OS-([^-]+)', data)


### PR DESCRIPTION
The newer SONiC versions have a different string to match to extract the version. Add that. Plus, fix a bug in extracting the version during device init.

# Set `develop` as target branch of this PR (delete this line before issuing the PR)


## Description

Fix detection of SONiC devices and version extraction of newer SONiC versions.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

SONiC newer versions are correctly detected as SONiC, and version correctly extracted for all versions, old and new.
...

## Proposed Release Note Entry

* Fix SONiC auto detect for newer versions, and fix version extraction for SONiC devices
<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
