### PR TITLE
Fix sonic routes version 4.2 

### DIFF
--- a/suzieq/config/routes.yml
+++ b/suzieq/config/routes.yml
@@ -25,7 +25,16 @@ apply:
     copy: cumulus
 
   sonic:
-    copy: cumulus
+    - version: '>= 4.2.0'
+      merge: False
+      command:
+        - command: ip vrf show
+          textfsm: textfsm_templates/sonic_vrf_show.tfsm
+        - command: ip route show table all
+          textfsm: textfsm_templates/sonic_routes_v42.tfsm
+    - version: all
+      command: ip route show table all
+      textfsm: textfsm_templates/linux_routes.tfsm
 
   eos:
     version: all

--- a/suzieq/config/textfsm_templates/sonic_routes_v42.tfsm
+++ b/suzieq/config/textfsm_templates/sonic_routes_v42.tfsm
@@ -1,0 +1,24 @@
+Value protocol (\w+)
+Value Required prefix ([0-9./]*|[0-9a-f:/]*|default)
+Value vrf_id (\d+)
+Value source ([0-9./]*)
+Value List nexthopIps ([0-9./]*|[0-9a-f:/]*)
+Value List oifs (\S+)
+Value List weights (\d+)
+Value metric (\d+)
+Value action (blackhole)
+
+Start
+  ^\S+ -> Continue.Record
+  ^${action}\s+(?:nhid \d+\s+)?${prefix}\s+proto ${protocol}\s+metric ${metric}.*$$
+  ^\s+nexthop via\s+${nexthopIps}\s+dev ${oifs}\s+weight ${weights}.*$$
+  ^${prefix}\s+(?:nhid \d+\s+)?via\s+${nexthopIps}\s+dev ${oifs}\s+table ${vrf_id}\s+proto ${protocol}\s+metric ${metric}.*$$
+  ^${prefix}\s+(?:nhid \d+\s+)?dev ${oifs}\s+table ${vrf_id}\s+proto ${protocol}.*src ${source}.*$$
+  ^unreachable\s+(?:nhid \d+\s+)?${prefix}\s+table ${vrf_id}\s+metric ${metric}.*$$
+  ^${prefix}\s+(?:nhid \d+\s+)?via\s+${nexthopIps}\s+dev ${oifs}\s+table ${vrf_id}
+  ^${prefix}\s+(?:nhid \d+\s+)?proto ${protocol}\s+metric ${metric}.*$$
+  ^${prefix}\s+(?:nhid \d+\s+)?proto ${protocol}\s+src ${source}\s+metric ${metric}.*$$  
+  ^${prefix}\s+(?:nhid \d+\s+)?via ${nexthopIps}\s+dev ${oifs}\s+proto ${protocol}\s+metric ${metric}.*$$ 
+  ^${prefix}\s+(?:nhid \d+\s+)?dev ${oifs}\s+proto ${protocol}.*src ${source}.*$$  
+  ^${prefix}\s+(?:nhid \d+\s+)?via ${nexthopIps}\s+dev ${oifs}.*$$
+  ^${prefix}\s+(?:nhid \d+\s+)?table ${vrf_id}\s+proto ${protocol}\s+metric ${metric}

--- a/suzieq/config/textfsm_templates/sonic_vrf_show.tfsm
+++ b/suzieq/config/textfsm_templates/sonic_vrf_show.tfsm
@@ -1,0 +1,5 @@
+Value vrf (\S+)
+Value table_id (\d+)
+
+Start
+  ^${vrf}\s+${table_id} -> Record

--- a/suzieq/poller/worker/services/routes.py
+++ b/suzieq/poller/worker/services/routes.py
@@ -1,4 +1,5 @@
 import re
+from typing import Dict, List
 import numpy as np
 
 from suzieq.poller.worker.services.service import Service
@@ -56,9 +57,18 @@ class RoutesService(Service):
 
     def _clean_linux_data(self, processed_data, _):
         """Clean Linux ip route data"""
+        drop_indices: List[int] = []
+        id_vrf_match: Dict[str, str] = {}
 
-        for entry in processed_data:
-            entry["vrf"] = entry["vrf"] or "default"
+        for i, entry in enumerate(processed_data):
+            if table_id := entry.get('table_id'):
+                id_vrf_match[table_id] = entry.get('vrf') or 'default'
+                drop_indices.append(i)
+                continue
+            if vrf_id := entry.get('vrf_id'):
+                entry["vrf"] = id_vrf_match.get(vrf_id) or 'default'
+            else:
+                entry["vrf"] = entry.get("vrf") or "default"
             entry["metric"] = entry["metric"] or 20
             entry['preference'] = entry['metric']
             for ele in ["nexthopIps", "oifs"]:
@@ -84,6 +94,10 @@ class RoutesService(Service):
                 entry["oifs"] = ["blackhole"]
 
             entry['inHardware'] = True  # Till the offload flag is here
+
+        if drop_indices:
+            processed_data = np.delete(
+                processed_data, drop_indices).tolist()   # type: ignore
 
         return processed_data
 

--- a/suzieq/poller/worker/services/service.py
+++ b/suzieq/poller/worker/services/service.py
@@ -321,8 +321,8 @@ class Service(SqPlugin):
                 # There are various outputs that due to an old parsing bug
                 # return a node version of 0. Use 'all' for those
                 continue
-            opdict = {'>': operator.gt, '<': operator.lt,
-                      '>=': operator.ge, '<=': operator.le,
+            opdict = {'>=': operator.ge, '<=': operator.le,
+                      '>': operator.gt, '<': operator.lt,
                       '=': operator.eq, '!=': operator.ne}
             op = operator.eq
 


### PR DESCRIPTION
## Description
SONIC 4.2 doesn't provide the VRF name in the route table output. We need to extract the vrf from the output of ip vrf.
This PR implement the fix

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
