### PR TITLE
Fix/panos failed to parse interfaces 992

### DIFF
--- a/suzieq/poller/worker/services/arpnd.py
+++ b/suzieq/poller/worker/services/arpnd.py
@@ -117,7 +117,7 @@ class ArpndService(Service):
             # ARP entries are shown with status as merely a letter while
             # ND entries are shown with the status as a self-respecting word.
             # sigh
-            state = entry.get("state", "").lower()
+            state = (entry.get("state") or "").lower()
             if state in ["s", "static"]:
                 entry["state"] = "permanent"
             elif state in ["c", "e", "stale", "reachable"]:

--- a/suzieq/poller/worker/services/interfaces.py
+++ b/suzieq/poller/worker/services/interfaces.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from collections import defaultdict
-from json import loads
+from json import loads, JSONDecodeError
 from typing import Dict
 import numpy as np
 
@@ -9,7 +9,8 @@ from suzieq.poller.worker.services.service import Service
 from suzieq.shared.utils import (get_timestamp_from_junos_time,
                                  expand_ios_ifname, expand_nxos_ifname,
                                  convert_macaddr_format_to_colon,
-                                 parse_relative_timestamp)
+                                 parse_relative_timestamp, 
+                                 normalize_junos_field)
 from suzieq.shared.utils import MISSING_SPEED, NO_SPEED, MISSING_SPEED_IF_TYPES
 
 
@@ -297,7 +298,10 @@ class InterfaceService(Service):
             if not entry.get('macaddr', ''):
                 entry['macaddr'] = '00:00:00:00:00:00'
 
-            entry['type'] = entry.get('type', '').lower()
+            normalized_type = normalize_junos_field(entry.get('type')).lower()
+            normalized_link_type = normalize_junos_field(entry.get('_linkLevelType')).lower()
+            
+            entry['type'] = normalized_link_type or normalized_type
 
             if entry['type'] in ['vrf', 'virtual-router']:
                 entry['type'] = 'vrf'
@@ -993,15 +997,18 @@ class InterfaceService(Service):
 
             # mtu values are collected separatly
             if _mtu_data:
-                # fix json so that it can be parsed
-                d = _mtu_data.split(": ", 1)[1].replace("'", "\"")
-                d = re.sub(
-                    r"([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})", r'"\1"', d)
-                d = re.sub(r"(\"[\w0-9\.\/]+\": \{\s\},\s)", r"", d)
-                d = re.sub(r"(,\s\})", r" }", d)
-                j = loads(d)
-                for ifname, value in j.items():
-                    mtu_data[ifname] = value["mtu"]
+                # # fix json so that it can be parsed
+                try:
+                    fixed_json_mtu = _mtu_data.split(": ", 1)[1].replace("'", "\"")
+                    fixed_json_mtu = re.sub(r"([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})"\
+                                            , r'"\1"', fixed_json_mtu)
+                    fixed_json_mtu = re.sub(r"(\"[\w0-9\.\/]+\": \{\s\},\s)", r""\
+                                            , fixed_json_mtu)
+                    fixed_json_mtu = re.sub(r"(,\s\})", r" }", fixed_json_mtu)
+                    for ifname, value in loads(fixed_json_mtu).items():
+                        mtu_data[ifname] = value["mtu"]
+                except (ValueError, JSONDecodeError, KeyError, TypeError):
+                    self.logger.warning("Failed to parse panos MTU data: %s", _mtu_data)
                 continue
 
             if entry["ifname"] in mtu_data:


### PR DESCRIPTION
## Related Issue
Fixes #992

## Description
Fix PanOS interface and arpnd parsing issues. The parser was failing to correctly handle PanOS device output.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## New Behavior
PanOS interfaces and arpnd data are now parsed correctly.

## Contrast to Current Behavior
Previously, the parser failed to parse PanOS interface and arpnd data, causing errors.

## Discussion: Benefits and Drawbacks
- **Benefits**: PanOS devices can now be properly monitored by SuzieQ
- **Drawbacks**: None
- **Backwards-compatible**: Yes

## Changes to the Documentation
None required.

## Proposed Release Note Entry
Fix PanOS interface and arpnd parsing issues (#992)

## Comments
Split into two commits:
- `poller/arpnd`: fix panos parsing issue
- `poller/interfaces`: fix panos parsing issue

## Double Check
- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied