### PR TITLE
Cumulus lldp subtype parsing error

### DIFF
--- a/suzieq/poller/worker/services/lldp.py
+++ b/suzieq/poller/worker/services/lldp.py
@@ -161,6 +161,8 @@ class LldpService(Service):
                 entry['subtype'] = "interface name"
             elif subtype == "local":
                 entry['subtype'] = "locally assigned"
+            elif subtype == 'mac':
+                entry['subtype'] = "mac address"
 
             self._common_cleaner(entry)
 


### PR DESCRIPTION
## Description
There is an error for cumulus devices with the lldp service. For some entries we put mac as subtype instead of mac address. This Pr fix it 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
