### PR TITLE
Interface assert: fixed vlan mismatch assert for mlag peerlinks

### DIFF
--- a/suzieq/engines/pandas/interfaces.py
+++ b/suzieq/engines/pandas/interfaces.py
@@ -569,7 +569,7 @@ class InterfacesObj(SqPandasEngine):
 
         combined_df['assertReason'] += combined_df.apply(
             lambda x, mlag_peerlinks: []
-            if ((x.indexPeer > 0 and
+            if ((x.indexPeer >= 0 and
                 ((x.namespace, x.hostname, x.master) not in mlag_peerlinks) and
                  (set(x['vlanList']) == set(x['vlanListPeer']))) or
                 ((x.indexPeer < 0) or


### PR DESCRIPTION
## Related Issue

<!--Add the related issue in the form of #issue-number (Example #100)-->
Fixes #987 

## Description

Due to an issue reported by an user, we noticed that when a user run an `interface assert` on a dataset containing mlag peerlinks, the assert may or may not pass randomly.

The problem is that when we evaluate the vlan mismatch for mlag peerlinks, we were looking just for `indexPeer` less than 0 or greater than 0, without never checking the entry at index 0. This was the cause of that random behavior.

This PR fix it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Fixed interface assert vlan mismatch for mlag interfaces

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [X] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [X] I have explained my PR according to the information in the comments or in a linked issue.
- [X] My PR source branch is created from the `develop` branch.
- [X] My PR targets the `develop` branch.
- [X] All my commits have `--signoff` applied
