### PR TITLE
pandas/network.py: fix typo in finding fhr

### DIFF
--- a/suzieq/engines/pandas/network.py
+++ b/suzieq/engines/pandas/network.py
@@ -481,8 +481,8 @@ class NetworkObj(SqPandasEngine):
                     match_ifname = row.ifname
                     break
 
-                lldp_df = lldpobj.get(namespace=[row.namespace],
-                                      hostname=[row.hostname],
+                lldp_df = lldpobj.get(namespace=[match_namespace],
+                                      hostname=[match_hostname],
                                       ifname=mbr_ports)
 
                 if not lldp_df.empty:


### PR DESCRIPTION
# Set `develop` as target branch of this PR (delete this line before issuing the PR)

## Test inclusion requirements

No new tests as we don't have data relevant to this bug fix in our setup. It needs multiple levels of L2 network to reproduce this bug. User found it.

## Description

When there is more than one layer of L2 network to traverse to find the attached endpoint, a typo caused us to fail to find the right attached endpoint.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Fixed bug in locating correct endpoint when there's more than one layer of L2 network to traverse to find an endpoint.
...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
