### PR TITLE
Handle PAN-OS poller cleaning edge cases

### DIFF
--- a/suzieq/poller/worker/services/arpnd.py
+++ b/suzieq/poller/worker/services/arpnd.py
@@ -117,7 +117,7 @@ class ArpndService(Service):
             # ARP entries are shown with status as merely a letter while
             # ND entries are shown with the status as a self-respecting word.
             # sigh
-            state = entry.get("state", "").lower()
+            state = (entry.get("state") or "").lower()
             if state in ["s", "static"]:
                 entry["state"] = "permanent"
             elif state in ["c", "e", "stale", "reachable"]:

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from collections import defaultdict
-from json import loads
+from json import loads, JSONDecodeError
 from typing import Dict
 import numpy as np
 
@@ -993,13 +993,32 @@ class InterfaceService(Service):
 
             # mtu values are collected separatly
             if _mtu_data:
+                try:
+                    _, json_blob = _mtu_data.split(": ", 1)
+                except ValueError:
+                    self.logger.warning(
+                        "Unexpected panos MTU data format: %s", _mtu_data)
+                    continue
+
                 # fix json so that it can be parsed
-                d = _mtu_data.split(": ", 1)[1].replace("'", "\"")
+                d = json_blob.replace("'", "\"")
                 d = re.sub(
                     r"([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})", r'"\1"', d)
                 d = re.sub(r"(\"[\w0-9\.\/]+\": \{\s\},\s)", r"", d)
-                d = re.sub(r"(,\s\})", r" }", d)
-                j = loads(d)
+                d = re.sub(r"(,\s\})", r" }", d).strip()
+
+                if not d:
+                    self.logger.warning(
+                        "Empty panos MTU data after cleanup: %s", _mtu_data)
+                    continue
+
+                try:
+                    j = loads(d)
+                except JSONDecodeError:  # pragma: no cover - defensive
+                    self.logger.warning(
+                        "Unable to parse panos MTU data: %s", d)
+                    continue
+
                 for ifname, value in j.items():
                     mtu_data[ifname] = value["mtu"]
                 continue

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from collections import defaultdict
-from json import loads
+from json import loads, JSONDecodeError
 from typing import Dict
 import numpy as np
 
@@ -996,13 +996,32 @@ class InterfaceService(Service):
 
             # mtu values are collected separatly
             if _mtu_data:
+                try:
+                    _, json_blob = _mtu_data.split(": ", 1)
+                except ValueError:
+                    self.logger.warning(
+                        "Unexpected panos MTU data format: %s", _mtu_data)
+                    continue
+
                 # fix json so that it can be parsed
-                d = _mtu_data.split(": ", 1)[1].replace("'", "\"")
+                d = json_blob.replace("'", "\"")
                 d = re.sub(
                     r"([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})", r'"\1"', d)
                 d = re.sub(r"(\"[\w0-9\.\/]+\": \{\s\},\s)", r"", d)
-                d = re.sub(r"(,\s\})", r" }", d)
-                j = loads(d)
+                d = re.sub(r"(,\s\})", r" }", d).strip()
+
+                if not d:
+                    self.logger.warning(
+                        "Empty panos MTU data after cleanup: %s", _mtu_data)
+                    continue
+
+                try:
+                    j = loads(d)
+                except JSONDecodeError:  # pragma: no cover - defensive
+                    self.logger.warning(
+                        "Unable to parse panos MTU data: %s", d)
+                    continue
+
                 for ifname, value in j.items():
                     mtu_data[ifname] = value["mtu"]
                 continue


### PR DESCRIPTION
## Test inclusion requirements

No new tests were added; this change hardens existing PAN-OS cleaners without altering expected behaviour. Verified with:
`CONDA_NO_PLUGINS=true conda run -n suzieq pytest tests/unit/poller/worker/services/test_service.py`

## Related Issue

Fixes #992

## Description

PAN-OS devices occasionally emit ARP/ND rows without a `state` and MTU data that isn’t valid JSON. The poller crashed while cleaning those responses. This patch normalises missing states and parses MTU blobs defensively so malformed payloads raise warnings instead of exceptions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## New Behavior

- PAN-OS ARP/ND cleaner defaults absent states to an empty string before mapping to `permanent`, `reachable`, or `failed`.
- PAN-OS interface cleaner validates MTU payload strings; malformed blobs are skipped with a warning.

## Contrast to Current Behavior

- Previously, missing `state` values caused `AttributeError` and malformed MTU blobs caused `JSONDecodeError`, aborting the poller.

## Discussion: Benefits and Drawbacks

- Benefits: improves poller resilience for PAN-OS without impacting other platforms; backwards-compatible.
- Drawbacks: none identified.

## Changes to the Documentation

- None required.

## Proposed Release Note Entry

- Fix PAN-OS poller crashes triggered by missing ARP state values and malformed interface MTU data.

## Comments

- Tests executed: `CONDA_NO_PLUGINS=true conda run -n suzieq pytest tests/unit/poller/worker/services/test_service.py`

## Double Check

- [x] I have read the comments and followed the CONTRIBUTING.md.
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied
