### PR TITLE
Bug #925 fix

### DIFF
--- a/suzieq/engines/pandas/topology.py
+++ b/suzieq/engines/pandas/topology.py
@@ -29,6 +29,7 @@ class TopologyObj(SqPandasEngine):
         self.lsdb = pd.DataFrame()
         self._a_df = pd.DataFrame()
         self._ip_table = pd.DataFrame()
+        self._namespaces = []
 
     @staticmethod
     def table_name():
@@ -77,7 +78,7 @@ class TopologyObj(SqPandasEngine):
             extra_cols: list
             augment: any
 
-        self._namespaces = kwargs.get("namespace", self.ctxt.namespace)
+        self._namespaces = kwargs.get("namespace", self.ctxt.namespace) or []
         hostname = kwargs.pop('hostname', [])
         user_query = kwargs.pop('query_str', '')
         polled = kwargs.pop('polled', '')


### PR DESCRIPTION
## Bug #925  Report Summary

A user reported a usability issue with Suzieq version 0.22.0 when using the Python API to retrieve path information. The API call was made with `namespace` provided as a string instead of a list, leading to an `EmptyDataframeError`. The error did not clearly indicate the cause, leading to confusion.

## Changes Made

To address this issue, two significant changes were implemented:

### Introduction of Argument Validation in `basicobj.py`:

- A new method `_validate_list_args` was added to enforce that certain arguments, specifically `namespace` and `hostname`, are provided as lists. If these arguments are not lists, the method raises a `TypeError` with a clear and informative error message. 


### Modification in `topology.py`:

- The initialization of `self._namespaces` was set to an empty list `[]`. 
- In the `get` method, `self._namespaces` was changed to default to an empty list `[]` instead of using `self.ctxt.namespace`. This modification was implemented to address testing issues that arose following the introduction of `_validate_list_args` in `basicobj.py`.
