### PR TITLE
Eos routes wrong nexthopIps for protocol=connected entries

### DIFF
--- a/suzieq/poller/worker/services/routes.py
+++ b/suzieq/poller/worker/services/routes.py
@@ -48,6 +48,8 @@ class RoutesService(Service):
                 entry['oifs'] = len(entry['nexthopIps']) * \
                     ['_nexthopVrf:default']
             entry['protocol'] = entry['protocol'].lower()
+            if entry['protocol'] == 'connected':
+                entry['nexthopIps'] = []
             entry['preference'] = int(entry.get('preference', 0))
             entry['metric'] = int(entry.get('metric', 0))
             self._fix_ipvers(entry)


### PR DESCRIPTION
## Description
With eos devices, when we have an entry with protocol = connected we put 0.0.0.0 as nexthopIps while we should leave it empty.
The PR fix it

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
