### PR TITLE
Fix/ clean junos data with keyerror problem 903

### DIFF
--- a/suzieq/config/device.yml
+++ b/suzieq/config/device.yml
@@ -110,7 +110,7 @@ apply:
         ]'
 
   junos-ex:
-    - version: < 14.2R8.4
+    - version: <= 14.2R8.4
       command:
         - command: "show system information | display json | no-more"
           normalize: 'system-information/*/[

--- a/suzieq/config/device.yml
+++ b/suzieq/config/device.yml
@@ -110,8 +110,36 @@ apply:
         ]'
 
   junos-ex:
-    copy: junos-qfx
+    - version: < 18.1R1
+      command:
+        - command: "show system information | display json | no-more"
+          normalize: 'system-information/*/[
+          "hardware-model/[0]/data: model",
+          "os-name/[0]/data: os?|junos",
+          "os-version/[0]/data: version",
+          "vendor: vendor?|Juniper",
+          "serial-number/[0]/data: serialNumber",
+          ]'
+        - command: "show system uptime | display json"
+          normalize: 'system-uptime-information/*/[
+          "system-booted-time/[0]/date-time/[0]/attributes: bootupTimestamp?|"
+          ]'
 
+    - version: all
+      command:
+        - command: "show system information | display json | no-more"
+          normalize: 'system-information/*/[
+          "hardware-model/[0]/data: model",
+          "os-name/[0]/data: os?|junos",
+          "os-version/[0]/data: version",
+          "vendor: vendor?|Juniper",
+          "serial-number/[0]/data: serialNumber",
+          ]'
+        - command: "show system uptime | display json"
+          normalize: 'multi-routing-engine-results/[0]/multi-routing-engine-item/[0]/system-uptime-information/*/[
+          "system-booted-time/[0]/date-time/[0]/attributes: bootupTimestamp?|"
+          ]'
+    
   junos-mx:
     version: all
     command:

--- a/suzieq/config/device.yml
+++ b/suzieq/config/device.yml
@@ -110,7 +110,7 @@ apply:
         ]'
 
   junos-ex:
-    - version: < 18.1R1
+    - version: < 14.2R8.4
       command:
         - command: "show system information | display json | no-more"
           normalize: 'system-information/*/[

--- a/suzieq/poller/worker/nodes/node.py
+++ b/suzieq/poller/worker/nodes/node.py
@@ -1966,19 +1966,21 @@ class JunosNode(Node):
             data = output[0]["data"]
             try:
                 jdata = json.loads(data.replace('\n', '').strip())
-                if self.devtype not in ["junos-mx", "junos-qfx10k",
-                                        "junos-evo"]:
+                
+                if jdata.get('multi-routing-engine-results'):
                     jdata = (jdata['multi-routing-engine-results'][0]
                              ['multi-routing-engine-item'][0])
 
                 timestr = (jdata['system-uptime-information'][0]
                            ['system-booted-time'][0]['date-time'][0]
                            ['attributes'])
+                        
             except Exception:
                 self.logger.warning(
                     f'{self.address}:{self.port} Unable to parse junos boot '
                     f'time from {data}')
                 timestr = '{"junos:seconds": "0"}'
+                
             self.bootupTimestamp = get_timestamp_from_junos_time(
                 timestr, ms=False)
 


### PR DESCRIPTION
## Related Issue
Fixes #903

## Description
Fix KeyError when parsing Junos device data. The `_clean_junos_data` function was failing when `bootupTimestamp` key was missing from the device output, which occurs on certain Junos EX devices with different JSON output structures.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## New Behavior
Junos device data is now parsed correctly even when `bootupTimestamp` is missing from the output. The parser handles different JSON structures across various Junos versions and device types.

## Contrast to Current Behavior
Previously, the parser threw a KeyError exception when processing Junos devices (such as EX9208 with Junos 14.2R8.4) that return a different JSON structure for `show system uptime` output.

## Discussion: Benefits and Drawbacks
- **Benefits**: Junos EX devices with different JSON output formats can now be properly monitored by SuzieQ
- **Drawbacks**: None
- **Backwards-compatible**: Yes

## Changes to the Documentation
None required.

## Proposed Release Note Entry
Fix KeyError when parsing Junos device data with missing bootupTimestamp (#903)

## Comments
The issue was caused by different Junos devices returning different JSON structures for the `show system uptime` command. Some devices use `system-uptime-information` directly, while others wrap it in `multi-routing-engine-results`.

Changes include:
- `config/device`: Modified the junos-ex device logic to match different versions
- `poller/node`: The parsing logic was relaxed

## Double Check
- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied