### PR TITLE
fix(suzieq/poller/worker/services/interfaces.py): change xcvr unsupported adminState for NX-OS

### DIFF
--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -674,7 +674,7 @@ class InterfaceService(Service):
 
                 if entry['reason'] == "xcvr not inserted":
                     entry['state'] = 'notConnected'
-                    entry['adminState'] = 'notConnected'
+                    entry['adminState'] = 'down'
 
             if entry.get('reason', '') == 'administratively down':
                 entry['adminState'] = 'down'

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -669,9 +669,12 @@ class InterfaceService(Service):
                 if entry['reason'] == 'none' or not entry['reason']:
                     entry['reason'] = ''
 
-                if entry['reason'] in ["link not connected",
-                                       "xcvr not inserted"]:
+                if entry['reason'] == "link not connected":
                     entry['state'] = 'notConnected'
+
+                if entry['reason'] == "xcvr not inserted":
+                    entry['state'] = 'notConnected'
+                    entry['adminState'] = 'notConnected'
 
             if entry.get('reason', '') == 'administratively down':
                 entry['adminState'] = 'down'


### PR DESCRIPTION
## Related Issue

Fixes #930 

## Description

`XCVR not inserted` should be managed as admin down interface.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

When dealing with Cisco NX-OS, output for shutdown interface when SFP is not inserted is the following : 

```console
cisco# show interface brief
<...>
--------------------------------------------------------------------------------
Ethernet      VLAN    Type Mode   Status  Reason                   Speed     Port
Interface                                                                    Ch #
--------------------------------------------------------------------------------
Eth1/1        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/2        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/3        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/4        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/5        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/6        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/7        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/8        --      eth  routed down    XCVR not inserted          auto(D) --
Eth1/9        1       eth  trunk  up      none                        25G(D) 9
Eth1/10       --      eth  routed up      none                        25G(D) --
Eth1/11       1       eth  trunk  up      none                        25G(D) --
Eth1/12       --      eth  routed up      none                        25G(D) --
```

Even if the interface is in shutdown adminState.

...

## Contrast to Current Behavior

In the following line, this is considered as if the link is not connected, even if the interface is set to shutdown state.

```python
                if entry['reason'] in ["link not connected",
                                       "xcvr not inserted"]:
                    entry['state'] = 'notConnected'
```

Creating a specific case for the entry reason "xcvr not inserted" to change adminState to down:

```python
               if entry['reason'] == "xcvr not inserted":
                    entry['state'] = 'notConnected'
                    entry['adminState'] = 'down'
```


## Discussion: Benefits and Drawbacks

It will help to show interfaces really down, as an interface with no XCVR is by default shutdown.

## Changes to the Documentation

None

## Proposed Release Note Entry

Consider NX-OS interface with Reason 'XCVR not inserted' as adminState=down
...

## Comments

None

## Double Check

- [X ] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
