### PR TITLE
Wrong selection of service definition for version

### DIFF
--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1072,8 +1072,8 @@ class Node:
                     for item in use:
                         if item.get('version', '') != "all":
                             os_version = item['version']
-                            opdict = {'>': operator.gt, '<': operator.lt,
-                                      '>=': operator.ge, '<=': operator.le,
+                            opdict = {'>=': operator.ge, '<=': operator.le,
+                                      '>': operator.gt, '<': operator.lt,
                                       '=': operator.eq, '!=': operator.ne}
                             op = operator.eq
 


### PR DESCRIPTION
## Description
There is a bug in the node, which cause the wrong selection of the nos version.
It happen with the operator >= (ge) and <= (le).
This PR fix it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
