### PR TITLE
fix(cli): init rest config for per-command engine

### DIFF
--- a/suzieq/sqobjects/basicobj.py
+++ b/suzieq/sqobjects/basicobj.py
@@ -5,7 +5,8 @@ import pandas as pd
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 from suzieq.shared.utils import (load_sq_config, humanize_timestamp,
-                                 deprecated_table_function_warning)
+                                 deprecated_table_function_warning,
+                                 set_rest_engine)
 from suzieq.shared.schema import Schema, SchemaForTable
 from suzieq.engines import get_sqengine
 from suzieq.shared.sq_plugin import SqPlugin
@@ -29,12 +30,18 @@ class SqObject(SqPlugin):
             self.ctxt.schemas = Schema(self.ctxt.cfg["schema-directory"])
         else:
             self.ctxt = context
+            orig_engine = self.ctxt.engine
             if not self.ctxt.cfg:
                 self.ctxt.cfg = load_sq_config(validate=True,
                                                config_file=config_file)
                 self.ctxt.schemas = Schema(self.ctxt.cfg["schema-directory"])
             if not self.ctxt.engine:
                 self.ctxt.engine = engine_name
+            if engine_name == 'rest' and orig_engine != 'rest':
+                self.ctxt.rest_server_ip, \
+                 self.ctxt.rest_server_port, \
+                 self.ctxt.rest_transport, \
+                 self.ctxt.rest_api_key = set_rest_engine(self.ctxt.cfg)
 
         self._cfg = self.ctxt.cfg
         self._schema = SchemaForTable(table, self.ctxt.schemas)

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,5 +1,11 @@
+import os
+
 import pytest
+
+from suzieq.shared.context import SqContext
+from suzieq.shared.schema import Schema
 from suzieq.sqobjects.basicobj import SqObject
+import suzieq.sqobjects.basicobj as basicobj
 from suzieq.engines.base_engine import SqEngineObj
 from suzieq.sqobjects.vlan import VlanObj
 from suzieq.sqobjects import get_tables, get_sqobject
@@ -42,3 +48,34 @@ def test_plugin():
 
     with pytest.raises(DBNotFoundError):
         get_sqdb_engine({'db': {'foobar': 'bar'}}, 'foobar', None, None)
+
+
+def test_rest_engine_initializes_context_from_config(monkeypatch):
+    """Per-command rest engine selection should load REST config."""
+
+    class DummyEngine:
+        def __init__(self, obj):
+            self.obj = obj
+
+    cfg = {
+        'schema-directory': os.path.abspath('suzieq/config/schema'),
+        'rest': {
+            'API_KEY': 'my-api-key',
+            'address': '127.0.0.1',
+            'port': 8000,
+            'no-https': True,
+        },
+    }
+    ctxt = SqContext(cfg=cfg)
+    ctxt.schemas = Schema(cfg['schema-directory'])
+
+    monkeypatch.setattr(
+        basicobj, 'get_sqengine', lambda engine, table: lambda obj: DummyEngine(obj))
+
+    obj = VlanObj(context=ctxt, engine_name='rest')
+
+    assert obj.ctxt.engine == 'pandas'
+    assert obj.ctxt.rest_api_key == 'my-api-key'
+    assert obj.ctxt.rest_server_ip == '127.0.0.1'
+    assert obj.ctxt.rest_server_port == 8000
+    assert obj.ctxt.rest_transport == 'http'


### PR DESCRIPTION
 now pulls REST settings from the loaded config when the current context is still on pandas, so the CLI no longer needs a global engine switch first.

Added a unit test for the per-command rest path and verified the context gets the configured API key, host, port, and transport.

Fixes #1000
Pushed from BillionClaw.