### PR TITLE
Fixed issue ospf gui (Issue #929)

### DIFF
--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -103,11 +103,13 @@ class OspfObj(SqPandasEngine):
         nbr_df = self._get_table_sqobj('ospfNbr') \
                      .get(columns=nbrcols, **kwargs)
         if nbr_df.empty:
-            missing_cols = set(ospfschema.get_display_fields(['default'])) - set(df.columns)
+            ospf_clmns = ospfschema.get_display_fields(['default'])
+            missing_cols = set(ospf_clmns) - set(df.columns)
             for col in missing_cols:
                 df[col] = np.nan
             df = df.fillna({'peerIP': '-', 'peerHostname': '',
-                        'lastChangeTime': 0, 'numChanges': 0, 'ifState': '', 'adjState': ''})
+                            'lastChangeTime': 0, 'numChanges': 0,
+                            'ifState': '', 'adjState': ''})
             return df
 
         merge_cols = [x for x in ['namespace', 'hostname', 'ifname']

--- a/suzieq/engines/pandas/ospf.py
+++ b/suzieq/engines/pandas/ospf.py
@@ -39,6 +39,7 @@ class OspfObj(SqPandasEngine):
 
         ifschema = SchemaForTable('ospfIf', schema=self.all_schemas)
         nbrschema = SchemaForTable('ospfNbr', schema=self.all_schemas)
+        ospfschema = SchemaForTable('ospf', schema=self.all_schemas)
 
         if columns not in [['default'], ['*']]:
             ifkeys = ifschema.key_fields()
@@ -102,6 +103,11 @@ class OspfObj(SqPandasEngine):
         nbr_df = self._get_table_sqobj('ospfNbr') \
                      .get(columns=nbrcols, **kwargs)
         if nbr_df.empty:
+            missing_cols = set(ospfschema.get_display_fields(['default'])) - set(df.columns)
+            for col in missing_cols:
+                df[col] = np.nan
+            df = df.fillna({'peerIP': '-', 'peerHostname': '',
+                        'lastChangeTime': 0, 'numChanges': 0, 'ifState': '', 'adjState': ''})
             return df
 
         merge_cols = [x for x in ['namespace', 'hostname', 'ifname']


### PR DESCRIPTION
A user reported an `AttributeError` occuring when using the main GUI page when having no OSPF tables.

## Related Issue

#929 

## Description

The error originated from the ospf engine: when merging the ospfNbr and ospfIf tables, the code didn't ensure that the schema was correct also in case of missing data. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
