### PR TITLE
bgp: make bfdStatus be lowercase for nonestd sessions

### DIFF
--- a/suzieq/poller/worker/services/bgp.py
+++ b/suzieq/poller/worker/services/bgp.py
@@ -40,6 +40,7 @@ class BgpService(Service):
                 entry['afi'] = entry['safi'] = ''
                 if not entry.get('bfdStatus', ''):
                     entry['bfdStatus'] = ''
+                entry['bfdStatus'] = entry['bfdStatus'].lower()
                 if (entry.get('holdTime', '0') == '0' and
                         entry.get('configHoldtime', '')):
                     entry['holdTime'] = entry['configHoldtime']
@@ -464,15 +465,16 @@ class BgpService(Service):
         drop_indices = []
 
         for i, entry in enumerate(processed_data):
-            if entry['state'] != 'Established':
-                continue
-
             bfd_status = entry.get('bfdStatus', 'disabled').lower()
             if not bfd_status or (bfd_status == "unknown"):
                 bfd_status = "disabled"
             entry['bfdStatus'] = bfd_status
 
             self._normalize_asn(entry)
+
+            if entry['state'] != 'Established':
+                continue
+
             for afi in entry.get('_afiInfo', {}):
                 if afi in (entry.get('afisAdvOnly', []) or []):
                     continue
@@ -662,7 +664,7 @@ class BgpService(Service):
             if "peerIP" in entry:
                 peerIp = entry.get("peerIP", "").split(":")[0]
                 entry["peerIP"] = peerIp
-                entry["bfdStatus"] = bfdDict.get(peerIp, "")
+                entry["bfdStatus"] = bfdDict.get(peerIp, "").lower()
 
             if "updateSource" in entry:
                 entry["updateSource"] = entry.get(


### PR DESCRIPTION
## Description
BGP's bfdStatus was not lowercased for Cumulus/EOS when session was not in Estd state.
This PR fix it

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
