### PR TITLE
sonic: change some interfaces to 'internal'

### DIFF
--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from collections import defaultdict
 from json import loads
+from typing import Dict
 import numpy as np
 
 from suzieq.poller.worker.services.service import Service
@@ -202,25 +203,22 @@ class InterfaceService(Service):
 
         return processed_data
 
-    def _clean_cumulus_data(self, processed_data, _):
-        """We have to merge the appropriate outputs of two separate commands"""
+    def _entry_cumulus_sonic_cleaner(self, entry: Dict):
+        if entry.get('hardware', '') == 'ether':
+            entry['type'] = 'ethernet'
 
-        for entry in processed_data:
-            if entry.get('hardware', '') == 'ether':
-                entry['type'] = 'ethernet'
+        if entry['adminState'] == "down":
+            entry['state'] = "down"
 
-            if entry['adminState'] == "down":
-                entry['state'] = "down"
+        if entry['type'] == 'ether':
+            entry['type'] = 'ethernet'
+        if entry.get('type', '') == 'vxlan':
+            entry['speed'] = NO_SPEED
 
-            if entry['type'] == 'ether':
-                entry['type'] = 'ethernet'
-            if entry.get('type', '') == 'vxlan':
-                entry['speed'] = NO_SPEED
-
-            if not entry['linkUpCnt']:
-                entry['linkUpCnt'] = 0
-            if not entry['linkDownCnt']:
-                entry['linkDownCnt'] = 0
+        if not entry['linkUpCnt']:
+            entry['linkUpCnt'] = 0
+        if not entry['linkDownCnt']:
+            entry['linkDownCnt'] = 0
 
             entry["numChanges"] = (int(entry["linkUpCnt"]) +
                                    int(entry["linkDownCnt"]))
@@ -243,30 +241,36 @@ class InterfaceService(Service):
             entry["statusChangeTimestamp1"] = entry.get(
                 "statusChangeTimestamp", '')
 
-            if '(' in entry['master']:
-                entry['master'] = entry['master'].replace(
-                    '(', '').replace(')', '')
+        if '(' in entry['master']:
+            entry['master'] = entry['master'].replace(
+                '(', '').replace(')', '')
 
-            # Lowercase the master value thanks to SoNIC
-            entry['master'] = entry.get('master', '').lower()
-            if entry['ip6AddressList'] and 'ip6AddressList-_2nd' in entry:
-                # This is because textfsm adds peer LLA as well
-                entry['ip6AddressList'] = entry['ip6AddressList-_2nd']
+        # Lowercase the master value thanks to SoNIC
+        entry['master'] = entry.get('master', '').lower()
+        if entry['ip6AddressList'] and 'ip6AddressList-_2nd' in entry:
+            # This is because textfsm adds peer LLA as well
+            entry['ip6AddressList'] = entry['ip6AddressList-_2nd']
 
-            # Remove loopbacks
-            entry['ip6AddressList'] = [x for x in entry['ip6AddressList']
-                                       if x != "::1/128"]
+        # Remove loopbacks
+        entry['ip6AddressList'] = [x for x in entry['ip6AddressList']
+                                   if x != "::1/128"]
 
-            if 'type-_2nd' in entry:
-                entry['type'] = entry['type-_2nd']
+        if 'type-_2nd' in entry:
+            entry['type'] = entry['type-_2nd']
 
-            del entry["linkUpCnt"]
-            del entry["linkDownCnt"]
-            del entry["linkUpTimestamp"]
-            del entry["linkDownTimestamp"]
-            del entry["vrf"]
+        del entry["linkUpCnt"]
+        del entry["linkDownCnt"]
+        del entry["linkUpTimestamp"]
+        del entry["linkDownTimestamp"]
+        del entry["vrf"]
 
-            entry['speed'] = self._textfsm_valid_speed_value(entry)
+        entry['speed'] = self._textfsm_valid_speed_value(entry)
+
+    def _clean_cumulus_data(self, processed_data, _):
+        """We have to merge the appropriate outputs of two separate commands"""
+
+        for entry in processed_data:
+            self._entry_cumulus_sonic_cleaner(entry)
 
         return processed_data
 
@@ -956,8 +960,17 @@ class InterfaceService(Service):
     def _clean_ios_data(self, processed_data, raw_data):
         return self._clean_iosxr_data(processed_data, raw_data)
 
-    def _clean_sonic_data(self, processed_data, raw_data):
-        return self._clean_cumulus_data(processed_data, raw_data)
+    def _clean_sonic_data(self, processed_data, _):
+
+        internal_ifnames = ['BFDRX', 'BFDTX', 'CPU', 'bcm0', 'dummy']
+
+        for entry in processed_data:
+            self._entry_cumulus_sonic_cleaner(entry)
+
+            if entry.get('ifname', '') in internal_ifnames:
+                entry['type'] = 'internal'
+
+        return processed_data
 
     def _common_data_cleaner(self, processed_data, _):
         for entry in processed_data:


### PR DESCRIPTION
## Description
Some of Sonic internal interfaces wasn't parsed as internal. This PR fix it 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
