### PR TITLE
Vlan remove state key

### DIFF
--- a/suzieq/config/schema/vlan.avsc
+++ b/suzieq/config/schema/vlan.avsc
@@ -39,7 +39,6 @@
         {
             "name": "state",
             "type": "string",
-            "key": 2,
             "display": 4,
             "description": "VLAN state: active or suspended"
         },

--- a/tests/integration/sqcmds/common-samples/describe.yml
+++ b/tests/integration/sqcmds/common-samples/describe.yml
@@ -575,7 +575,7 @@ tests:
     carrying this VLAN"}, {"name": "namespace", "type": "string", "key": 0, "display":
     0, "description": "Namespace associated with record"}, {"name": "sqvers", "type":
     "string", "key": "", "display": "", "description": "Schema version, not selectable"},
-    {"name": "state", "type": "string", "key": 2, "display": 4, "description": "VLAN
+    {"name": "state", "type": "string", "key": "", "display": 4, "description": "VLAN
     state: active or suspended"}, {"name": "timestamp", "type": "timestamp", "key":
     "", "display": 7, "description": ""}, {"name": "vlan", "type": "long", "key":
     "", "display": 6, "description": "VLAN ID"}, {"name": "vlanName", "type": "string",


### PR DESCRIPTION
## Description
The state column was a key of vlan table. I removed it.
We should migrate the data, but the user won't see any difference because:

view=all/changes do not drop duplicates, hence the result won't change
view=latest do the drop duplicates on the keys. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied