### PR TITLE
sq-poller: Fix reference to undefined self.prompt in _ssh_connect

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1679,7 +1679,6 @@ class IosXENode(Node):
 
     async def _fetch_init_dev_data_devtype(self, reconnect: bool):
         """Fill in the boot time of the node by executing certain cmds"""
-        self.prompt = self.IOS_DEFAULT_PROMPT
         await self._exec_cmd(self._parse_init_dev_data,
                              ["show version"], None, 'text',
                              reconnect=reconnect)
@@ -1689,6 +1688,7 @@ class IosXENode(Node):
         enough as we need to start an interactive session for XE.
         """
         await super()._ssh_connect()
+        self.prompt = self.IOS_DEFAULT_PROMPT
 
         if self.is_connected and not self._stdin:
             self.logger.info(


### PR DESCRIPTION
## Description

_ssh_connect was refactored in PR #877 and introduced a reference to self.prompt before prompt was defined.

This resulted in the error:
```
suzieq.poller.worker.nodes.node - ERROR - Unable to create persistent SSH session for 1.2.3.4 due to 'IosXENode' object has no attribute 'prompt'
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Comments

I've defined self.prompt after call to super() but it might make sense to set before call.


## Double Check

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
