### PR TITLE
Fix/nxos bgp type error 637

### DIFF
--- a/suzieq/poller/worker/services/bgp.py
+++ b/suzieq/poller/worker/services/bgp.py
@@ -335,14 +335,6 @@ class BgpService(Service):
                     adv = af_adv[i] if i < len(af_adv) else None
                     rcv = af_rcv[i] if i < len(af_rcv) else None
                     
-                    # if adv is None or rcv is None:
-                    #     continue
-                    # if adv != rcv:
-                    #     if adv == 'true':
-                    #         entry['afisAdvOnly'].append(item)
-                    #     else:
-                    #         entry['afisRcvOnly'].append(item)
-                    
                     if adv and rcv and adv != rcv:
                         entry['afisAdvOnly' if adv == 'true' else 'afisRcvOnly'].append(item)
                 

--- a/suzieq/poller/worker/services/bgp.py
+++ b/suzieq/poller/worker/services/bgp.py
@@ -324,18 +324,31 @@ class BgpService(Service):
                 continue
 
             if 'afiSafi' in entry:
+                afis = entry.get('afiSafi') or []
+                af_adv = entry.get('afAdvertised') or []
+                af_rcv = entry.get('afRcvd') or []
+                
                 entry['afisAdvOnly'] = []
                 entry['afisRcvOnly'] = []
-                for i, item in enumerate(entry['afiSafi']):
-                    if entry['afAdvertised'][i] != entry['afRcvd'][i]:
-                        if entry['afAdvertised'][i] == 'true':
-                            entry['afisAdvOnly'].append(entry['afiSafi'])
-                        else:
-                            entry['afisRcvOnly'].append(entry['afiSafi'])
-
-                entry.pop('afiSafi')
-                entry.pop('afAdvertised')
-                entry.pop('afRcvd')
+                
+                for i, item in enumerate(afis):
+                    adv = af_adv[i] if i < len(af_adv) else None
+                    rcv = af_rcv[i] if i < len(af_rcv) else None
+                    
+                    # if adv is None or rcv is None:
+                    #     continue
+                    # if adv != rcv:
+                    #     if adv == 'true':
+                    #         entry['afisAdvOnly'].append(item)
+                    #     else:
+                    #         entry['afisRcvOnly'].append(item)
+                    
+                    if adv and rcv and adv != rcv:
+                        entry['afisAdvOnly' if adv == 'true' else 'afisRcvOnly'].append(item)
+                
+                entry.pop('afiSafi', None)
+                entry.pop('afAdvertised', None)
+                entry.pop('afRcvd', None)
 
             rrclient = entry.get('rrclient', [])
             if rrclient and 'true' in rrclient:


### PR DESCRIPTION
## Related Issue
Fixes #637

## Description
Fix TypeError when parsing NXOS BGP data. The BGP service was failing when processing certain NXOS devices that return unexpected data types in BGP output.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## New Behavior
NXOS BGP data is now parsed correctly without TypeError exceptions.

## Contrast to Current Behavior
Previously, the parser threw a TypeError when processing BGP data from certain NXOS devices.

## Discussion: Benefits and Drawbacks
- **Benefits**: NXOS devices with BGP can now be properly monitored by SuzieQ
- **Drawbacks**: None
- **Backwards-compatible**: Yes

## Changes to the Documentation
None required.

## Proposed Release Note Entry
Fix TypeError when parsing NXOS BGP data (#637)

## Comments
None

## Double Check
- [x] I have read the comments and followed the [CONTRIBUTING.md](https://github.com/netenglabs/suzieq/blob/master/CONTRIBUTING.md).
- [x] I have explained my PR according to the information in the comments or in a linked issue.
- [x] My PR source branch is created from the `develop` branch.
- [x] My PR targets the `develop` branch.
- [x] All my commits have `--signoff` applied